### PR TITLE
Ensure AJAX flows use shortcode defaults

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -19,6 +19,48 @@ class My_Articles_Shortcode {
         add_shortcode( 'mon_affichage_articles', array( $this, 'render_shortcode' ) );
     }
 
+    public static function get_default_options() {
+        return [
+            'post_type' => 'post',
+            'taxonomy' => '',
+            'term' => '',
+            'counting_behavior' => 'exact',
+            'posts_per_page' => 10,
+            'pagination_mode' => 'none',
+            'show_category_filter' => 0,
+            'filter_alignment' => 'right',
+            'filter_categories' => array(),
+            'pinned_posts' => array(),
+            'pinned_border_color' => '#eab308',
+            'pinned_posts_ignore_filter' => 0,
+            'pinned_show_badge' => 0,
+            'pinned_badge_text' => 'Épinglé',
+            'pinned_badge_bg_color' => '#eab308',
+            'pinned_badge_text_color' => '#ffffff',
+            'exclude_posts' => '',
+            'ignore_native_sticky' => 1,
+            'enable_lazy_load' => 1,
+            'enable_debug_mode' => 0,
+            'display_mode' => 'grid',
+            'columns_mobile' => 1, 'columns_tablet' => 2, 'columns_desktop' => 3, 'columns_ultrawide' => 4,
+            'module_padding_left' => 0, 'module_padding_right' => 0,
+            'gap_size' => 25, 'list_item_gap' => 25,
+            'list_content_padding_top' => 0, 'list_content_padding_right' => 0,
+            'list_content_padding_bottom' => 0, 'list_content_padding_left' => 0,
+            'border_radius' => 12, 'title_font_size' => 16,
+            'meta_font_size' => 12, 'show_category' => 1, 'show_author' => 1, 'show_date' => 1,
+            'show_excerpt' => 0,
+            'excerpt_length' => 25,
+            'excerpt_more_text' => 'Lire la suite',
+            'excerpt_font_size' => 14,
+            'excerpt_color' => '#4b5563',
+            'module_bg_color' => 'rgba(255,255,255,0)', 'vignette_bg_color' => '#ffffff',
+            'title_wrapper_bg_color' => '#ffffff', 'title_color' => '#333333',
+            'meta_color' => '#6b7280', 'meta_color_hover' => '#000000', 'pagination_color' => '#333333',
+            'shadow_color' => 'rgba(0,0,0,0.07)', 'shadow_color_hover' => 'rgba(0,0,0,0.12)',
+        ];
+    }
+
     public function render_shortcode( $atts ) {
         $atts = shortcode_atts( ['id' => 0], $atts, 'mon_affichage_articles' );
         $id = absint($atts['id']);
@@ -28,45 +70,7 @@ class My_Articles_Shortcode {
         }
 
         $options = (array) get_post_meta( $id, '_my_articles_settings', true );
-        $defaults = [
-            'post_type' => 'post',
-            'taxonomy' => '',
-            'term' => '',
-            'counting_behavior' => 'exact',
-            'posts_per_page' => 10,
-            'pagination_mode' => 'none',
-            'show_category_filter' => 0, 
-            'filter_alignment' => 'right', 
-            'filter_categories' => array(),
-            'pinned_posts' => array(), 
-            'pinned_border_color' => '#eab308',
-            'pinned_posts_ignore_filter' => 0,
-            'pinned_show_badge' => 0, 
-            'pinned_badge_text' => 'Épinglé',
-            'pinned_badge_bg_color' => '#eab308', 
-            'pinned_badge_text_color' => '#ffffff',
-            'exclude_posts' => '', 
-            'ignore_native_sticky' => 1,
-            'enable_lazy_load' => 1,
-            'enable_debug_mode' => 0,
-            'display_mode' => 'grid',
-            'columns_mobile' => 1, 'columns_tablet' => 2, 'columns_desktop' => 3, 'columns_ultrawide' => 4,
-            'module_padding_left' => 0, 'module_padding_right' => 0, 
-            'gap_size' => 25, 'list_item_gap' => 25, 
-            'list_content_padding_top' => 0, 'list_content_padding_right' => 0,
-            'list_content_padding_bottom' => 0, 'list_content_padding_left' => 0,
-            'border_radius' => 12, 'title_font_size' => 16, 
-            'meta_font_size' => 12, 'show_category' => 1, 'show_author' => 1, 'show_date' => 1, 
-            'show_excerpt' => 0,
-            'excerpt_length' => 25,
-            'excerpt_more_text' => 'Lire la suite',
-            'excerpt_font_size' => 14,
-            'excerpt_color' => '#4b5563',
-            'module_bg_color' => 'rgba(255,255,255,0)', 'vignette_bg_color' => '#ffffff', 
-            'title_wrapper_bg_color' => '#ffffff', 'title_color' => '#333333', 
-            'meta_color' => '#6b7280', 'meta_color_hover' => '#000000', 'pagination_color' => '#333333',
-            'shadow_color' => 'rgba(0,0,0,0.07)', 'shadow_color_hover' => 'rgba(0,0,0,0.12)',
-        ];
+        $defaults = self::get_default_options();
         $options = wp_parse_args($options, $defaults);
 
         $resolved_taxonomy = $this->resolve_taxonomy( $options );

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -70,14 +70,21 @@ final class Mon_Affichage_Articles {
         }
 
         $shortcode_instance = My_Articles_Shortcode::get_instance();
-        $options = (array) get_post_meta( $instance_id, '_my_articles_settings', true );
+        $options_meta       = (array) get_post_meta( $instance_id, '_my_articles_settings', true );
+        $defaults           = My_Articles_Shortcode::get_default_options();
+        $options            = wp_parse_args( $options_meta, $defaults );
+
         $display_mode = $options['display_mode'] ?? 'grid';
-        $post_type = ( ! empty( $options['post_type'] ) && post_type_exists( $options['post_type'] ) ) ? $options['post_type'] : 'post';
-        $taxonomy = ( ! empty( $options['taxonomy'] ) && taxonomy_exists( $options['taxonomy'] ) ) ? $options['taxonomy'] : '';
+        $post_type    = ( ! empty( $options['post_type'] ) && post_type_exists( $options['post_type'] ) ) ? $options['post_type'] : 'post';
+        $taxonomy     = ( ! empty( $options['taxonomy'] ) && taxonomy_exists( $options['taxonomy'] ) ) ? $options['taxonomy'] : '';
         if ( empty( $taxonomy ) && 'post' === $post_type && taxonomy_exists( 'category' ) ) {
             $taxonomy = 'category';
         }
-        
+
+        $options['display_mode'] = $display_mode;
+        $options['post_type']    = $post_type;
+        $options['taxonomy']     = $taxonomy;
+
         $posts_per_page = isset( $options['posts_per_page'] ) ? (int) $options['posts_per_page'] : 10;
         if ( ( $options['counting_behavior'] ?? 'exact' ) === 'auto_fill' && in_array( $display_mode, array( 'grid', 'slideshow' ), true ) ) {
             $master_columns = isset( $options['columns_ultrawide'] ) ? (int) $options['columns_ultrawide'] : 0;
@@ -86,12 +93,16 @@ final class Mon_Affichage_Articles {
                 $posts_per_page = $rows_needed * $master_columns;
             }
         }
-        $ignore_sticky_posts = ! empty( $options['ignore_native_sticky'] ) ? (int) $options['ignore_native_sticky'] : 0;
+        $options['posts_per_page'] = $posts_per_page;
+
+        $ignore_sticky_posts        = ! empty( $options['ignore_native_sticky'] ) ? (int) $options['ignore_native_sticky'] : 0;
+        $options['ignore_native_sticky'] = $ignore_sticky_posts;
 
         $pinned_ids = array();
         if ( ! empty( $options['pinned_posts'] ) && is_array( $options['pinned_posts'] ) ) {
             $pinned_ids = array_map( 'absint', $options['pinned_posts'] );
         }
+        $options['pinned_posts'] = $pinned_ids;
 
         $exclude_ids = array();
         if ( ! empty( $options['exclude_posts'] ) ) {
@@ -262,17 +273,24 @@ final class Mon_Affichage_Articles {
         if (!$instance_id) { wp_send_json_error(); }
 
         $shortcode_instance = My_Articles_Shortcode::get_instance();
-        $options = (array) get_post_meta( $instance_id, '_my_articles_settings', true );
+        $options_meta       = (array) get_post_meta( $instance_id, '_my_articles_settings', true );
+        $defaults           = My_Articles_Shortcode::get_default_options();
+        $options            = wp_parse_args( $options_meta, $defaults );
+
         $display_mode = $options['display_mode'] ?? 'grid';
-        $post_type = ( ! empty( $options['post_type'] ) && post_type_exists( $options['post_type'] ) ) ? $options['post_type'] : 'post';
-        $taxonomy = ( ! empty( $options['taxonomy'] ) && taxonomy_exists( $options['taxonomy'] ) ) ? $options['taxonomy'] : '';
+        $post_type    = ( ! empty( $options['post_type'] ) && post_type_exists( $options['post_type'] ) ) ? $options['post_type'] : 'post';
+        $taxonomy     = ( ! empty( $options['taxonomy'] ) && taxonomy_exists( $options['taxonomy'] ) ) ? $options['taxonomy'] : '';
         if ( empty( $taxonomy ) && 'post' === $post_type && taxonomy_exists( 'category' ) ) {
             $taxonomy = 'category';
         }
+        $options['display_mode'] = $display_mode;
+        $options['post_type']    = $post_type;
+        $options['taxonomy']     = $taxonomy;
         $pinned_ids = array();
         if ( ! empty( $options['pinned_posts'] ) && is_array( $options['pinned_posts'] ) ) {
             $pinned_ids = array_map( 'absint', $options['pinned_posts'] );
         }
+        $options['pinned_posts'] = $pinned_ids;
 
         $request_pinned_ids    = array();
         $displayed_pinned_count = 0;
@@ -291,7 +309,8 @@ final class Mon_Affichage_Articles {
 
         $all_excluded_ids = array_unique( array_merge( $pinned_ids, $exclude_ids ) );
 
-        $ignore_sticky_posts = ! empty( $options['ignore_native_sticky'] ) ? (int) $options['ignore_native_sticky'] : 0;
+        $ignore_sticky_posts        = ! empty( $options['ignore_native_sticky'] ) ? (int) $options['ignore_native_sticky'] : 0;
+        $options['ignore_native_sticky'] = $ignore_sticky_posts;
 
         $posts_per_page = isset( $options['posts_per_page'] ) ? (int) $options['posts_per_page'] : 10;
         if ( ( $options['counting_behavior'] ?? 'exact' ) === 'auto_fill' && in_array( $display_mode, array( 'grid', 'slideshow' ), true ) ) {
@@ -301,6 +320,7 @@ final class Mon_Affichage_Articles {
                 $posts_per_page = $rows_needed * $master_columns;
             }
         }
+        $options['posts_per_page'] = $posts_per_page;
 
         $regular_posts_on_page_1 = max( 0, $posts_per_page - $displayed_pinned_count );
         $offset = 0;


### PR DESCRIPTION
## Summary
- add a reusable helper on the shortcode class to expose its default options
- merge stored settings with defaults inside the AJAX filter and load-more callbacks
- reuse the normalized option set for rendering items and related calculations

## Testing
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php
- php -l mon-affichage-article/mon-affichage-articles.php

------
https://chatgpt.com/codex/tasks/task_e_68ce8a1694e0832e8e938b5236718f4e