### PR TITLE
Reset Swiper instance after filtering

### DIFF
--- a/mon-affichage-article/assets/js/filter.js
+++ b/mon-affichage-article/assets/js/filter.js
@@ -37,7 +37,41 @@
 
                     if (wrapper.hasClass('my-articles-slideshow')) {
                         if (typeof window.mySwiperInstances !== 'undefined' && window.mySwiperInstances[instanceId]) {
-                            window.mySwiperInstances[instanceId].update();
+                            window.mySwiperInstances[instanceId].destroy(true, true);
+                        }
+
+                        var settingsObjectName = 'myArticlesSwiperSettings_' + instanceId;
+                        if (typeof window[settingsObjectName] !== 'undefined') {
+                            var settings = window[settingsObjectName];
+
+                            window.mySwiperInstances = window.mySwiperInstances || {};
+
+                            window.mySwiperInstances[instanceId] = new Swiper(settings.container_selector, {
+                                slidesPerView: settings.columns_mobile,
+                                spaceBetween: settings.gap_size,
+                                loop: true,
+                                pagination: {
+                                    el: settings.container_selector + ' .swiper-pagination',
+                                    clickable: true,
+                                },
+                                navigation: {
+                                    nextEl: settings.container_selector + ' .swiper-button-next',
+                                    prevEl: settings.container_selector + ' .swiper-button-prev',
+                                },
+                                breakpoints: {
+                                    768: { slidesPerView: settings.columns_tablet, spaceBetween: settings.gap_size },
+                                    1024: { slidesPerView: settings.columns_desktop, spaceBetween: settings.gap_size },
+                                    1536: { slidesPerView: settings.columns_ultrawide, spaceBetween: settings.gap_size }
+                                },
+                                on: {
+                                    init: function () {
+                                        var mainWrapper = document.querySelector('#my-articles-wrapper-' + instanceId);
+                                        if (mainWrapper) {
+                                            mainWrapper.classList.add('swiper-initialized');
+                                        }
+                                    }
+                                }
+                            });
                         }
                     }
                 } else {


### PR DESCRIPTION
## Summary
- destroy existing Swiper instance on filter change
- recreate Swiper with localized settings after AJAX update

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c80e0f5ca8832e8271643f281eb803