### PR TITLE
Ensure article rendering respects posts per page limit

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -253,9 +253,9 @@ class My_Articles_Shortcode {
         if ($options['display_mode'] === 'slideshow') {
             $this->render_slideshow($pinned_query, $articles_query, $options, $posts_per_page);
         } else if ($options['display_mode'] === 'list') {
-            $this->render_list($pinned_query, $articles_query, $options);
+            $this->render_list($pinned_query, $articles_query, $options, $posts_per_page);
         } else {
-            $this->render_grid($pinned_query, $articles_query, $options);
+            $this->render_grid($pinned_query, $articles_query, $options, $posts_per_page);
         }
 
         if ($options['display_mode'] === 'grid' || $options['display_mode'] === 'list') {
@@ -333,26 +333,84 @@ class My_Articles_Shortcode {
         return ob_get_clean();
     }
     
-    private function render_list($pinned_query, $regular_query, $options) {
+    private function render_list($pinned_query, $regular_query, $options, $posts_per_page) {
         $has_rendered_posts = false;
+        $rendered_count      = 0;
+        $limit               = (int) $posts_per_page;
+        $enforce_limit       = ( $limit > 0 );
+
         echo '<div class="my-articles-list-content">';
-        if ( $pinned_query && $pinned_query->have_posts() ) { while ( $pinned_query->have_posts() ) { $pinned_query->the_post(); $this->render_article_item($options, true); $has_rendered_posts = true; } }
-        if ( $regular_query && $regular_query->have_posts() ) { while ( $regular_query->have_posts() ) { $regular_query->the_post(); $this->render_article_item($options, false); $has_rendered_posts = true; } }
+
+        if ( $pinned_query && $pinned_query->have_posts() ) {
+            while ( $pinned_query->have_posts() ) {
+                if ( $enforce_limit && $rendered_count >= $limit ) {
+                    break;
+                }
+
+                $pinned_query->the_post();
+                $this->render_article_item( $options, true );
+                $has_rendered_posts = true;
+                $rendered_count++;
+            }
+        }
+
+        if ( $regular_query && $regular_query->have_posts() ) {
+            while ( $regular_query->have_posts() ) {
+                if ( $enforce_limit && $rendered_count >= $limit ) {
+                    break;
+                }
+
+                $regular_query->the_post();
+                $this->render_article_item( $options, false );
+                $has_rendered_posts = true;
+                $rendered_count++;
+            }
+        }
+
         echo '</div>';
 
-        if ( !$has_rendered_posts ) {
+        if ( ! $has_rendered_posts ) {
             $this->render_empty_state_message();
         }
     }
 
-    private function render_grid($pinned_query, $regular_query, $options) {
+    private function render_grid($pinned_query, $regular_query, $options, $posts_per_page) {
         $has_rendered_posts = false;
+        $rendered_count      = 0;
+        $limit               = (int) $posts_per_page;
+        $enforce_limit       = ( $limit > 0 );
+
         echo '<div class="my-articles-grid-content">';
-        if ( $pinned_query && $pinned_query->have_posts() ) { while ( $pinned_query->have_posts() ) { $pinned_query->the_post(); $this->render_article_item($options, true); $has_rendered_posts = true; } }
-        if ( $regular_query && $regular_query->have_posts() ) { while ( $regular_query->have_posts() ) { $regular_query->the_post(); $this->render_article_item($options, false); $has_rendered_posts = true; } }
+
+        if ( $pinned_query && $pinned_query->have_posts() ) {
+            while ( $pinned_query->have_posts() ) {
+                if ( $enforce_limit && $rendered_count >= $limit ) {
+                    break;
+                }
+
+                $pinned_query->the_post();
+                $this->render_article_item( $options, true );
+                $has_rendered_posts = true;
+                $rendered_count++;
+            }
+        }
+
+        if ( $regular_query && $regular_query->have_posts() ) {
+            while ( $regular_query->have_posts() ) {
+                if ( $enforce_limit && $rendered_count >= $limit ) {
+                    break;
+                }
+
+                $regular_query->the_post();
+                $this->render_article_item( $options, false );
+                $has_rendered_posts = true;
+                $rendered_count++;
+            }
+        }
+
         echo '</div>';
 
-        if ( !$has_rendered_posts ) {
+        if ( ! $has_rendered_posts ) {
             $this->render_empty_state_message();
         }
     }

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -180,27 +180,52 @@ final class Mon_Affichage_Articles {
 
         ob_start();
 
-        $displayed_posts_count = $pinned_posts_found;
+        $displayed_posts_count = 0;
+        $limit                 = (int) $posts_per_page;
+        $enforce_limit         = ( 'slideshow' !== $display_mode && $limit > 0 );
 
         if ( $pinned_query && $pinned_query->have_posts() ) {
             while ( $pinned_query->have_posts() ) {
+                if ( $enforce_limit && $displayed_posts_count >= $limit ) {
+                    break;
+                }
+
                 $pinned_query->the_post();
-                if ($display_mode === 'slideshow') echo '<div class="swiper-slide">';
-                $shortcode_instance->render_article_item($options, true);
-                if ($display_mode === 'slideshow') echo '</div>';
+
+                if ( $display_mode === 'slideshow' ) {
+                    echo '<div class="swiper-slide">';
+                }
+
+                $shortcode_instance->render_article_item( $options, true );
+
+                if ( $display_mode === 'slideshow' ) {
+                    echo '</div>';
+                }
+
+                $displayed_posts_count++;
             }
         }
 
         if ( $articles_query && $articles_query->have_posts() ) {
             while ( $articles_query->have_posts() ) {
+                if ( $enforce_limit && $displayed_posts_count >= $limit ) {
+                    break;
+                }
+
                 $articles_query->the_post();
-                if ($display_mode === 'slideshow') echo '<div class="swiper-slide">';
-                $shortcode_instance->render_article_item($options, false);
-                if ($display_mode === 'slideshow') echo '</div>';
+
+                if ( $display_mode === 'slideshow' ) {
+                    echo '<div class="swiper-slide">';
+                }
+
+                $shortcode_instance->render_article_item( $options, false );
+
+                if ( $display_mode === 'slideshow' ) {
+                    echo '</div>';
+                }
+
+                $displayed_posts_count++;
             }
-            $displayed_posts_count += (int) $articles_query->post_count;
-        } elseif ( $articles_query instanceof WP_Query ) {
-            $displayed_posts_count += (int) $articles_query->post_count;
         }
 
         if ( 0 === $displayed_posts_count ) {


### PR DESCRIPTION
## Summary
- enforce the posts_per_page limit when rendering filtered articles on the frontend, while leaving slideshow mode unchanged
- pass the computed posts_per_page value into the grid and list renderers and cap their output after pinned and regular posts

## Testing
- php -l mon-affichage-article/mon-affichage-articles.php
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68ce9042e7dc832e899e7ec75940c508