### PR TITLE
Align pagination totals with pinned post layout

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -271,12 +271,12 @@ class My_Articles_Shortcode {
                 $total_regular_posts = (int) $count_query->found_posts;
             }
 
-            $total_posts = $pinned_posts_found + $total_regular_posts;
-            $regular_first_page_capacity = $posts_per_page > 0 ? max( 0, $posts_per_page - $pinned_posts_found ) : 0;
-            $regular_on_first_page = min( $total_regular_posts, $regular_first_page_capacity );
-            $remaining_regular_posts = max( 0, $total_regular_posts - $regular_on_first_page );
-            $additional_regular_pages = $posts_per_page > 0 ? (int) ceil( $remaining_regular_posts / $posts_per_page ) : 0;
-            $total_pages = $total_posts > 0 ? 1 + $additional_regular_pages : 0;
+            $pagination_totals = my_articles_calculate_total_pages(
+                $pinned_posts_found,
+                $total_regular_posts,
+                $posts_per_page
+            );
+            $total_pages = $pagination_totals['total_pages'];
 
             if ($options['pagination_mode'] === 'load_more') {
                 if ( $total_pages > 1 && $paged < $total_pages) {

--- a/mon-affichage-article/includes/helpers.php
+++ b/mon-affichage-article/includes/helpers.php
@@ -48,3 +48,44 @@ if ( ! function_exists( 'my_articles_sanitize_color' ) ) {
         return $default;
     }
 }
+
+if ( ! function_exists( 'my_articles_calculate_total_pages' ) ) {
+    /**
+     * Calculate the total number of pages required when pinned posts appear on the first page.
+     *
+     * The first page contains all pinned posts plus as many regular posts as needed to reach
+     * the configured posts per page. Subsequent pages only contain regular posts.
+     *
+     * @param int $pinned_posts_found   Number of pinned posts displayed on the first page.
+     * @param int $total_regular_posts  Number of available regular posts.
+     * @param int $posts_per_page       Posts per page setting.
+     *
+     * @return array{
+     *     total_pages:int,
+     *     next_page:int,
+     * }
+     */
+    function my_articles_calculate_total_pages( $pinned_posts_found, $total_regular_posts, $posts_per_page ) {
+        $pinned_posts_found  = max( 0, (int) $pinned_posts_found );
+        $total_regular_posts = max( 0, (int) $total_regular_posts );
+        $posts_per_page      = max( 0, (int) $posts_per_page );
+
+        $regular_first_page_capacity = $posts_per_page > 0
+            ? max( 0, $posts_per_page - $pinned_posts_found )
+            : 0;
+        $regular_on_first_page = min( $total_regular_posts, $regular_first_page_capacity );
+        $remaining_regular     = max( 0, $total_regular_posts - $regular_on_first_page );
+        $additional_pages      = $posts_per_page > 0
+            ? (int) ceil( $remaining_regular / $posts_per_page )
+            : 0;
+
+        $total_pages = ( $pinned_posts_found + $total_regular_posts ) > 0
+            ? 1 + $additional_pages
+            : 0;
+
+        return [
+            'total_pages' => $total_pages,
+            'next_page'   => $total_pages > 1 ? 2 : 0,
+        ];
+    }
+}

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -232,14 +232,13 @@ final class Mon_Affichage_Articles {
             wp_reset_postdata();
         }
 
-        $total_posts = $pinned_posts_found + $total_regular_posts;
-        $regular_first_page_capacity = $total_posts_needed > 0 ? max( 0, $total_posts_needed - $pinned_posts_found ) : 0;
-        $regular_on_first_page = min( $total_regular_posts, $regular_first_page_capacity );
-        $remaining_regular_posts = max( 0, $total_regular_posts - $regular_on_first_page );
-        $additional_regular_pages = $posts_per_page > 0 ? (int) ceil( $remaining_regular_posts / $posts_per_page ) : 0;
-        $total_pages = $total_posts > 0 ? 1 + $additional_regular_pages : 0;
-
-        $next_page = $total_pages > 1 ? 2 : 0;
+        $pagination_totals = my_articles_calculate_total_pages(
+            $pinned_posts_found,
+            $total_regular_posts,
+            $posts_per_page
+        );
+        $total_pages = $pagination_totals['total_pages'];
+        $next_page   = $pagination_totals['next_page'];
         $pinned_ids_string = ! empty( $effective_pinned_ids ) ? implode( ',', array_map( 'absint', $effective_pinned_ids ) ) : '';
 
         wp_send_json_success(


### PR DESCRIPTION
## Summary
- add a shared helper to compute load-more pagination when pinned posts occupy the first page
- reuse the helper in the shortcode renderer and filter AJAX endpoint so data-total-pages and next_page stay consistent

## Testing
- php -l mon-affichage-article/includes/helpers.php
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php
- php -l mon-affichage-article/mon-affichage-articles.php

------
https://chatgpt.com/codex/tasks/task_e_68cd759d6e78832e82b86ac58f7a275b