### PR TITLE
Aligner la gestion des articles épinglés entre filtrage et chargement

### DIFF
--- a/mon-affichage-article/assets/js/load-more.js
+++ b/mon-affichage-article/assets/js/load-more.js
@@ -44,6 +44,12 @@
                     // Ajoute les nouveaux articles à la suite des anciens
                     contentArea.append(response.data.html);
 
+                    if (response.data && typeof response.data.pinned_ids !== 'undefined') {
+                        var updatedPinnedIds = response.data.pinned_ids;
+                        button.data('pinned-ids', updatedPinnedIds);
+                        button.attr('data-pinned-ids', updatedPinnedIds);
+                    }
+
                     var newPage = paged + 1;
                     button.data('paged', newPage);
                     button.attr('data-paged', newPage);


### PR DESCRIPTION
## Summary
- relever les identifiants des articles épinglés réellement rendus lors du filtrage et s'en servir pour la pagination
- faire remonter la même liste d'identifiants dans les rendus grille et liste du shortcode afin de configurer correctement le bouton "Charger plus"
- adapter le callback AJAX de chargement complémentaire pour ne renvoyer que les épinglés restants avant les articles réguliers et retourner la nouvelle liste au front

## Testing
- php -l mon-affichage-article/mon-affichage-articles.php
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68ce94e866b8832e9c438f8c4a131d0f