### PR TITLE
Fix pagination totals to include all pinned posts

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -138,7 +138,8 @@ class My_Articles_Shortcode {
         $pinned_query = null;
         $pinned_posts_found = 0;
         $first_page_projected_pinned = 0;
-        $displayed_pinned_ids = array();
+        $total_matching_pinned      = 0;
+        $displayed_pinned_ids       = array();
         if ( ! empty( $pinned_ids ) ) {
             $pinned_query_args = [
                 'post_type'    => 'any',
@@ -168,8 +169,8 @@ class My_Articles_Shortcode {
             if ( $paged === 1 ) {
                 $pinned_query_args['posts_per_page'] = count( $pinned_ids );
                 $pinned_query                        = new WP_Query( $pinned_query_args );
-                $pinned_posts_found                  = (int) ( $pinned_query->found_posts ?? $pinned_query->post_count );
-                $first_page_projected_pinned         = $pinned_posts_found;
+                $total_matching_pinned               = (int) ( $pinned_query->found_posts ?? $pinned_query->post_count );
+                $first_page_projected_pinned         = $total_matching_pinned;
 
                 if ( $should_limit_display ) {
                     $first_page_projected_pinned = min( $first_page_projected_pinned, $render_limit );
@@ -180,8 +181,8 @@ class My_Articles_Shortcode {
                 $count_query_args['fields']         = 'ids';
 
                 $count_query        = new WP_Query( $count_query_args );
-                $pinned_posts_found = (int) $count_query->found_posts;
-                $first_page_projected_pinned = $pinned_posts_found;
+                $total_matching_pinned = (int) $count_query->found_posts;
+                $first_page_projected_pinned = $total_matching_pinned;
 
                 if ( $should_limit_display ) {
                     $first_page_projected_pinned = min( $first_page_projected_pinned, $render_limit );
@@ -269,8 +270,10 @@ class My_Articles_Shortcode {
         }
 
         if ( $paged === 1 ) {
-            $pinned_posts_found = count( $displayed_pinned_ids );
-            $first_page_projected_pinned = $pinned_posts_found;
+            $first_page_projected_pinned = count( $displayed_pinned_ids );
+            if ( 0 === $total_matching_pinned && ! empty( $displayed_pinned_ids ) ) {
+                $total_matching_pinned = count( $displayed_pinned_ids );
+            }
         }
 
         if ($options['display_mode'] === 'grid' || $options['display_mode'] === 'list') {
@@ -301,7 +304,7 @@ class My_Articles_Shortcode {
             }
 
             $pagination_totals = my_articles_calculate_total_pages(
-                $first_page_projected_pinned,
+                $total_matching_pinned,
                 $total_regular_posts,
                 $posts_per_page
             );

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -113,8 +113,8 @@ final class Mon_Affichage_Articles {
 
         $all_excluded_ids = array_unique( array_merge( $pinned_ids, $exclude_ids ) );
 
-        $pinned_query = null;
-        $pinned_posts_found = 0;
+        $pinned_query         = null;
+        $total_pinned_posts   = 0;
         $displayed_pinned_ids = array();
 
         if ( ! empty( $pinned_ids ) ) {
@@ -147,7 +147,9 @@ final class Mon_Affichage_Articles {
                 }
             }
             $pinned_query = new WP_Query( $pinned_query_args );
-            $pinned_posts_found = $pinned_query->post_count;
+            if ( $pinned_query instanceof WP_Query ) {
+                $total_pinned_posts = (int) ( $pinned_query->found_posts ?? $pinned_query->post_count );
+            }
         }
 
         $displayed_posts_count = 0;
@@ -220,7 +222,6 @@ final class Mon_Affichage_Articles {
         wp_reset_postdata();
         $html = ob_get_clean();
 
-        $pinned_posts_found = count( $displayed_pinned_ids );
         $total_regular_posts = 0;
 
         if ( $articles_query instanceof WP_Query ) {
@@ -254,8 +255,12 @@ final class Mon_Affichage_Articles {
             wp_reset_postdata();
         }
 
+        if ( 0 === $total_pinned_posts && ! empty( $displayed_pinned_ids ) ) {
+            $total_pinned_posts = count( $displayed_pinned_ids );
+        }
+
         $pagination_totals = my_articles_calculate_total_pages(
-            $pinned_posts_found,
+            $total_pinned_posts,
             $total_regular_posts,
             $posts_per_page
         );


### PR DESCRIPTION
## Summary
- update pagination helper to account for the full pinned catalogue when computing total pages
- retain pinned query totals in AJAX filtering and shortcode rendering so pagination buttons use the corrected totals
- ensure pagination text reflects remaining pinned items before regular posts

## Testing
- php -l mon-affichage-article/includes/helpers.php
- php -l mon-affichage-article/mon-affichage-articles.php
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68cf38dbf544832e947e96acedf810a7