### PR TITLE
Exclude attachments from selectable post types

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -240,10 +240,20 @@ class My_Articles_Metaboxes {
                 echo '<p class="description">' . __('Si aucune catégorie n\'est cochée, toutes seront affichées.', 'mon-articles') . '</p>';
                 break;
             case 'post_type_select':
-                $post_types = get_post_types(['public' => true], 'objects');
+                $post_types = my_articles_get_selectable_post_types();
+
+                if ( empty( $post_types ) ) {
+                    $fallback_post_type = get_post_type_object( 'post' );
+                    if ( $fallback_post_type ) {
+                        $post_types = array( 'post' => $fallback_post_type );
+                    }
+                }
+
+                $value = my_articles_normalize_post_type( $value );
+
                 echo '<select id="post_type_selector" name="' . $name . '">';
-                foreach ($post_types as $post_type) {
-                    echo '<option value="' . esc_attr($post_type->name) . '" ' . selected($value, $post_type->name, false) . '>' . esc_html($post_type->labels->singular_name) . '</option>';
+                foreach ( $post_types as $post_type ) {
+                    echo '<option value="' . esc_attr( $post_type->name ) . '" ' . selected( $value, $post_type->name, false ) . '>' . esc_html( $post_type->labels->singular_name ) . '</option>';
                 }
                 echo '</select>';
                 break;
@@ -265,7 +275,7 @@ class My_Articles_Metaboxes {
         $input = isset( $_POST[$this->option_key] ) ? wp_unslash( $_POST[$this->option_key] ) : [];
         $sanitized = [];
         
-        $sanitized['post_type'] = isset($input['post_type']) ? sanitize_key($input['post_type']) : 'post';
+        $sanitized['post_type'] = my_articles_normalize_post_type( $input['post_type'] ?? '' );
         $sanitized['taxonomy'] = isset($input['taxonomy']) ? sanitize_key($input['taxonomy']) : '';
         $sanitized['term'] = isset($input['term']) ? sanitize_text_field( wp_unslash( $input['term'] ) ) : '';
         $sanitized['counting_behavior'] = isset($input['counting_behavior']) && in_array($input['counting_behavior'], ['exact', 'auto_fill']) ? $input['counting_behavior'] : 'exact';

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -73,6 +73,8 @@ class My_Articles_Shortcode {
         $defaults = self::get_default_options();
         $options = wp_parse_args($options, $defaults);
 
+        $options['post_type'] = my_articles_normalize_post_type( $options['post_type'] ?? '' );
+
         $resolved_taxonomy = self::resolve_taxonomy( $options );
         $options['resolved_taxonomy'] = $resolved_taxonomy;
 
@@ -714,7 +716,7 @@ class My_Articles_Shortcode {
     }
 
     public static function resolve_taxonomy( $options ) {
-        $post_type = ! empty( $options['post_type'] ) ? $options['post_type'] : 'post';
+        $post_type = my_articles_normalize_post_type( $options['post_type'] ?? 'post' );
 
         if ( ! empty( $options['taxonomy'] ) && taxonomy_exists( $options['taxonomy'] ) && is_object_in_taxonomy( $post_type, $options['taxonomy'] ) ) {
             return $options['taxonomy'];

--- a/mon-affichage-article/includes/helpers.php
+++ b/mon-affichage-article/includes/helpers.php
@@ -49,6 +49,59 @@ if ( ! function_exists( 'my_articles_sanitize_color' ) ) {
     }
 }
 
+if ( ! function_exists( 'my_articles_get_selectable_post_types' ) ) {
+    /**
+     * Retrieve the list of selectable post types for the plugin.
+     *
+     * Attachments are intentionally excluded because they do not represent
+     * regular content entries and would lead to unexpected behaviour in the
+     * module rendering.
+     *
+     * @return array<string, WP_Post_Type> Associative array of post type objects keyed by their name.
+     */
+    function my_articles_get_selectable_post_types() {
+        $post_types = get_post_types( [ 'public' => true ], 'objects' );
+
+        if ( ! is_array( $post_types ) ) {
+            $post_types = array();
+        }
+
+        unset( $post_types['attachment'] );
+
+        return $post_types;
+    }
+}
+
+if ( ! function_exists( 'my_articles_normalize_post_type' ) ) {
+    /**
+     * Ensure a post type is valid for the plugin and provide a safe fallback.
+     *
+     * @param string $post_type Raw post type value.
+     *
+     * @return string A valid post type value supported by the plugin.
+     */
+    function my_articles_normalize_post_type( $post_type ) {
+        $post_type = sanitize_key( (string) $post_type );
+
+        $available_post_types = my_articles_get_selectable_post_types();
+
+        if ( isset( $available_post_types[ $post_type ] ) ) {
+            return $post_type;
+        }
+
+        if ( isset( $available_post_types['post'] ) ) {
+            return 'post';
+        }
+
+        $available_post_type_keys = array_keys( $available_post_types );
+        if ( ! empty( $available_post_type_keys ) ) {
+            return (string) reset( $available_post_type_keys );
+        }
+
+        return post_type_exists( 'post' ) ? 'post' : $post_type;
+    }
+}
+
 if ( ! function_exists( 'my_articles_calculate_total_pages' ) ) {
     /**
      * Calculate the total number of pages required when pinned posts appear on the first page.

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -111,7 +111,7 @@ final class Mon_Affichage_Articles {
         $options            = wp_parse_args( $options_meta, $defaults );
 
         $display_mode = $options['display_mode'] ?? 'grid';
-        $post_type    = ( ! empty( $options['post_type'] ) && post_type_exists( $options['post_type'] ) ) ? $options['post_type'] : 'post';
+        $post_type    = my_articles_normalize_post_type( $options['post_type'] ?? '' );
         $taxonomy     = ( ! empty( $options['taxonomy'] ) && taxonomy_exists( $options['taxonomy'] ) ) ? $options['taxonomy'] : '';
 
         $default_term = isset( $options['term'] ) ? sanitize_title( $options['term'] ) : '';
@@ -377,7 +377,7 @@ final class Mon_Affichage_Articles {
         $options            = wp_parse_args( $options_meta, $defaults );
 
         $display_mode = $options['display_mode'] ?? 'grid';
-        $post_type    = ( ! empty( $options['post_type'] ) && post_type_exists( $options['post_type'] ) ) ? $options['post_type'] : 'post';
+        $post_type    = my_articles_normalize_post_type( $options['post_type'] ?? '' );
         $taxonomy     = ( ! empty( $options['taxonomy'] ) && taxonomy_exists( $options['taxonomy'] ) ) ? $options['taxonomy'] : '';
         $options['display_mode'] = $display_mode;
         $options['post_type']    = $post_type;
@@ -584,7 +584,7 @@ final class Mon_Affichage_Articles {
             wp_send_json_error( array( 'message' => __( 'Action non autorisée.', 'mon-articles' ) ) );
         }
 
-        $post_type = isset( $_POST['post_type'] ) ? sanitize_text_field( wp_unslash( $_POST['post_type'] ) ) : '';
+        $post_type = my_articles_normalize_post_type( $_POST['post_type'] ?? '' );
 
         if ( empty( $post_type ) || ! post_type_exists( $post_type ) ) {
             wp_send_json_error( array( 'message' => __( 'Type de contenu invalide.', 'mon-articles' ) ) );
@@ -654,15 +654,7 @@ final class Mon_Affichage_Articles {
         }
 
         $search_term = isset( $_GET['search'] ) ? sanitize_text_field( wp_unslash( $_GET['search'] ) ) : '';
-        $post_type   = 'post';
-
-        if ( isset( $_GET['post_type'] ) ) {
-            $post_type = sanitize_key( wp_unslash( $_GET['post_type'] ) );
-        }
-
-        if ( empty( $post_type ) ) {
-            $post_type = 'post';
-        }
+        $post_type   = my_articles_normalize_post_type( $_GET['post_type'] ?? 'post' );
 
         if ( ! post_type_exists( $post_type ) ) {
             wp_send_json_error( __( 'Type de contenu invalide.', 'mon-articles' ), 400 );


### PR DESCRIPTION
## Summary
- add helper utilities to list selectable post types without attachments and normalize stored values
- update metabox, shortcode and AJAX handlers to rely on the normalized post type and fall back to valid types
- ensure saved settings and existing modules gracefully avoid the media post type

## Testing
- php -l mon-affichage-article/includes/helpers.php
- php -l mon-affichage-article/includes/class-my-articles-metaboxes.php
- php -l mon-affichage-article/mon-affichage-articles.php
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php


------
https://chatgpt.com/codex/tasks/task_e_68d1810deaf4832ea21f679b86cbcd04