### PR TITLE
Add text domain to pagination labels

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -451,7 +451,7 @@ class My_Articles_Shortcode {
         }
 
         $base_url = remove_query_arg( $paged_var, $current_url );
-        $pagination_links = paginate_links(['base' => $base_url . '%_%', 'format' => (strpos($base_url, '?') ? '&' : '?') . $paged_var . '=%#%', 'current' => max( 1, $paged ), 'total' => $total_pages, 'prev_text' => __('&laquo; Précédent'), 'next_text' => __('Suivant &raquo;')]);
+        $pagination_links = paginate_links(['base' => $base_url . '%_%', 'format' => (strpos($base_url, '?') ? '&' : '?') . $paged_var . '=%#%', 'current' => max( 1, $paged ), 'total' => $total_pages, 'prev_text' => __('&laquo; Précédent', 'mon-articles'), 'next_text' => __('Suivant &raquo;', 'mon-articles')]);
         if ($pagination_links) { echo '<nav class="my-articles-pagination">' . $pagination_links . '</nav>'; }
     }
 


### PR DESCRIPTION
## Summary
- ensure the numbered pagination prev/next labels use the `mon-articles` text domain

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce742ef468832e87e35a7157f8cc84