### PR TITLE
Handle pagination data in AJAX filter

### DIFF
--- a/mon-affichage-article/assets/js/filter.js
+++ b/mon-affichage-article/assets/js/filter.js
@@ -37,6 +37,36 @@
                     contentArea.html(response.data.html);
                     contentArea.css('opacity', 1);
 
+                    var loadMoreBtn = wrapper.find('.my-articles-load-more-btn');
+                    if (loadMoreBtn.length) {
+                        var totalPages = (response.data && typeof response.data.total_pages !== 'undefined') ? parseInt(response.data.total_pages, 10) : 0;
+                        var nextPage = (response.data && typeof response.data.next_page !== 'undefined') ? parseInt(response.data.next_page, 10) : 2;
+                        var pinnedIds = (response.data && typeof response.data.pinned_ids !== 'undefined') ? response.data.pinned_ids : '';
+
+                        if (isNaN(nextPage) || nextPage < 2) {
+                            nextPage = 2;
+                        }
+
+                        loadMoreBtn.data('category', categorySlug);
+                        loadMoreBtn.attr('data-category', categorySlug);
+
+                        loadMoreBtn.data('paged', nextPage);
+                        loadMoreBtn.attr('data-paged', nextPage);
+
+                        loadMoreBtn.data('total-pages', totalPages);
+                        loadMoreBtn.attr('data-total-pages', totalPages);
+
+                        loadMoreBtn.data('pinned-ids', pinnedIds);
+                        loadMoreBtn.attr('data-pinned-ids', pinnedIds);
+
+                        if (totalPages > 1) {
+                            loadMoreBtn.show();
+                            loadMoreBtn.prop('disabled', false);
+                        } else {
+                            loadMoreBtn.hide();
+                        }
+                    }
+
                     if (wrapper.hasClass('my-articles-slideshow')) {
                         if (typeof window.mySwiperInstances !== 'undefined' && window.mySwiperInstances[instanceId]) {
                             window.mySwiperInstances[instanceId].destroy(true, true);


### PR DESCRIPTION
## Summary
- return pagination metadata from the article filter AJAX callback so the front-end can control the load more button
- update the filter JavaScript to refresh load more button state, pagination counters, and pinned IDs after applying a filter

## Testing
- php -l mon-affichage-article/mon-affichage-articles.php

------
https://chatgpt.com/codex/tasks/task_e_68ca83f0ef94832eafa25244bcfdcc1b