### PR TITLE
Validate AJAX instance post type before processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Pour vérifier la prise en charge d'un slug de taxonomie égal à `"0"` :
 2. Configurez un module **Tuiles – LCV** afin qu'il utilise ce terme comme valeur par défaut et activez, si besoin, le filtre de catégories en frontal.
 3. Affichez le module côté public et vérifiez que les articles associés au terme `0` apparaissent bien, que le filtre est sélectionné et que la pagination/chargement additionnel respecte ce terme.
 
+Pour valider la gestion d'un identifiant d'instance invalide lors des appels AJAX :
+
+1. Déclenchez les actions `filter_articles` et `load_more_articles` avec un identifiant qui ne correspond pas à un contenu de type `mon_affichage`.
+2. Vérifiez que la réponse est une erreur JSON comportant un code HTTP `400` et le message « Type de contenu invalide pour cette instance. ».
+
 ## Crédits
 
 Développé par LCV.

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -41,7 +41,7 @@ final class Mon_Affichage_Articles {
     private function add_hooks() {
         add_action( 'init', array( $this, 'register_post_type' ) );
         add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
-        
+
         add_action( 'wp_ajax_filter_articles', array( $this, 'filter_articles_callback' ) );
         add_action( 'wp_ajax_nopriv_filter_articles', array( $this, 'filter_articles_callback' ) );
 
@@ -58,16 +58,28 @@ final class Mon_Affichage_Articles {
         My_Articles_Shortcode::get_instance();
         My_Articles_Enqueue::get_instance();
     }
-    
+
+    private function assert_valid_instance_post_type( $instance_id ) {
+        $post_type = get_post_type( $instance_id );
+
+        if ( 'mon_affichage' !== $post_type ) {
+            wp_send_json_error( __( 'Type de contenu invalide pour cette instance.', 'mon-articles' ), 400 );
+        }
+
+        return $post_type;
+    }
+
     public function filter_articles_callback() {
         check_ajax_referer( 'my_articles_filter_nonce', 'security' );
 
         $instance_id = isset( $_POST['instance_id'] ) ? absint( wp_unslash( $_POST['instance_id'] ) ) : 0;
         $category_slug = isset( $_POST['category'] ) ? sanitize_text_field( wp_unslash( $_POST['category'] ) ) : '';
 
-        if ( !$instance_id ) {
+        if ( ! $instance_id ) {
             wp_send_json_error( __( 'ID d\'instance manquant.', 'mon-articles' ) );
         }
+
+        $this->assert_valid_instance_post_type( $instance_id );
 
         $shortcode_instance = My_Articles_Shortcode::get_instance();
         $options_meta       = (array) get_post_meta( $instance_id, '_my_articles_settings', true );
@@ -347,7 +359,11 @@ final class Mon_Affichage_Articles {
         $pinned_ids_str = isset( $_POST['pinned_ids'] ) ? sanitize_text_field( wp_unslash( $_POST['pinned_ids'] ) ) : '';
         $category = isset( $_POST['category'] ) ? sanitize_text_field( wp_unslash( $_POST['category'] ) ) : '';
 
-        if (!$instance_id) { wp_send_json_error(); }
+        if ( ! $instance_id ) {
+            wp_send_json_error( __( 'ID d\'instance manquant.', 'mon-articles' ) );
+        }
+
+        $this->assert_valid_instance_post_type( $instance_id );
 
         $shortcode_instance = My_Articles_Shortcode::get_instance();
         $options_meta       = (array) get_post_meta( $instance_id, '_my_articles_settings', true );


### PR DESCRIPTION
## Summary
- add a shared helper that ensures the requested instance belongs to the mon_affichage post type before processing AJAX handlers
- return a 400 JSON error when the instance does not reference the correct post type in both filter and load-more callbacks
- document manual testing steps to cover invalid instance identifiers during AJAX calls

## Testing
- php -l mon-affichage-article/mon-affichage-articles.php

------
https://chatgpt.com/codex/tasks/task_e_68d045dc9ee0832eaf710ca6f165a3d4