### PR TITLE
Reset post data after search query

### DIFF
--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -191,9 +191,10 @@ final class Mon_Affichage_Articles {
                         'text' => get_the_title(),
                     ];
                 }
+                wp_reset_postdata();
             }
         }
-        
+
         wp_send_json_success($results);
     }
 


### PR DESCRIPTION
## Summary
- reset global post data after looping in `search_posts_callback`

## Testing
- `php -l mon-affichage-article/mon-affichage-articles.php`


------
https://chatgpt.com/codex/tasks/task_e_68c80e11f020832e83c72a0a6767e5cf