### PR TITLE
Add capability check to search posts AJAX callback

### DIFF
--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -172,6 +172,10 @@ final class Mon_Affichage_Articles {
     public function search_posts_callback() {
         check_ajax_referer( 'my_articles_select2_nonce', 'security' );
 
+        if ( ! current_user_can( 'edit_posts' ) ) {
+            wp_send_json_error( 'Unauthorized', 403 );
+        }
+
         $search_term = isset( $_GET['search'] ) ? sanitize_text_field( $_GET['search'] ) : '';
         $results = [];
 


### PR DESCRIPTION
## Summary
- verify the current user can edit posts before processing the search AJAX request
- return a 403 Unauthorized error when the capability check fails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c84828e508832ebd2765ca462d57ce