### PR TITLE
Respect pinned ignore filter on load more pinned lookup

### DIFF
--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -331,7 +331,7 @@ final class Mon_Affichage_Articles {
                 'post__not_in'   => $exclude_ids,
             ];
 
-            if ( '' !== $category && 'all' !== $category ) {
+            if ( empty( $options['pinned_posts_ignore_filter'] ) && '' !== $category && 'all' !== $category ) {
                 if ( ! empty( $taxonomy ) ) {
                     $pinned_lookup_args['tax_query'] = [
                         [


### PR DESCRIPTION
## Summary
- ensure the load-more pinned lookup bypasses taxonomy filters when the option to always show pinned posts is enabled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf1853cae8832ebc2df184590b964b