### PR TITLE
Handle empty string taxonomy terms for filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ mon-affichage-article/
 - `load_more_articles`
 - `search_posts_for_select2`
 
+## Tests manuels
+
+Pour vérifier la prise en charge d'un slug de taxonomie égal à `"0"` :
+
+1. Créez ou identifiez une catégorie (ou tout terme de la taxonomie utilisée) dont le slug vaut exactement `0`.
+2. Configurez un module **Tuiles – LCV** afin qu'il utilise ce terme comme valeur par défaut et activez, si besoin, le filtre de catégories en frontal.
+3. Affichez le module côté public et vérifiez que les articles associés au terme `0` apparaissent bien, que le filtre est sélectionné et que la pagination/chargement additionnel respecte ce terme.
+
 ## Crédits
 
 Développé par LCV.

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -144,7 +144,7 @@ class My_Articles_Shortcode {
             $default_term = isset( $options['term'] ) ? sanitize_text_field( $options['term'] ) : '';
             $taxonomy = $resolved_taxonomy;
 
-            if ( empty( $options['pinned_posts_ignore_filter'] ) && ! empty( $default_term ) && 'all' !== $default_term ) {
+            if ( empty( $options['pinned_posts_ignore_filter'] ) && '' !== $default_term && 'all' !== $default_term ) {
                 if ( ! empty( $taxonomy ) ) {
                     $pinned_query_args['tax_query'] = [
                         [
@@ -186,7 +186,7 @@ class My_Articles_Shortcode {
                 'ignore_sticky_posts' => (int)$options['ignore_native_sticky'],
             ];
 
-            if ( ! empty( $resolved_taxonomy ) && ! empty( $options['term'] ) ) {
+            if ( '' !== $resolved_taxonomy && '' !== $options['term'] && 'all' !== $options['term'] ) {
                 $regular_query_args['tax_query'] = [
                     [
                         'taxonomy' => $resolved_taxonomy,
@@ -227,7 +227,7 @@ class My_Articles_Shortcode {
                     $alignment_class = 'filter-align-' . esc_attr($options['filter_alignment']);
                     echo '<nav class="my-articles-filter-nav ' . $alignment_class . '"><ul>';
                     $default_cat = $options['term'] ?? '';
-                    $is_all_active = empty($default_cat) || $default_cat === 'all';
+                    $is_all_active = '' === $default_cat || 'all' === $default_cat;
                     echo '<li class="' . ($is_all_active ? 'active' : '') . '"><a href="#" data-category="all">' . __('Tout', 'mon-articles') . '</a></li>';
                     foreach ($categories as $category) {
                         echo '<li class="' . ($default_cat === $category->slug ? 'active' : '') . '"><a href="#" data-category="' .esc_attr($category->slug) . '">' . esc_html($category->name) . '</a></li>';
@@ -259,7 +259,7 @@ class My_Articles_Shortcode {
                     'fields' => 'ids',
                 ];
 
-                if ( ! empty( $resolved_taxonomy ) && ! empty( $options['term'] ) ) {
+                if ( '' !== $resolved_taxonomy && '' !== $options['term'] && 'all' !== $options['term'] ) {
                     $count_query_args['tax_query'] = [[
                         'taxonomy' => $resolved_taxonomy,
                         'field'    => 'slug',

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -114,7 +114,7 @@ final class Mon_Affichage_Articles {
                 'post__not_in'   => $exclude_ids,
             ];
 
-            if ( empty( $options['pinned_posts_ignore_filter'] ) && ! empty( $category_slug ) && 'all' !== $category_slug ) {
+            if ( empty( $options['pinned_posts_ignore_filter'] ) && '' !== $category_slug && 'all' !== $category_slug ) {
                 if ( ! empty( $taxonomy ) ) {
                     $pinned_query_args['tax_query'] = [
                         [
@@ -147,7 +147,7 @@ final class Mon_Affichage_Articles {
                 'ignore_sticky_posts' => $ignore_sticky_posts,
             ];
 
-            if ( !empty($category_slug) && $category_slug !== 'all' ) {
+            if ( '' !== $category_slug && 'all' !== $category_slug ) {
                 if ( ! empty( $taxonomy ) ) {
                     $query_args['tax_query'] = [
                         [
@@ -213,7 +213,7 @@ final class Mon_Affichage_Articles {
                 'fields'              => 'ids',
             ];
 
-            if ( ! empty( $category_slug ) && 'all' !== $category_slug ) {
+            if ( '' !== $category_slug && 'all' !== $category_slug ) {
                 if ( ! empty( $taxonomy ) ) {
                     $count_query_args['tax_query'] = [
                         [
@@ -317,7 +317,7 @@ final class Mon_Affichage_Articles {
             'ignore_sticky_posts' => $ignore_sticky_posts,
         ];
 
-        if ( !empty($category) && $category !== 'all' ) {
+        if ( '' !== $category && 'all' !== $category ) {
             if ( ! empty( $taxonomy ) ) {
                 $query_args['tax_query'] = [
                     [


### PR DESCRIPTION
## Summary
- ensure ajax filters treat an empty string category slug differently from the string '0'
- apply the same strict comparison logic to shortcode queries and active state rendering
- document a manual test scenario covering a taxonomy term whose slug equals "0"

## Testing
- php -l mon-affichage-article/mon-affichage-articles.php
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68cd8c57a1d4832e92f6810b2a2b9308