### PR TITLE
Internationalize author label

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -561,7 +561,16 @@ class My_Articles_Shortcode {
             <?php if ($options['show_category'] || $options['show_author'] || $options['show_date']) : ?>
                 <div class="article-meta">
                     <?php if ($options['show_category'] && !empty($taxonomy)) echo '<span class="article-category">' . wp_kses_post(get_the_term_list(get_the_ID(), $taxonomy, '', ', ')) . '</span>'; ?>
-                    <?php if ($options['show_author']) echo '<span class="article-author">par <a href="' . esc_url(get_author_posts_url(get_the_author_meta('ID'))) . '">' . esc_html(get_the_author()) . '</a></span>'; ?>
+                    <?php
+                    if ( $options['show_author'] ) {
+                        printf(
+                            '<span class="article-author">%s <a href="%s">%s</a></span>',
+                            esc_html__( 'par', 'mon-articles' ),
+                            esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
+                            esc_html( get_the_author() )
+                        );
+                    }
+                    ?>
                     <?php if ($options['show_date']) echo '<span class="article-date">' . esc_html(get_the_date()) . '</span>'; ?>
                 </div>
             <?php endif; ?>


### PR DESCRIPTION
## Summary
- replace the hard-coded author label with a translated string using `esc_html__`
- preserve escaping around the author link and name when printing the markup

## Testing
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68d27c8cb1c4832ea66dcf7ec853ee9a