### PR TITLE
Localize JavaScript interface strings

### DIFF
--- a/mon-affichage-article/assets/js/admin-dynamic-fields.js
+++ b/mon-affichage-article/assets/js/admin-dynamic-fields.js
@@ -1,6 +1,8 @@
 (function ($) {
     'use strict';
 
+    var adminSettings = (typeof myArticlesAdmin !== 'undefined') ? myArticlesAdmin : {};
+
     function updateTaxonomySelector() {
         var $postTypeSelector = $('#post_type_selector');
         var $taxonomyWrapper = $('#taxonomy_selector_wrapper');
@@ -18,7 +20,7 @@
             type: 'POST',
             data: {
                 action: 'get_post_type_taxonomies',
-                security: myArticlesAdmin.nonce,
+                security: adminSettings.nonce || '',
                 post_type: selectedPostType
             },
             beforeSend: function() {
@@ -64,7 +66,7 @@
             type: 'POST',
             data: {
                 action: 'get_taxonomy_terms',
-                security: myArticlesAdmin.nonce,
+                security: adminSettings.nonce || '',
                 taxonomy: selectedTaxonomy
             },
             beforeSend: function() {
@@ -76,7 +78,7 @@
                     var currentTerm = $termSelect.data('current');
                     $termSelect.empty();
                     
-                    $termSelect.append($('<option>', { value: '', text: 'Toutes les catégories' }));
+                    $termSelect.append($('<option>', { value: '', text: adminSettings.allCategoriesText || '' }));
 
                     $.each(response.data, function (index, term) {
                         $termSelect.append($('<option>', {

--- a/mon-affichage-article/assets/js/admin-select2.js
+++ b/mon-affichage-article/assets/js/admin-select2.js
@@ -4,10 +4,11 @@
 
     $(function () {
         var $selectField = $('.my-articles-post-selector');
+        var select2Settings = (typeof myArticlesSelect2 !== 'undefined') ? myArticlesSelect2 : {};
 
         if ($selectField.length) {
             $selectField.select2({
-                placeholder: 'Rechercher un contenu par son titre...',
+                placeholder: select2Settings.placeholder || '',
                 minimumInputLength: 3,
                 ajax: {
                     url: ajaxurl,
@@ -17,7 +18,7 @@
                     data: function (params) {
                         return {
                             action: 'search_posts_for_select2',
-                            security: myArticlesSelect2.nonce,
+                            security: select2Settings.nonce || '',
                             search: params.term,
                             post_type: $('#post_type_selector').val() // On envoie le type de contenu sélectionné
                         };

--- a/mon-affichage-article/assets/js/filter.js
+++ b/mon-affichage-article/assets/js/filter.js
@@ -2,6 +2,8 @@
 (function ($) {
     'use strict';
 
+    var filterSettings = (typeof myArticlesFilter !== 'undefined') ? myArticlesFilter : {};
+
     $(document).on('click', '.my-articles-filter-nav a', function (e) {
         e.preventDefault();
 
@@ -19,11 +21,11 @@
         filterLink.parent().addClass('active');
 
         $.ajax({
-            url: myArticlesFilter.ajax_url,
+            url: filterSettings.ajax_url,
             type: 'POST',
             data: {
                 action: 'filter_articles',
-                security: myArticlesFilter.nonce,
+                security: filterSettings.nonce || '',
                 instance_id: instanceId,
                 category: categorySlug,
             },
@@ -80,7 +82,8 @@
             },
             error: function () {
                 contentArea.css('opacity', 1);
-                console.error('Erreur AJAX.');
+                var errorMessage = filterSettings.errorText || 'AJAX error.';
+                console.error(errorMessage);
             }
         });
     });

--- a/mon-affichage-article/assets/js/load-more.js
+++ b/mon-affichage-article/assets/js/load-more.js
@@ -2,6 +2,8 @@
 (function ($) {
     'use strict';
 
+    var loadMoreSettings = (typeof myArticlesLoadMore !== 'undefined') ? myArticlesLoadMore : {};
+
     $(document).on('click', '.my-articles-load-more-btn', function (e) {
         e.preventDefault();
 
@@ -17,25 +19,25 @@
         var category = button.data('category');
 
         $.ajax({
-            url: myArticlesLoadMore.ajax_url,
+            url: loadMoreSettings.ajax_url,
             type: 'POST',
             data: {
                 action: 'load_more_articles',
-                security: myArticlesLoadMore.nonce,
+                security: loadMoreSettings.nonce || '',
                 instance_id: instanceId,
                 paged: paged,
                 pinned_ids: pinnedIds,
                 category: category
             },
             beforeSend: function () {
-                button.text('Chargement...');
+                button.text(loadMoreSettings.loadingText || button.text());
                 button.prop('disabled', true);
             },
             success: function (response) {
                 if (response.success) {
                     // Ajoute les nouveaux articles à la suite des anciens
                     contentArea.append(response.data.html);
-                    
+
                     var newPage = paged + 1;
                     button.data('paged', newPage);
 
@@ -43,7 +45,7 @@
                         // S'il n'y a plus de page, on cache le bouton
                         button.hide();
                     } else {
-                        button.text('Charger plus');
+                        button.text(loadMoreSettings.loadMoreText || button.text());
                         button.prop('disabled', false);
                     }
                 } else {
@@ -53,7 +55,7 @@
             },
             error: function () {
                 button.hide();
-                console.error('Erreur AJAX.');
+                console.error(loadMoreSettings.errorText || 'AJAX error.');
             }
         });
     });

--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -33,8 +33,22 @@ class My_Articles_Metaboxes {
             wp_enqueue_script( 'my-articles-admin-options', MY_ARTICLES_PLUGIN_URL . 'assets/js/admin-options.js', array('jquery'), MY_ARTICLES_VERSION, true );
             wp_enqueue_script( 'my-articles-dynamic-fields', MY_ARTICLES_PLUGIN_URL . 'assets/js/admin-dynamic-fields.js', array('jquery'), MY_ARTICLES_VERSION, true );
 
-            wp_localize_script('my-articles-admin-select2', 'myArticlesSelect2', [ 'nonce' => wp_create_nonce('my_articles_select2_nonce') ]);
-            wp_localize_script('my-articles-dynamic-fields', 'myArticlesAdmin', [ 'nonce' => wp_create_nonce('my_articles_admin_nonce') ]);
+            wp_localize_script(
+                'my-articles-admin-select2',
+                'myArticlesSelect2',
+                [
+                    'nonce'       => wp_create_nonce('my_articles_select2_nonce'),
+                    'placeholder' => __( 'Rechercher un contenu par son titre...', 'mon-articles' ),
+                ]
+            );
+            wp_localize_script(
+                'my-articles-dynamic-fields',
+                'myArticlesAdmin',
+                [
+                    'nonce'             => wp_create_nonce('my_articles_admin_nonce'),
+                    'allCategoriesText' => __( 'Toutes les catégories', 'mon-articles' ),
+                ]
+            );
         }
     }
 

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -71,12 +71,30 @@ class My_Articles_Shortcode {
 
         if ( !empty($options['show_category_filter']) ) {
             wp_enqueue_script('my-articles-filter', MY_ARTICLES_PLUGIN_URL . 'assets/js/filter.js', ['jquery'], MY_ARTICLES_VERSION, true);
-            wp_localize_script('my-articles-filter', 'myArticlesFilter', [ 'ajax_url' => admin_url('admin-ajax.php'), 'nonce' => wp_create_nonce('my_articles_filter_nonce') ]);
+            wp_localize_script(
+                'my-articles-filter',
+                'myArticlesFilter',
+                [
+                    'ajax_url'  => admin_url('admin-ajax.php'),
+                    'nonce'     => wp_create_nonce('my_articles_filter_nonce'),
+                    'errorText' => __( 'Erreur AJAX.', 'mon-articles' ),
+                ]
+            );
         }
-        
+
         if ( $options['pagination_mode'] === 'load_more' ) {
             wp_enqueue_script('my-articles-load-more', MY_ARTICLES_PLUGIN_URL . 'assets/js/load-more.js', ['jquery'], MY_ARTICLES_VERSION, true);
-            wp_localize_script('my-articles-load-more', 'myArticlesLoadMore', [ 'ajax_url' => admin_url('admin-ajax.php'), 'nonce' => wp_create_nonce('my_articles_load_more_nonce') ]);
+            wp_localize_script(
+                'my-articles-load-more',
+                'myArticlesLoadMore',
+                [
+                    'ajax_url'     => admin_url('admin-ajax.php'),
+                    'nonce'        => wp_create_nonce('my_articles_load_more_nonce'),
+                    'loadingText'  => __( 'Chargement...', 'mon-articles' ),
+                    'loadMoreText' => __( 'Charger plus', 'mon-articles' ),
+                    'errorText'    => __( 'Erreur AJAX.', 'mon-articles' ),
+                ]
+            );
         }
 
         if ( $options['pagination_mode'] === 'numbered' ) {


### PR DESCRIPTION
## Summary
- pass translated interface strings to the front-end filter and load more scripts via `wp_localize_script`
- expose localized placeholders and option labels to admin scripts and consume them in JavaScript
- replace hardcoded French strings in JavaScript with the localized variables

## Testing
- php -l includes/class-my-articles-metaboxes.php
- php -l includes/class-my-articles-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68c9b30f2b7c832ea2066d5d01f06b0b