### PR TITLE
Clamp regular posts count before calculating offset

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -170,9 +170,9 @@ class My_Articles_Shortcode {
             }
         }
 
-        $regular_posts_on_page_1 = $posts_per_page - $pinned_posts_found;
-        $offset = ($paged > 1) ? $regular_posts_on_page_1 + (($paged - 2) * $posts_per_page) : 0;
-        $posts_to_fetch = ($paged === 1) ? $regular_posts_on_page_1 : $posts_per_page;
+        $regular_posts_on_page_1 = max( 0, $posts_per_page - $pinned_posts_found );
+        $offset = ( $paged > 1 ) ? $regular_posts_on_page_1 + ( ( $paged - 2 ) * $posts_per_page ) : 0;
+        $posts_to_fetch = ( $paged === 1 ) ? $regular_posts_on_page_1 : $posts_per_page;
         
         $articles_query = null;
         if ($posts_to_fetch > 0) {


### PR DESCRIPTION
## Summary
- prevent the regular post count on the first page from going negative when there are more pinned posts than the page size
- reuse the clamped value when computing offsets and posts fetched so pagination stays consistent

## Testing
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php
- php -r '$posts_per_page=10;$pinned_posts_found=15;for($paged=1;$paged<=3;$paged++){ $regular=max(0,$posts_per_page-$pinned_posts_found); $offset=($paged>1)?$regular+(($paged-2)*$posts_per_page):0; $posts_to_fetch=($paged===1)?$regular:$posts_per_page; echo "page $paged -> regular=$regular offset=$offset fetch=$posts_to_fetch\n"; }'

------
https://chatgpt.com/codex/tasks/task_e_68cc493c35ac832e91e174aba8ce52a9