### PR TITLE
Sanitize POST data in filter_articles_callback

### DIFF
--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -62,8 +62,8 @@ final class Mon_Affichage_Articles {
     public function filter_articles_callback() {
         check_ajax_referer( 'my_articles_filter_nonce', 'security' );
 
-        $instance_id = isset( $_POST['instance_id'] ) ? absint( $_POST['instance_id'] ) : 0;
-        $category_slug = isset( $_POST['category'] ) ? sanitize_text_field( $_POST['category'] ) : '';
+        $instance_id = isset( $_POST['instance_id'] ) ? absint( wp_unslash( $_POST['instance_id'] ) ) : 0;
+        $category_slug = isset( $_POST['category'] ) ? sanitize_text_field( wp_unslash( $_POST['category'] ) ) : '';
 
         if ( !$instance_id ) {
             wp_send_json_error( 'ID d\'instance manquant.' );


### PR DESCRIPTION
## Summary
- ensure `filter_articles_callback` unslashes incoming POST values before sanitizing
- confirmed no other POST uses in the callback required changes

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c93646c9e4832ea9282d4b404f76b1