### PR TITLE
Use strict comparisons in admin handlers

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -23,7 +23,7 @@ class My_Articles_Metaboxes {
     }
 
     public function enqueue_admin_scripts( $hook ) {
-        if ( ('post.php' == $hook || 'post-new.php' == $hook) && 'mon_affichage' === get_post_type() ) {
+        if ( ('post.php' === $hook || 'post-new.php' === $hook) && 'mon_affichage' === get_post_type() ) {
             wp_enqueue_style( 'wp-color-picker' );
             wp_enqueue_style( 'select2-css', MY_ARTICLES_PLUGIN_URL . 'assets/vendor/select2/select2.min.css', [], '4.1.0-rc.0' );
             
@@ -53,7 +53,7 @@ class My_Articles_Metaboxes {
     }
 
     public function render_shortcode_metabox( $post ) {
-        if ( $post->ID && $post->post_status != 'auto-draft' ) {
+        if ( $post->ID && 'auto-draft' !== $post->post_status ) {
             echo '<p>' . __( 'Copiez ce shortcode dans vos pages ou articles :', 'mon-articles' ) . '</p>';
             echo '<input type="text" value="[mon_affichage_articles id=&quot;' . esc_attr( $post->ID ) . '&quot;]" readonly style="width: 100%; padding: 8px; text-align: center;">';
         } else {

--- a/mon-affichage-article/includes/class-my-articles-settings.php
+++ b/mon-affichage-article/includes/class-my-articles-settings.php
@@ -29,7 +29,7 @@ class My_Articles_Settings {
     }
 
     public function enqueue_admin_scripts( $hook ) {
-        if ( $hook != $this->plugin_page_hook ) { return; }
+        if ( $hook !== $this->plugin_page_hook ) { return; }
         wp_enqueue_style( 'wp-color-picker' );
         wp_enqueue_script( 'my-articles-admin-script', MY_ARTICLES_PLUGIN_URL . 'assets/js/admin.js', array( 'wp-color-picker' ), MY_ARTICLES_VERSION, true );
     }

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -106,7 +106,7 @@ class My_Articles_Shortcode {
         
         $pinned_query = null;
         $pinned_posts_found = 0;
-        if ($paged == 1 && !empty($pinned_ids)) {
+        if ($paged === 1 && !empty($pinned_ids)) {
             $pinned_query = new WP_Query([
                 'post_type' => 'any',
                 'post_status' => 'publish',
@@ -120,7 +120,7 @@ class My_Articles_Shortcode {
 
         $regular_posts_on_page_1 = $posts_per_page - $pinned_posts_found;
         $offset = ($paged > 1) ? $regular_posts_on_page_1 + (($paged - 2) * $posts_per_page) : 0;
-        $posts_to_fetch = ($paged == 1) ? $regular_posts_on_page_1 : $posts_per_page;
+        $posts_to_fetch = ($paged === 1) ? $regular_posts_on_page_1 : $posts_per_page;
         
         $articles_query = null;
         if ($posts_to_fetch > 0) {


### PR DESCRIPTION
## Summary
- enforce strict comparison for admin page hook detection in settings and metabox registration
- ensure shortcode metabox check uses strict status comparison
- adjust shortcode pagination logic to rely on strict page checks

## Testing
- php -l includes/class-my-articles-settings.php
- php -l includes/class-my-articles-metaboxes.php
- php -l includes/class-my-articles-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68c9b307c8ac832e8f1627e36b31b13b