### PR TITLE
Add uninstall cleanup for custom post type

### DIFF
--- a/mon-affichage-article/uninstall.php
+++ b/mon-affichage-article/uninstall.php
@@ -1,1 +1,21 @@
-à compléter
+<?php
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+    exit;
+}
+
+delete_option( 'my_articles_options' );
+
+$posts = get_posts(
+    array(
+        'post_type'      => 'mon_affichage',
+        'posts_per_page' => -1,
+        'post_status'    => 'any',
+        'fields'         => 'ids',
+    )
+);
+
+if ( ! empty( $posts ) ) {
+    foreach ( $posts as $post_id ) {
+        wp_delete_post( $post_id, true );
+    }
+}


### PR DESCRIPTION
## Summary
- add uninstall guard to prevent direct access
- delete plugin options and force-delete custom posts during uninstall

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb1dc26c34832eb7a9182dbd9f2963