### PR TITLE
Enforce minimum column counts in admin settings

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -312,10 +312,10 @@ class My_Articles_Metaboxes {
         $sanitized['enable_debug_mode'] = isset( $input['enable_debug_mode'] ) ? 1 : 0;
 
         $sanitized['display_mode'] = in_array($input['display_mode'] ?? 'grid', ['grid', 'slideshow', 'list']) ? $input['display_mode'] : 'grid';
-        $sanitized['columns_mobile'] = isset( $input['columns_mobile'] ) ? absint( $input['columns_mobile'] ) : 1;
-        $sanitized['columns_tablet'] = isset( $input['columns_tablet'] ) ? absint( $input['columns_tablet'] ) : 2;
-        $sanitized['columns_desktop'] = isset( $input['columns_desktop'] ) ? absint( $input['columns_desktop'] ) : 3;
-        $sanitized['columns_ultrawide'] = isset( $input['columns_ultrawide'] ) ? absint( $input['columns_ultrawide'] ) : 4;
+        $sanitized['columns_mobile'] = isset( $input['columns_mobile'] ) ? max( 1, absint( $input['columns_mobile'] ) ) : 1;
+        $sanitized['columns_tablet'] = isset( $input['columns_tablet'] ) ? max( 1, absint( $input['columns_tablet'] ) ) : 2;
+        $sanitized['columns_desktop'] = isset( $input['columns_desktop'] ) ? max( 1, absint( $input['columns_desktop'] ) ) : 3;
+        $sanitized['columns_ultrawide'] = isset( $input['columns_ultrawide'] ) ? max( 1, absint( $input['columns_ultrawide'] ) ) : 4;
         $sanitized['module_padding_left'] = isset( $input['module_padding_left'] ) ? absint( $input['module_padding_left'] ) : 0;
         $sanitized['module_padding_right'] = isset( $input['module_padding_right'] ) ? absint( $input['module_padding_right'] ) : 0;
         $sanitized['gap_size'] = isset( $input['gap_size'] ) ? absint( $input['gap_size'] ) : 25;

--- a/mon-affichage-article/includes/class-my-articles-settings.php
+++ b/mon-affichage-article/includes/class-my-articles-settings.php
@@ -94,8 +94,8 @@ class My_Articles_Settings {
         $sanitized_input['display_mode'] = isset( $input['display_mode'] ) && in_array($input['display_mode'], ['grid', 'slideshow']) ? $input['display_mode'] : 'grid';
         $sanitized_input['default_category'] = isset( $input['default_category'] ) ? sanitize_text_field( $input['default_category'] ) : '';
         $sanitized_input['posts_per_page'] = isset( $input['posts_per_page'] ) ? max( 1, absint( $input['posts_per_page'] ) ) : 10;
-        $sanitized_input['desktop_columns'] = isset( $input['desktop_columns'] ) ? absint( $input['desktop_columns'] ) : 3;
-        $sanitized_input['mobile_columns'] = isset( $input['mobile_columns'] ) ? absint( $input['mobile_columns'] ) : 1;
+        $sanitized_input['desktop_columns'] = isset( $input['desktop_columns'] ) ? max( 1, absint( $input['desktop_columns'] ) ) : 3;
+        $sanitized_input['mobile_columns'] = isset( $input['mobile_columns'] ) ? max( 1, absint( $input['mobile_columns'] ) ) : 1;
         $sanitized_input['gap_size'] = isset( $input['gap_size'] ) ? absint( $input['gap_size'] ) : 25;
         $sanitized_input['border_radius'] = isset( $input['border_radius'] ) ? absint( $input['border_radius'] ) : 12;
         $sanitized_input['title_color'] = my_articles_sanitize_color($input['title_color'] ?? '', '#333333');


### PR DESCRIPTION
## Summary
- clamp all column count values saved from the metabox to at least one
- ensure global settings for desktop and mobile columns also enforce a minimum of one

## Testing
- php -l includes/class-my-articles-metaboxes.php
- php -l includes/class-my-articles-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68d1c97a0edc832eb69f59f2b0702adf