### PR TITLE
Add shared color sanitizer helper

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -245,11 +245,11 @@ class My_Articles_Metaboxes {
             $sanitized['pinned_posts'] = array_map('absint', $input['pinned_posts']);
         }
         $sanitized['pinned_posts_ignore_filter'] = isset( $input['pinned_posts_ignore_filter'] ) ? 1 : 0;
-        $sanitized['pinned_border_color'] = $this->sanitize_color($input['pinned_border_color'] ?? '', '#eab308');
+        $sanitized['pinned_border_color'] = my_articles_sanitize_color($input['pinned_border_color'] ?? '', '#eab308');
         $sanitized['pinned_show_badge'] = isset( $input['pinned_show_badge'] ) ? 1 : 0;
         $sanitized['pinned_badge_text'] = isset( $input['pinned_badge_text'] ) ? sanitize_text_field($input['pinned_badge_text']) : 'Épinglé';
-        $sanitized['pinned_badge_bg_color'] = $this->sanitize_color($input['pinned_badge_bg_color'] ?? '', '#eab308');
-        $sanitized['pinned_badge_text_color'] = $this->sanitize_color($input['pinned_badge_text_color'] ?? '', '#ffffff');
+        $sanitized['pinned_badge_bg_color'] = my_articles_sanitize_color($input['pinned_badge_bg_color'] ?? '', '#eab308');
+        $sanitized['pinned_badge_text_color'] = my_articles_sanitize_color($input['pinned_badge_text_color'] ?? '', '#ffffff');
         
         if (isset($input['exclude_posts'])) {
             $cleaned_ids = preg_replace('/[^0-9,]/', '', $input['exclude_posts']);
@@ -286,24 +286,19 @@ class My_Articles_Metaboxes {
         $sanitized['excerpt_length'] = isset( $input['excerpt_length'] ) ? absint($input['excerpt_length']) : 25;
         $sanitized['excerpt_more_text'] = isset( $input['excerpt_more_text'] ) ? sanitize_text_field($input['excerpt_more_text']) : 'Lire la suite';
         $sanitized['excerpt_font_size'] = isset( $input['excerpt_font_size'] ) ? absint($input['excerpt_font_size']) : 14;
-        $sanitized['excerpt_color'] = $this->sanitize_color($input['excerpt_color'] ?? '', '#4b5563');
+        $sanitized['excerpt_color'] = my_articles_sanitize_color($input['excerpt_color'] ?? '', '#4b5563');
 
-        $sanitized['module_bg_color'] = $this->sanitize_color($input['module_bg_color'] ?? '', 'rgba(255,255,255,0)');
-        $sanitized['vignette_bg_color'] = $this->sanitize_color($input['vignette_bg_color'] ?? '', '#ffffff');
-        $sanitized['title_wrapper_bg_color'] = $this->sanitize_color($input['title_wrapper_bg_color'] ?? '', '#ffffff');
-        $sanitized['title_color'] = $this->sanitize_color($input['title_color'] ?? '', '#333333');
-        $sanitized['meta_color'] = $this->sanitize_color($input['meta_color'] ?? '', '#6b7280');
-        $sanitized['meta_color_hover'] = $this->sanitize_color($input['meta_color_hover'] ?? '', '#000000');
-        $sanitized['pagination_color'] = $this->sanitize_color($input['pagination_color'] ?? '', '#333333');
-        $sanitized['shadow_color'] = $this->sanitize_color($input['shadow_color'] ?? '', 'rgba(0,0,0,0.07)');
-        $sanitized['shadow_color_hover'] = $this->sanitize_color($input['shadow_color_hover'] ?? '', 'rgba(0,0,0,0.12)');
+        $sanitized['module_bg_color'] = my_articles_sanitize_color($input['module_bg_color'] ?? '', 'rgba(255,255,255,0)');
+        $sanitized['vignette_bg_color'] = my_articles_sanitize_color($input['vignette_bg_color'] ?? '', '#ffffff');
+        $sanitized['title_wrapper_bg_color'] = my_articles_sanitize_color($input['title_wrapper_bg_color'] ?? '', '#ffffff');
+        $sanitized['title_color'] = my_articles_sanitize_color($input['title_color'] ?? '', '#333333');
+        $sanitized['meta_color'] = my_articles_sanitize_color($input['meta_color'] ?? '', '#6b7280');
+        $sanitized['meta_color_hover'] = my_articles_sanitize_color($input['meta_color_hover'] ?? '', '#000000');
+        $sanitized['pagination_color'] = my_articles_sanitize_color($input['pagination_color'] ?? '', '#333333');
+        $sanitized['shadow_color'] = my_articles_sanitize_color($input['shadow_color'] ?? '', 'rgba(0,0,0,0.07)');
+        $sanitized['shadow_color_hover'] = my_articles_sanitize_color($input['shadow_color_hover'] ?? '', 'rgba(0,0,0,0.12)');
 
         update_post_meta( $post_id, $this->option_key, $sanitized );
     }
 
-    private function sanitize_color( $color, $default = '' ) {
-        if ( preg_match('/^rgba\((\d{1,3}),\s*(\d{1,3}),\s*(\d{1,3}),\s*(\d*(?:\.\d+)?)\)$/', $color) ) { return $color; }
-        if ( sanitize_hex_color( $color ) ) { return sanitize_hex_color( $color ); }
-        return $default;
-    }
 }

