### PR TITLE
Handle AJAX pagination updates when filtering articles

### DIFF
--- a/mon-affichage-article/assets/js/filter.js
+++ b/mon-affichage-article/assets/js/filter.js
@@ -70,6 +70,21 @@
                         }
                     }
 
+                    if (response.data && typeof response.data.pagination_html !== 'undefined') {
+                        var paginationHtml = response.data.pagination_html;
+                        var paginationElement = wrapper.find('.my-articles-pagination').first();
+
+                        if (typeof paginationHtml === 'string' && paginationHtml.trim().length > 0) {
+                            if (paginationElement.length) {
+                                paginationElement.replaceWith(paginationHtml);
+                            } else if (contentArea.length) {
+                                contentArea.after(paginationHtml);
+                            }
+                        } else if (paginationElement.length) {
+                            paginationElement.remove();
+                        }
+                    }
+
                     if (wrapper.hasClass('my-articles-slideshow')) {
                         if (typeof window.mySwiperInstances !== 'undefined' && window.mySwiperInstances[instanceId]) {
                             window.mySwiperInstances[instanceId].destroy(true, true);

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -297,12 +297,44 @@ final class Mon_Affichage_Articles {
         $next_page   = $pagination_totals['next_page'];
         $pinned_ids_string = ! empty( $displayed_pinned_ids ) ? implode( ',', array_map( 'absint', $displayed_pinned_ids ) ) : '';
 
+        $pagination_html = '';
+        if ( 'numbered' === ( $options['pagination_mode'] ?? '' ) ) {
+            $pagination_query_args = array();
+            $category_query_var    = 'my_articles_cat_' . $instance_id;
+            $current_filter_slug   = $category_slug;
+
+            if ( '' === $current_filter_slug ) {
+                $current_filter_slug = $default_term;
+            }
+
+            if ( '' !== $current_filter_slug ) {
+                $pagination_query_args[ $category_query_var ] = $current_filter_slug;
+            }
+
+            $referer_url = wp_get_referer();
+            if ( $referer_url ) {
+                $referer_url = esc_url_raw( $referer_url );
+                $referer_url = strtok( $referer_url, '#' );
+            } else {
+                $referer_url = '';
+            }
+
+            $pagination_html = $shortcode_instance->get_numbered_pagination_html(
+                $total_pages,
+                1,
+                'paged_' . $instance_id,
+                $pagination_query_args,
+                $referer_url
+            );
+        }
+
         wp_send_json_success(
             [
-                'html'         => $html,
-                'total_pages'  => $total_pages,
-                'next_page'    => $next_page,
-                'pinned_ids'   => $pinned_ids_string,
+                'html'             => $html,
+                'total_pages'      => $total_pages,
+                'next_page'        => $next_page,
+                'pinned_ids'       => $pinned_ids_string,
+                'pagination_html'  => $pagination_html,
             ]
         );
     }


### PR DESCRIPTION
## Summary
- expose a new helper on the shortcode class to build numbered pagination markup with optional category query args
- include the generated pagination HTML in the filter AJAX response so the front end can refresh the navigation when filters change
- update the filter script to swap the pagination fragment returned by AJAX, ensuring links track the active category

## Testing
- php -l mon-affichage-article/mon-affichage-articles.php
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68cfef15e81c832e97f5bd299e7ab03c