### PR TITLE
Ensure pinned ids array defaults for slideshow

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -198,7 +198,6 @@ class My_Articles_Shortcode {
         $pinned_posts_found        = 0;
         $first_page_projected_pinned = 0;
         $total_matching_pinned     = 0;
-        $displayed_pinned_ids      = array();
         $matching_pinned_ids       = array();
         $pinned_offset             = 0;
         $pinned_ids_for_page       = array();
@@ -321,12 +320,20 @@ class My_Articles_Shortcode {
 
             echo '</ul></nav>';
         }
+        $displayed_pinned_ids = array();
+
         if ($options['display_mode'] === 'slideshow') {
             $this->render_slideshow($pinned_query, $articles_query, $options, $posts_per_page);
         } else if ($options['display_mode'] === 'list') {
             $displayed_pinned_ids = $this->render_list($pinned_query, $articles_query, $options, $posts_per_page);
+            if ( ! is_array( $displayed_pinned_ids ) ) {
+                $displayed_pinned_ids = array();
+            }
         } else {
             $displayed_pinned_ids = $this->render_grid($pinned_query, $articles_query, $options, $posts_per_page);
+            if ( ! is_array( $displayed_pinned_ids ) ) {
+                $displayed_pinned_ids = array();
+            }
         }
 
         if ( $paged === 1 ) {


### PR DESCRIPTION
## Summary
- move the `$displayed_pinned_ids` initialization to the display-mode branch so it is set before slideshow rendering
- guard the list and grid rendering branches to keep `$displayed_pinned_ids` as an array and avoid warnings when counting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1811c6480832e83bfd4fcdb233b88