### PR TITLE
Expose filter pagination data and sync load more state

### DIFF
--- a/mon-affichage-article/assets/js/filter.js
+++ b/mon-affichage-article/assets/js/filter.js
@@ -37,6 +37,31 @@
                     contentArea.html(response.data.html);
                     contentArea.css('opacity', 1);
 
+                    var loadMoreBtn = wrapper.find('.my-articles-load-more-btn');
+                    if (loadMoreBtn.length) {
+                        var totalPages = parseInt(response.data.total_pages, 10);
+                        if (isNaN(totalPages)) {
+                            totalPages = 0;
+                        }
+
+                        var nextPage = parseInt(response.data.next_page, 10);
+                        if (isNaN(nextPage) || nextPage < 2) {
+                            nextPage = 2;
+                        }
+
+                        loadMoreBtn.data('category', categorySlug || '');
+                        loadMoreBtn.data('paged', nextPage);
+                        loadMoreBtn.data('total-pages', totalPages);
+                        loadMoreBtn.data('pinned-ids', response.data.pinned_ids || '');
+
+                        if (totalPages > 1) {
+                            loadMoreBtn.show();
+                            loadMoreBtn.prop('disabled', false);
+                        } else {
+                            loadMoreBtn.hide();
+                        }
+                    }
+
                     if (wrapper.hasClass('my-articles-slideshow')) {
                         if (typeof window.mySwiperInstances !== 'undefined' && window.mySwiperInstances[instanceId]) {
                             window.mySwiperInstances[instanceId].destroy(true, true);


### PR DESCRIPTION
## Summary
- enrich the filter AJAX callback with pagination metadata and refined query handling for pinned and excluded posts
- update the filter JavaScript to refresh the Load More button state after category changes

## Testing
- php -l mon-affichage-article/mon-affichage-articles.php

------
https://chatgpt.com/codex/tasks/task_e_68ca83fbdf64832eab7058ac45574af0