### PR TITLE
Fix load more offset with pinned posts

### DIFF
--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -272,9 +272,12 @@ final class Mon_Affichage_Articles {
             $pinned_ids = array_map( 'absint', $options['pinned_posts'] );
         }
 
-        $request_pinned_ids = array();
+        $request_pinned_ids    = array();
+        $displayed_pinned_count = 0;
         if ( ! empty( $pinned_ids_str ) ) {
             $request_pinned_ids = array_map( 'absint', array_filter( array_map( 'trim', explode( ',', $pinned_ids_str ) ) ) );
+            $request_pinned_ids = array_values( array_unique( array_filter( $request_pinned_ids ) ) );
+            $displayed_pinned_count = count( $request_pinned_ids );
         }
 
         $pinned_ids = array_unique( array_merge( $pinned_ids, $request_pinned_ids ) );
@@ -297,12 +300,18 @@ final class Mon_Affichage_Articles {
             }
         }
 
+        $regular_posts_on_page_1 = max( 0, $posts_per_page - $displayed_pinned_count );
+        $offset = 0;
+        if ( $paged > 1 ) {
+            $offset = $regular_posts_on_page_1 + ( ( $paged - 2 ) * $posts_per_page );
+        }
+
         $query_args = [
             'post_type' => $post_type,
             'post_status' => 'publish',
             'posts_per_page' => $posts_per_page,
             'post__not_in' => $all_excluded_ids,
-            'paged' => $paged,
+            'offset' => $offset,
             'ignore_sticky_posts' => $ignore_sticky_posts,
         ];
 


### PR DESCRIPTION
## Summary
- compute the count of pinned articles already rendered from the AJAX payload and reuse it while merging with configured pinned IDs
- reproduce the shortcode offset logic in the load more handler so paginated requests account for displayed pinned posts
- issue load more queries with an explicit offset instead of paged to avoid skipping posts between batches

## Testing
- php -l mon-affichage-article/mon-affichage-articles.php

------
https://chatgpt.com/codex/tasks/task_e_68cb163b1b80832ea3bbb7c367d5cae5