### PR TITLE
Handle unlimited posts per page values

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -269,7 +269,7 @@ class My_Articles_Metaboxes {
         $sanitized['taxonomy'] = isset($input['taxonomy']) ? sanitize_key($input['taxonomy']) : '';
         $sanitized['term'] = isset($input['term']) ? sanitize_text_field( wp_unslash( $input['term'] ) ) : '';
         $sanitized['counting_behavior'] = isset($input['counting_behavior']) && in_array($input['counting_behavior'], ['exact', 'auto_fill']) ? $input['counting_behavior'] : 'exact';
-        $sanitized['posts_per_page'] = isset( $input['posts_per_page'] ) ? absint( $input['posts_per_page'] ) : 10;
+        $sanitized['posts_per_page'] = isset( $input['posts_per_page'] ) ? max( 1, absint( $input['posts_per_page'] ) ) : 10;
         $sanitized['pagination_mode'] = isset($input['pagination_mode']) && in_array($input['pagination_mode'], ['none', 'load_more', 'numbered']) ? $input['pagination_mode'] : 'none';
         $sanitized['show_category_filter'] = isset( $input['show_category_filter'] ) ? 1 : 0;
         $sanitized['filter_alignment'] = isset($input['filter_alignment']) && in_array($input['filter_alignment'], ['left', 'center', 'right']) ? $input['filter_alignment'] : 'right';

--- a/mon-affichage-article/includes/class-my-articles-settings.php
+++ b/mon-affichage-article/includes/class-my-articles-settings.php
@@ -93,7 +93,7 @@ class My_Articles_Settings {
         $sanitized_input = [];
         $sanitized_input['display_mode'] = isset( $input['display_mode'] ) && in_array($input['display_mode'], ['grid', 'slideshow']) ? $input['display_mode'] : 'grid';
         $sanitized_input['default_category'] = isset( $input['default_category'] ) ? sanitize_text_field( $input['default_category'] ) : '';
-        $sanitized_input['posts_per_page'] = isset( $input['posts_per_page'] ) ? absint( $input['posts_per_page'] ) : 10;
+        $sanitized_input['posts_per_page'] = isset( $input['posts_per_page'] ) ? max( 1, absint( $input['posts_per_page'] ) ) : 10;
         $sanitized_input['desktop_columns'] = isset( $input['desktop_columns'] ) ? absint( $input['desktop_columns'] ) : 3;
         $sanitized_input['mobile_columns'] = isset( $input['mobile_columns'] ) ? absint( $input['mobile_columns'] ) : 1;
         $sanitized_input['gap_size'] = isset( $input['gap_size'] ) ? absint( $input['gap_size'] ) : 25;

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -160,9 +160,12 @@ class My_Articles_Shortcode {
 
         $paged_var = 'paged_' . $id;
         $paged = isset($_GET[$paged_var]) ? absint( wp_unslash( $_GET[$paged_var] ) ) : 1;
-        $posts_per_page = (int)($options['posts_per_page'] ?? 10);
 
-        if ($options['counting_behavior'] === 'auto_fill' && ($options['display_mode'] === 'grid' || $options['display_mode'] === 'slideshow')) {
+        $raw_posts_per_page = (int) ( $options['posts_per_page'] ?? 10 );
+        $is_unlimited       = $raw_posts_per_page <= 0;
+        $posts_per_page     = $is_unlimited ? -1 : $raw_posts_per_page;
+
+        if ( ! $is_unlimited && $options['counting_behavior'] === 'auto_fill' && ($options['display_mode'] === 'grid' || $options['display_mode'] === 'slideshow')) {
             $master_columns = (int)($options['columns_ultrawide'] ?? 4);
             if ($master_columns > 0) {
                 $rows_needed = ceil($posts_per_page / $master_columns);
@@ -228,7 +231,7 @@ class My_Articles_Shortcode {
             $total_matching_pinned = (int) ( $pinned_lookup_query->found_posts ?? count( $matching_pinned_ids ) );
             wp_reset_postdata();
 
-            if ( $posts_per_page > 0 ) {
+            if ( ! $is_unlimited ) {
                 $pinned_offset = min( $total_matching_pinned, max( 0, ( $paged - 1 ) * $posts_per_page ) );
                 $slice_length  = $posts_per_page;
             } else {
@@ -237,7 +240,7 @@ class My_Articles_Shortcode {
             }
 
             if ( ! empty( $matching_pinned_ids ) ) {
-                $pinned_ids_for_page = array_slice( $matching_pinned_ids, $pinned_offset, $slice_length );
+                $pinned_ids_for_page = $is_unlimited ? $matching_pinned_ids : array_slice( $matching_pinned_ids, $pinned_offset, $slice_length );
             }
 
             if ( ! empty( $pinned_ids_for_page ) ) {
@@ -249,31 +252,23 @@ class My_Articles_Shortcode {
                 $pinned_posts_found = $pinned_query->post_count;
             }
 
-            if ( $posts_per_page > 0 ) {
-                $first_page_projected_pinned = min( $total_matching_pinned, $posts_per_page );
-            } else {
-                $first_page_projected_pinned = $total_matching_pinned;
-            }
+            $first_page_projected_pinned = $is_unlimited ? $total_matching_pinned : min( $total_matching_pinned, $posts_per_page );
         }
 
         $pinned_render_count = count( $pinned_ids_for_page );
-        $max_items_before_current_page = ( $posts_per_page > 0 ) ? max( 0, ( $paged - 1 ) * $posts_per_page ) : 0;
+        $max_items_before_current_page = $is_unlimited ? 0 : max( 0, ( $paged - 1 ) * $posts_per_page );
         $regular_posts_already_displayed = max( 0, $max_items_before_current_page - $pinned_offset );
 
         $offset = $regular_posts_already_displayed;
-        if ( $posts_per_page > 0 ) {
-            $posts_to_fetch = max( 0, $posts_per_page - $pinned_render_count );
-        } else {
-            $posts_to_fetch = $posts_per_page;
-        }
-        
+        $posts_to_fetch = $is_unlimited ? -1 : max( 0, $posts_per_page - $pinned_render_count );
+
         $articles_query = null;
-        if ($posts_to_fetch > 0) {
+        if ( $is_unlimited || $posts_to_fetch > 0 ) {
             $regular_query_args = [
                 'post_type' => $options['post_type'],
                 'post_status' => 'publish',
-                'posts_per_page' => $posts_to_fetch,
-                'offset' => $offset,
+                'posts_per_page' => $is_unlimited ? -1 : $posts_to_fetch,
+                'offset' => $is_unlimited ? 0 : $offset,
                 'post__not_in' => $all_excluded_ids,
                 'ignore_sticky_posts' => (int)$options['ignore_native_sticky'],
             ];
@@ -476,7 +471,8 @@ class My_Articles_Shortcode {
     }
 
     private function render_slideshow($pinned_query, $regular_query, $options, $posts_per_page) {
-        $total_posts_needed = $posts_per_page;
+        $is_unlimited = (int) $posts_per_page <= 0;
+        $total_posts_needed = $is_unlimited ? PHP_INT_MAX : (int) $posts_per_page;
         echo '<div class="swiper-container"><div class="swiper-wrapper">';
         $post_count = 0;
         if ( $pinned_query && $pinned_query->have_posts() ) { while ( $pinned_query->have_posts() && $post_count < $total_posts_needed ) { $pinned_query->the_post(); echo '<div class="swiper-slide">'; $this->render_article_item($options, true); echo '</div>'; $post_count++; } }


### PR DESCRIPTION
## Summary
- enforce a minimum of one article per page when sanitizing settings and metabox inputs
- treat non-positive posts-per-page values as unlimited across shortcode rendering and AJAX callbacks
- adjust pagination, offsets, and slideshow handling so unlimited mode loads all posts without empty states

## Testing
- php -l includes/class-my-articles-settings.php
- php -l includes/class-my-articles-metaboxes.php
- php -l includes/class-my-articles-shortcode.php
- php -l mon-affichage-articles.php

------
https://chatgpt.com/codex/tasks/task_e_68d0534532a8832eb28f062f6c46cf03