### PR TITLE
Clamp regular posts count when pinned exceed limit

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -170,7 +170,7 @@ class My_Articles_Shortcode {
             }
         }
 
-        $regular_posts_on_page_1 = $posts_per_page - $pinned_posts_found;
+        $regular_posts_on_page_1 = max( 0, $posts_per_page - $pinned_posts_found );
         $offset = ($paged > 1) ? $regular_posts_on_page_1 + (($paged - 2) * $posts_per_page) : 0;
         $posts_to_fetch = ($paged === 1) ? $regular_posts_on_page_1 : $posts_per_page;
         


### PR DESCRIPTION
## Summary
- clamp the computed number of regular posts displayed on the first page so it is never negative when many posts are pinned
- ensure the offset and first-page fetch size reuse the clamped value to avoid incoherent queries when pinned posts exceed the per-page limit

## Testing
- php -r '$posts_per_page = 5; $pinned_posts_found = 7; for ($paged = 1; $paged <= 3; $paged++) { $regular_posts_on_page_1 = max(0, $posts_per_page - $pinned_posts_found); $offset = ($paged > 1) ? $regular_posts_on_page_1 + (($paged - 2) * $posts_per_page) : 0; $posts_to_fetch = ($paged === 1) ? $regular_posts_on_page_1 : $posts_per_page; echo "page {$paged}: regular={$regular_posts_on_page_1}, offset={$offset}, fetch={$posts_to_fetch}\n"; }'

------
https://chatgpt.com/codex/tasks/task_e_68cc4b0fd294832ebb805c04c2df7ac0