### PR TITLE
Harmonize load more exclusions with filter logic

### DIFF
--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -259,16 +259,30 @@ final class Mon_Affichage_Articles {
         if ( empty( $taxonomy ) && 'post' === $post_type && taxonomy_exists( 'category' ) ) {
             $taxonomy = 'category';
         }
-        $pinned_ids = !empty($pinned_ids_str) ? array_map('absint', explode(',', $pinned_ids_str)) : array();
+        $pinned_ids = array();
+        if ( ! empty( $options['pinned_posts'] ) && is_array( $options['pinned_posts'] ) ) {
+            $pinned_ids = array_map( 'absint', $options['pinned_posts'] );
+        }
+
+        $request_pinned_ids = array();
+        if ( ! empty( $pinned_ids_str ) ) {
+            $request_pinned_ids = array_map( 'absint', array_filter( array_map( 'trim', explode( ',', $pinned_ids_str ) ) ) );
+        }
+
+        $pinned_ids = array_unique( array_merge( $pinned_ids, $request_pinned_ids ) );
 
         $exclude_ids = array();
         if ( ! empty( $options['exclude_posts'] ) ) {
-            $exclude_ids = array_map( 'absint', explode( ',', $options['exclude_posts'] ) );
+            if ( is_array( $options['exclude_posts'] ) ) {
+                $exclude_ids = array_map( 'absint', $options['exclude_posts'] );
+            } else {
+                $exclude_ids = array_map( 'absint', array_filter( array_map( 'trim', explode( ',', $options['exclude_posts'] ) ) ) );
+            }
         }
 
-        $all_excluded_ids = array_unique( array_merge( $pinned_ids, $exclude_ids ) );
+        $all_excluded_ids = array_filter( array_unique( array_merge( $pinned_ids, $exclude_ids ) ) );
 
-        $ignore_sticky_posts = ! empty( $options['ignore_native_sticky'] ) ? (int) $options['ignore_native_sticky'] : 0;
+        $ignore_sticky_posts = ! empty( $options['ignore_native_sticky'] );
 
         $query_args = [
             'post_type' => $post_type,


### PR DESCRIPTION
## Summary
- align the load more AJAX callback with the filter callback by parsing excluded post IDs from the widget settings
- merge pinned posts from the options and request with excluded IDs before feeding `post__not_in`
- honor the native sticky option by reusing its value for the WP_Query `ignore_sticky_posts` flag

## Testing
- php -l mon-affichage-article/mon-affichage-articles.php

------
https://chatgpt.com/codex/tasks/task_e_68cac45e37a0832eb30c3325eef24981