### PR TITLE
Align AJAX taxonomy resolution with shortcode

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -73,7 +73,7 @@ class My_Articles_Shortcode {
         $defaults = self::get_default_options();
         $options = wp_parse_args($options, $defaults);
 
-        $resolved_taxonomy = $this->resolve_taxonomy( $options );
+        $resolved_taxonomy = self::resolve_taxonomy( $options );
         $options['resolved_taxonomy'] = $resolved_taxonomy;
 
         $options['term'] = sanitize_title( $options['term'] ?? '' );
@@ -504,7 +504,7 @@ class My_Articles_Shortcode {
         $item_classes = 'my-article-item';
         if ($is_pinned) { $item_classes .= ' is-pinned'; }
         $display_mode = $options['display_mode'] ?? 'grid';
-        $taxonomy = $options['resolved_taxonomy'] ?? $this->resolve_taxonomy( $options );
+        $taxonomy = $options['resolved_taxonomy'] ?? self::resolve_taxonomy( $options );
         $enable_lazy_load = !empty($options['enable_lazy_load']);
         ?>
         <div class="<?php echo esc_attr($item_classes); ?>">
@@ -713,7 +713,7 @@ class My_Articles_Shortcode {
         wp_add_inline_style( 'my-articles-styles', $dynamic_css );
     }
 
-    private function resolve_taxonomy( $options ) {
+    public static function resolve_taxonomy( $options ) {
         $post_type = ! empty( $options['post_type'] ) ? $options['post_type'] : 'post';
 
         if ( ! empty( $options['taxonomy'] ) && taxonomy_exists( $options['taxonomy'] ) && is_object_in_taxonomy( $post_type, $options['taxonomy'] ) ) {


### PR DESCRIPTION
## Summary
- expose `My_Articles_Shortcode::resolve_taxonomy()` so it can be reused outside the shortcode renderer
- ensure the filter and load-more AJAX handlers reuse the resolved taxonomy for filter terms and all content queries
- prevent taxonomy filters from being applied when the resolved taxonomy is empty, keeping incompatible setups functional

## Testing
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php
- php -l mon-affichage-article/mon-affichage-articles.php

------
https://chatgpt.com/codex/tasks/task_e_68d14ca7d820832eb667c986abf8ccbb