### PR TITLE
Escape metadata outputs in article shortcode

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -309,9 +309,9 @@ class My_Articles_Shortcode {
             <h2 class="article-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
             <?php if ($options['show_category'] || $options['show_author'] || $options['show_date']) : ?>
                 <div class="article-meta">
-                    <?php if ($options['show_category']) echo '<span class="article-category">' . get_the_term_list(get_the_ID(), $taxonomy, '', ', ') . '</span>'; ?>
-                    <?php if ($options['show_author']) echo '<span class="article-author">par <a href="' . esc_url(get_author_posts_url(get_the_author_meta('ID'))) . '">' . get_the_author() . '</a></span>'; ?>
-                    <?php if ($options['show_date']) echo '<span class="article-date">' . get_the_date() . '</span>'; ?>
+                    <?php if ($options['show_category']) echo '<span class="article-category">' . wp_kses_post(get_the_term_list(get_the_ID(), $taxonomy, '', ', ')) . '</span>'; ?>
+                    <?php if ($options['show_author']) echo '<span class="article-author">par <a href="' . esc_url(get_author_posts_url(get_the_author_meta('ID'))) . '">' . esc_html(get_the_author()) . '</a></span>'; ?>
+                    <?php if ($options['show_date']) echo '<span class="article-date">' . esc_html(get_the_date()) . '</span>'; ?>
                 </div>
             <?php endif; ?>
             <?php if (!empty($options['show_excerpt'])): ?>


### PR DESCRIPTION
## Summary
- escape author names and publication dates when rendering article metadata
- sanitize category term list output to allow only permitted HTML

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c86aae972c832e9406034965ea0927