### PR TITLE
Align load-more exclusions with filter settings

### DIFF
--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -273,16 +273,12 @@ final class Mon_Affichage_Articles {
 
         $exclude_ids = array();
         if ( ! empty( $options['exclude_posts'] ) ) {
-            if ( is_array( $options['exclude_posts'] ) ) {
-                $exclude_ids = array_map( 'absint', $options['exclude_posts'] );
-            } else {
-                $exclude_ids = array_map( 'absint', array_filter( array_map( 'trim', explode( ',', $options['exclude_posts'] ) ) ) );
-            }
+            $exclude_ids = array_map( 'absint', explode( ',', $options['exclude_posts'] ) );
         }
 
-        $all_excluded_ids = array_filter( array_unique( array_merge( $pinned_ids, $exclude_ids ) ) );
+        $all_excluded_ids = array_unique( array_merge( $pinned_ids, $exclude_ids ) );
 
-        $ignore_sticky_posts = ! empty( $options['ignore_native_sticky'] );
+        $ignore_sticky_posts = ! empty( $options['ignore_native_sticky'] ) ? (int) $options['ignore_native_sticky'] : 0;
 
         $query_args = [
             'post_type' => $post_type,


### PR DESCRIPTION
## Summary
- parse excluded post IDs for the load-more AJAX endpoint the same way as in the filter handler
- combine excluded and pinned IDs for the WP_Query blacklist and propagate ignore_native_sticky to ignore_sticky_posts

## Testing
- php -l mon-affichage-article/mon-affichage-articles.php

------
https://chatgpt.com/codex/tasks/task_e_68caf60e75dc832ea0e7fb5ba55bd065