### PR TITLE
Clamp regular posts count before pagination queries

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -170,12 +170,15 @@ class My_Articles_Shortcode {
             }
         }
 
-        $regular_posts_on_page_1_raw = $posts_per_page - $pinned_posts_found;
-        $regular_posts_on_page_1 = max( 0, $regular_posts_on_page_1_raw );
-        $offset = ($paged > 1)
-            ? $regular_posts_on_page_1 + (($paged - 2) * $posts_per_page)
-            : 0;
-        $posts_to_fetch = ($paged === 1) ? $regular_posts_on_page_1 : $posts_per_page;
+        $regular_posts_on_page_1 = max( 0, $posts_per_page - $pinned_posts_found );
+
+        if ( $paged > 1 ) {
+            $offset = $regular_posts_on_page_1 + ( max( 0, $paged - 2 ) * $posts_per_page );
+            $posts_to_fetch = $posts_per_page;
+        } else {
+            $offset = 0;
+            $posts_to_fetch = $regular_posts_on_page_1;
+        }
         
         $articles_query = null;
         if ($posts_to_fetch > 0) {


### PR DESCRIPTION
## Summary
- clamp the first-page regular posts count before calculating offsets or fetch sizes
- reuse the bounded first-page count when deriving pagination queries to avoid negative offsets

## Testing
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php
- php -r '$posts_per_page=6;$pinned_posts_found=8;foreach([1,2,3] as $paged){$regular_posts_on_page_1=max(0,$posts_per_page-$pinned_posts_found);if($paged>1){$offset=$regular_posts_on_page_1+(max(0,$paged-2)*$posts_per_page);$posts_to_fetch=$posts_per_page;}else{$offset=0;$posts_to_fetch=$regular_posts_on_page_1;}echo "page $paged => regular_page1=$regular_posts_on_page_1 offset=$offset fetch=$posts_to_fetch\n";}'

------
https://chatgpt.com/codex/tasks/task_e_68cc5e174ca8832eaa47bf6735c22ea9