### PR TITLE
Validate category slugs before loading more articles

### DIFF
--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -331,6 +331,35 @@ final class Mon_Affichage_Articles {
         $options['display_mode'] = $display_mode;
         $options['post_type']    = $post_type;
         $options['taxonomy']     = $taxonomy;
+
+        $default_term  = isset( $options['term'] ) ? sanitize_title( $options['term'] ) : '';
+        $allowed_slugs = array();
+
+        if ( ! empty( $taxonomy ) && ! empty( $options['filter_categories'] ) && is_array( $options['filter_categories'] ) ) {
+            $allowed_term_ids = array_values( array_filter( array_map( 'absint', $options['filter_categories'] ) ) );
+
+            if ( ! empty( $allowed_term_ids ) ) {
+                $allowed_terms = get_terms(
+                    array(
+                        'taxonomy'   => $taxonomy,
+                        'include'    => $allowed_term_ids,
+                        'hide_empty' => false,
+                    )
+                );
+
+                if ( ! is_wp_error( $allowed_terms ) && ! empty( $allowed_terms ) ) {
+                    $allowed_slugs = array_values( array_filter( wp_list_pluck( $allowed_terms, 'slug' ) ) );
+                }
+            }
+        }
+
+        if ( ! empty( $allowed_slugs ) ) {
+            $valid_slugs = array_unique( array_merge( array( '', 'all', $default_term ), $allowed_slugs ) );
+
+            if ( ! in_array( $category, $valid_slugs, true ) ) {
+                wp_send_json_error( __( 'Catégorie non autorisée.', 'mon-articles' ) );
+            }
+        }
         $configured_pinned_ids = array();
         if ( ! empty( $options['pinned_posts'] ) && is_array( $options['pinned_posts'] ) ) {
             $configured_pinned_ids = array_map( 'absint', $options['pinned_posts'] );


### PR DESCRIPTION
## Summary
- replicate the taxonomy and allowed category slug resolution from the filter callback inside the load more handler
- abort the AJAX request when the requested category slug is not part of the allowed list before running any queries

## Testing
- php -l mon-affichage-article/mon-affichage-articles.php

------
https://chatgpt.com/codex/tasks/task_e_68cfdf44dc44832ea6bec9e019146197