### PR TITLE
Use wp_add_inline_style for dynamic styles

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -151,6 +151,8 @@ class My_Articles_Shortcode {
         
         if ($options['display_mode'] === 'slideshow') { $this->enqueue_swiper_scripts($options, $id); }
 
+        wp_enqueue_style('my-articles-styles');
+
         ob_start();
         $this->render_inline_styles($options, $id);
         
@@ -341,8 +343,6 @@ class My_Articles_Shortcode {
     }
 
     private function render_inline_styles($options, $id) {
-        wp_enqueue_style('my-articles-styles');
-
         $dynamic_css = "
         #my-articles-wrapper-{$id} {
             --my-articles-cols-mobile: " . intval($options['columns_mobile']) . ";
@@ -379,6 +379,6 @@ class My_Articles_Shortcode {
         #my-articles-wrapper-{$id} .my-articles-list .my-article-item .article-content-wrapper { background-color: " . esc_attr($options['title_wrapper_bg_color']) . "; }
         ";
 
-        echo '<style>' . $dynamic_css . '</style>';
+        wp_add_inline_style( 'my-articles-styles', $dynamic_css );
     }
 }


### PR DESCRIPTION
## Summary
- enqueue the my-articles-styles stylesheet before rendering the shortcode output
- replace the inline <style> tag with wp_add_inline_style so dynamic CSS is added to the registered handle

## Testing
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68c848313728832e9cd84a8618952d45