### PR TITLE
Sanitize incoming request data before use

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -219,7 +219,7 @@ class My_Articles_Metaboxes {
     }
 
     public function save_meta_data( $post_id ) {
-        if ( !isset($_POST['my_articles_meta_box_nonce']) || !wp_verify_nonce($_POST['my_articles_meta_box_nonce'], 'my_articles_save_meta_box_data') || (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) || !current_user_can('edit_post', $post_id) ) {
+        if ( !isset($_POST['my_articles_meta_box_nonce']) || !wp_verify_nonce( wp_unslash( $_POST['my_articles_meta_box_nonce'] ), 'my_articles_save_meta_box_data') || (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) || !current_user_can('edit_post', $post_id) ) {
             return;
         }
 

--- a/mon-affichage-article/includes/class-my-articles-settings.php
+++ b/mon-affichage-article/includes/class-my-articles-settings.php
@@ -193,7 +193,7 @@ class My_Articles_Settings {
     }
 
     public function reset_settings() {
-        if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'my_articles_reset_settings_nonce' ) ) { wp_die( 'La vérification a échoué.' ); }
+        if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( wp_unslash( $_POST['_wpnonce'] ), 'my_articles_reset_settings_nonce' ) ) { wp_die( 'La vérification a échoué.' ); }
         if ( ! current_user_can( 'manage_options' ) ) { wp_die( 'Permission refusée.' ); }
         delete_option( $this->option_name );
         wp_redirect( admin_url( 'admin.php?page=my-articles-settings&status=reset' ) );

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -89,7 +89,7 @@ class My_Articles_Shortcode {
         }
 
         $paged_var = 'paged_' . $id;
-        $paged = isset($_GET[$paged_var]) ? absint($_GET[$paged_var]) : 1;
+        $paged = isset($_GET[$paged_var]) ? absint( wp_unslash( $_GET[$paged_var] ) ) : 1;
         $posts_per_page = (int)($options['posts_per_page'] ?? 10);
 
         if ($options['counting_behavior'] === 'auto_fill' && ($options['display_mode'] === 'grid' || $options['display_mode'] === 'slideshow')) {

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -284,7 +284,7 @@ final class Mon_Affichage_Articles {
             wp_send_json_error( 'Unauthorized', 403 );
         }
 
-        $search_term = isset( $_GET['search'] ) ? sanitize_text_field( $_GET['search'] ) : '';
+        $search_term = isset( $_GET['search'] ) ? sanitize_text_field( wp_unslash( $_GET['search'] ) ) : '';
         $post_type   = 'post';
 
         if ( isset( $_GET['post_type'] ) ) {
@@ -313,7 +313,7 @@ final class Mon_Affichage_Articles {
                     $query->the_post();
                     $results[] = [
                         'id' => get_the_ID(),
-                        'text' => get_the_title(),
+                        'text' => wp_strip_all_tags( get_the_title() ),
                     ];
                 }
                 wp_reset_postdata();


### PR DESCRIPTION
## Summary
- unslash the Select2 AJAX search term before sanitizing and strip markup from returned titles
- unslash pagination and nonce parameters prior to validation to avoid slashed input issues

## Testing
- php -l mon-affichage-article/mon-affichage-articles.php
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php
- php -l mon-affichage-article/includes/class-my-articles-settings.php
- php -l mon-affichage-article/includes/class-my-articles-metaboxes.php

------
https://chatgpt.com/codex/tasks/task_e_68c9b30a6a18832eaef09ff6fc5a7889