### PR TITLE
Ensure slug filtering keeps zero slug values

### DIFF
--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -97,7 +97,7 @@ final class Mon_Affichage_Articles {
                 );
 
                 if ( ! is_wp_error( $allowed_terms ) && ! empty( $allowed_terms ) ) {
-                    $allowed_slugs = array_values( array_filter( wp_list_pluck( $allowed_terms, 'slug' ) ) );
+                    $allowed_slugs = array_values( array_filter( wp_list_pluck( $allowed_terms, 'slug' ), 'strlen' ) );
                 }
             }
         }
@@ -348,7 +348,7 @@ final class Mon_Affichage_Articles {
                 );
 
                 if ( ! is_wp_error( $allowed_terms ) && ! empty( $allowed_terms ) ) {
-                    $allowed_slugs = array_values( array_filter( wp_list_pluck( $allowed_terms, 'slug' ) ) );
+                    $allowed_slugs = array_values( array_filter( wp_list_pluck( $allowed_terms, 'slug' ), 'strlen' ) );
                 }
             }
         }


### PR DESCRIPTION
## Summary
- ensure `filter_articles_callback` keeps taxonomy slug values of "0" when filtering
- apply the same explicit callback to `load_more_articles_callback`

## Testing
- not run (environment does not include WordPress front-end)


------
https://chatgpt.com/codex/tasks/task_e_68cfea45d81c832e98deeff9c71f31ee