### PR TITLE
Sanitize load more request parameters

### DIFF
--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -155,10 +155,10 @@ final class Mon_Affichage_Articles {
     public function load_more_articles_callback() {
         check_ajax_referer( 'my_articles_load_more_nonce', 'security' );
 
-        $instance_id = isset( $_POST['instance_id'] ) ? absint( $_POST['instance_id'] ) : 0;
-        $paged = isset( $_POST['paged'] ) ? absint( $_POST['paged'] ) : 1;
-        $pinned_ids_str = isset( $_POST['pinned_ids'] ) ? sanitize_text_field( $_POST['pinned_ids'] ) : '';
-        $category = isset( $_POST['category'] ) ? sanitize_text_field( $_POST['category'] ) : '';
+        $instance_id = isset( $_POST['instance_id'] ) ? absint( wp_unslash( $_POST['instance_id'] ) ) : 0;
+        $paged = isset( $_POST['paged'] ) ? absint( wp_unslash( $_POST['paged'] ) ) : 1;
+        $pinned_ids_str = isset( $_POST['pinned_ids'] ) ? sanitize_text_field( wp_unslash( $_POST['pinned_ids'] ) ) : '';
+        $category = isset( $_POST['category'] ) ? sanitize_text_field( wp_unslash( $_POST['category'] ) ) : '';
 
         if (!$instance_id) { wp_send_json_error(); }
 


### PR DESCRIPTION
## Summary
- ensure load more AJAX handler unslashes POST values before sanitizing or casting
- align sanitization for instance id, pagination, pinned ids, and category inputs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c94c98f0a8832e893ef419ec7faa23