### PR TITLE
Adjust pagination counts for pinned articles

### DIFF
--- a/mon-affichage-article/assets/js/filter.js
+++ b/mon-affichage-article/assets/js/filter.js
@@ -40,18 +40,13 @@
                     var loadMoreBtn = wrapper.find('.my-articles-load-more-btn');
                     if (loadMoreBtn.length) {
                         var totalPages = (response.data && typeof response.data.total_pages !== 'undefined') ? parseInt(response.data.total_pages, 10) : 0;
-                        var nextPage = (response.data && typeof response.data.next_page !== 'undefined') ? parseInt(response.data.next_page, 10) : 2;
+                        totalPages = isNaN(totalPages) ? 0 : totalPages;
+                        var nextPage = (response.data && typeof response.data.next_page !== 'undefined') ? parseInt(response.data.next_page, 10) : 0;
+                        nextPage = isNaN(nextPage) ? 0 : nextPage;
                         var pinnedIds = (response.data && typeof response.data.pinned_ids !== 'undefined') ? response.data.pinned_ids : '';
-
-                        if (isNaN(nextPage) || nextPage < 2) {
-                            nextPage = 2;
-                        }
 
                         loadMoreBtn.data('category', categorySlug);
                         loadMoreBtn.attr('data-category', categorySlug);
-
-                        loadMoreBtn.data('paged', nextPage);
-                        loadMoreBtn.attr('data-paged', nextPage);
 
                         loadMoreBtn.data('total-pages', totalPages);
                         loadMoreBtn.attr('data-total-pages', totalPages);
@@ -60,10 +55,18 @@
                         loadMoreBtn.attr('data-pinned-ids', pinnedIds);
 
                         if (totalPages > 1) {
+                            if (nextPage < 2) {
+                                nextPage = 2;
+                            }
+                            loadMoreBtn.data('paged', nextPage);
+                            loadMoreBtn.attr('data-paged', nextPage);
                             loadMoreBtn.show();
                             loadMoreBtn.prop('disabled', false);
                         } else {
+                            loadMoreBtn.data('paged', nextPage);
+                            loadMoreBtn.attr('data-paged', nextPage);
                             loadMoreBtn.hide();
+                            loadMoreBtn.prop('disabled', false);
                         }
                     }
 

--- a/mon-affichage-article/assets/js/load-more.js
+++ b/mon-affichage-article/assets/js/load-more.js
@@ -13,10 +13,16 @@
         var contentArea = wrapper.find('.my-articles-grid-content, .my-articles-list-content');
         
         var instanceId = button.data('instance-id');
-        var paged = button.data('paged');
-        var totalPages = button.data('total-pages');
+        var paged = parseInt(button.data('paged'), 10) || 0;
+        var totalPages = parseInt(button.data('total-pages'), 10) || 0;
         var pinnedIds = button.data('pinned-ids');
         var category = button.data('category');
+
+        if (!totalPages || (paged && paged > totalPages)) {
+            button.hide();
+            button.prop('disabled', false);
+            return;
+        }
 
         $.ajax({
             url: loadMoreSettings.ajax_url,
@@ -40,21 +46,27 @@
 
                     var newPage = paged + 1;
                     button.data('paged', newPage);
+                    button.attr('data-paged', newPage);
 
-                    if (newPage > totalPages) {
+                    button.text(loadMoreSettings.loadMoreText || button.text());
+
+                    if (!totalPages || newPage > totalPages) {
                         // S'il n'y a plus de page, on cache le bouton
                         button.hide();
-                    } else {
-                        button.text(loadMoreSettings.loadMoreText || button.text());
                         button.prop('disabled', false);
+                        return;
                     }
+
+                    button.prop('disabled', false);
                 } else {
                     // En cas d'erreur, on cache le bouton pour éviter de boucler
                     button.hide();
+                    button.prop('disabled', false);
                 }
             },
             error: function () {
                 button.hide();
+                button.prop('disabled', false);
                 console.error(loadMoreSettings.errorText || 'AJAX error.');
             }
         });

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -272,7 +272,11 @@ class My_Articles_Shortcode {
             }
 
             $total_posts = $pinned_posts_found + $total_regular_posts;
-            $total_pages = $posts_per_page > 0 ? ceil($total_posts / $posts_per_page) : 0;
+            $regular_first_page_capacity = $posts_per_page > 0 ? max( 0, $posts_per_page - $pinned_posts_found ) : 0;
+            $regular_on_first_page = min( $total_regular_posts, $regular_first_page_capacity );
+            $remaining_regular_posts = max( 0, $total_regular_posts - $regular_on_first_page );
+            $additional_regular_pages = $posts_per_page > 0 ? (int) ceil( $remaining_regular_posts / $posts_per_page ) : 0;
+            $total_pages = $total_posts > 0 ? 1 + $additional_regular_pages : 0;
 
             if ($options['pagination_mode'] === 'load_more') {
                 if ( $total_pages > 1 && $paged < $total_pages) {

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -233,13 +233,11 @@ final class Mon_Affichage_Articles {
         }
 
         $total_posts = $pinned_posts_found + $total_regular_posts;
-        $total_pages = 0;
-
-        if ( $total_posts_needed > 0 && $total_posts > 0 ) {
-            $total_pages = (int) ceil( $total_posts / $total_posts_needed );
-        } elseif ( 0 === $total_posts_needed && $total_posts > 0 ) {
-            $total_pages = 1;
-        }
+        $regular_first_page_capacity = $total_posts_needed > 0 ? max( 0, $total_posts_needed - $pinned_posts_found ) : 0;
+        $regular_on_first_page = min( $total_regular_posts, $regular_first_page_capacity );
+        $remaining_regular_posts = max( 0, $total_regular_posts - $regular_on_first_page );
+        $additional_regular_pages = $posts_per_page > 0 ? (int) ceil( $remaining_regular_posts / $posts_per_page ) : 0;
+        $total_pages = $total_posts > 0 ? 1 + $additional_regular_pages : 0;
 
         $next_page = $total_pages > 1 ? 2 : 0;
         $pinned_ids_string = ! empty( $effective_pinned_ids ) ? implode( ',', array_map( 'absint', $effective_pinned_ids ) ) : '';


### PR DESCRIPTION
## Summary
- recalculated total pages for pinned and regular articles to respect the first-page distribution
- aligned AJAX filter response with the new total page calculation and updated load-more metadata handling
- hardened the load-more script to stop requests when exceeding the total number of pages

## Testing
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php
- php -l mon-affichage-article/mon-affichage-articles.php

------
https://chatgpt.com/codex/tasks/task_e_68cd6c2b3570832eba3f9bae5287ec3a