### PR TITLE
Fix lazysizes attribute for lazy-loaded thumbnails

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -519,7 +519,7 @@ class My_Articles_Shortcode {
                     $image_srcset = wp_get_attachment_image_srcset($image_id, 'large');
                     $placeholder_src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
                     if ($enable_lazy_load) {
-                        echo '<img src="' . $placeholder_src . '" data-src="' . esc_url($image_src) . '" data-srcset="' . esc_attr($image_srcset) . '" class="attachment-large size-large wp-post-image lazyload" alt="' . esc_attr(get_the_title()) . '" sizes="auto" />';
+                        echo '<img src="' . $placeholder_src . '" data-src="' . esc_url($image_src) . '" data-srcset="' . esc_attr($image_srcset) . '" class="attachment-large size-large wp-post-image lazyload" alt="' . esc_attr(get_the_title()) . '" data-sizes="auto" />';
                     } else {
                         the_post_thumbnail('large');
                     }


### PR DESCRIPTION
## Summary
- switch the lazysizes thumbnail markup to use data-sizes instead of sizes="auto"
- keep existing lazyload data attributes so responsive image sizing is handled by lazysizes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d07ea7d9d4832e87de205bb362e5fc