--- a/mon-affichage-article/includes/class-my-articles-settings.php
+++ b/mon-affichage-article/includes/class-my-articles-settings.php
@@ -98,28 +98,22 @@ class My_Articles_Settings {
         $sanitized_input['mobile_columns'] = isset( $input['mobile_columns'] ) ? absint( $input['mobile_columns'] ) : 1;
         $sanitized_input['gap_size'] = isset( $input['gap_size'] ) ? absint( $input['gap_size'] ) : 25;
         $sanitized_input['border_radius'] = isset( $input['border_radius'] ) ? absint( $input['border_radius'] ) : 12;
-        $sanitized_input['title_color'] = $this->sanitize_color($input['title_color'] ?? '', '#333333');
+        $sanitized_input['title_color'] = my_articles_sanitize_color($input['title_color'] ?? '', '#333333');
         $sanitized_input['title_font_size'] = isset( $input['title_font_size'] ) ? absint( $input['title_font_size'] ) : 16;
         $sanitized_input['show_category'] = isset( $input['show_category'] ) ? 1 : 0;
         $sanitized_input['show_author'] = isset( $input['show_author'] ) ? 1 : 0;
         $sanitized_input['show_date'] = isset( $input['show_date'] ) ? 1 : 0;
         $sanitized_input['meta_font_size'] = isset( $input['meta_font_size'] ) ? absint( $input['meta_font_size'] ) : 12;
-        $sanitized_input['meta_color'] = $this->sanitize_color($input['meta_color'] ?? '', '#6b7280');
-        $sanitized_input['meta_color_hover'] = $this->sanitize_color($input['meta_color_hover'] ?? '', '#000000');
-        $sanitized_input['module_bg_color'] = $this->sanitize_color($input['module_bg_color'] ?? '', 'rgba(255,255,255,0)');
-        $sanitized_input['vignette_bg_color'] = $this->sanitize_color($input['vignette_bg_color'] ?? '', '#ffffff');
-        $sanitized_input['title_wrapper_bg_color'] = $this->sanitize_color($input['title_wrapper_bg_color'] ?? '', '#ffffff');
+        $sanitized_input['meta_color'] = my_articles_sanitize_color($input['meta_color'] ?? '', '#6b7280');
+        $sanitized_input['meta_color_hover'] = my_articles_sanitize_color($input['meta_color_hover'] ?? '', '#000000');
+        $sanitized_input['module_bg_color'] = my_articles_sanitize_color($input['module_bg_color'] ?? '', 'rgba(255,255,255,0)');
+        $sanitized_input['vignette_bg_color'] = my_articles_sanitize_color($input['vignette_bg_color'] ?? '', '#ffffff');
+        $sanitized_input['title_wrapper_bg_color'] = my_articles_sanitize_color($input['title_wrapper_bg_color'] ?? '', '#ffffff');
         $sanitized_input['module_margin_left'] = isset( $input['module_margin_left'] ) ? absint( $input['module_margin_left'] ) : 0;
         $sanitized_input['module_margin_right'] = isset( $input['module_margin_right'] ) ? absint( $input['module_margin_right'] ) : 0;
-        $sanitized_input['pagination_color'] = $this->sanitize_color($input['pagination_color'] ?? '', '#333333');
+        $sanitized_input['pagination_color'] = my_articles_sanitize_color($input['pagination_color'] ?? '', '#333333');
 
         return $sanitized_input;
-    }
-
-    private function sanitize_color( $color, $default = '' ) {
-        if ( preg_match( '/^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$/', $color ) ) { return sanitize_hex_color( $color ); }
-        if ( preg_match('/^rgba\((\d{1,3}),\s*(\d{1,3}),\s*(\d{1,3}),\s*(\d*(?:\.\d+)?)\)$/', $color) ) { return $color; }
-        return $default;
     }
 
     // Callbacks

--- a/mon-affichage-article/includes/helpers.php
+++ b/mon-affichage-article/includes/helpers.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Helper functions for Mon Affichage Articles plugin.
+ */
+
+if ( ! function_exists( 'my_articles_sanitize_color' ) ) {
+    /**
+     * Sanitize a color value allowing HEX and RGBA formats.
+     *
+     * @param string $color   The color value to sanitize.
+     * @param string $default The default value to return when the color is invalid.
+     *
+     * @return string Sanitized color or default value.
+     */
+    function my_articles_sanitize_color( $color, $default = '' ) {
+        if ( is_string( $color ) ) {
+            $color = trim( $color );
+        }
+
+        if ( preg_match( '/^rgba\((\d{1,3}),\s*(\d{1,3}),\s*(\d{1,3}),\s*(\d*(?:\.\d+)?)\)$/', $color ) ) {
+            return $color;
+        }
+
+        $hex_color = sanitize_hex_color( $color );
+        if ( $hex_color ) {
+            return $hex_color;
+        }
+
+        return $default;
+    }
+}

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -31,6 +31,7 @@ final class Mon_Affichage_Articles {
     }
 
     private function includes() {
+        require_once MY_ARTICLES_PLUGIN_DIR . 'includes/helpers.php';
         require_once MY_ARTICLES_PLUGIN_DIR . 'includes/class-my-articles-metaboxes.php';
         require_once MY_ARTICLES_PLUGIN_DIR . 'includes/class-my-articles-shortcode.php';
         require_once MY_ARTICLES_PLUGIN_DIR . 'includes/class-my-articles-enqueue.php';


### PR DESCRIPTION
## Summary
- add a shared helpers file containing `my_articles_sanitize_color()` for HEX and RGBA values
- load the helpers file from the main plugin bootstrap
- reuse the helper in metabox and settings sanitizers

## Testing
- php -l mon-affichage-article/includes/helpers.php
- php -l mon-affichage-article/includes/class-my-articles-metaboxes.php
- php -l mon-affichage-article/includes/class-my-articles-settings.php
- php -l mon-affichage-article/mon-affichage-articles.php

------
https://chatgpt.com/codex/tasks/task_e_68c84833f258832eb6f8f21251983ce1