### PR TITLE
Exclude all pinned posts from regular AJAX pagination

### DIFF
--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -451,7 +451,13 @@ final class Mon_Affichage_Articles {
 
         $offset = $regular_posts_already_displayed;
 
-        $regular_excluded_ids = array_unique( array_merge( $seen_pinned_ids, $exclude_ids ) );
+        $regular_excluded_ids = array_unique(
+            array_merge(
+                $seen_pinned_ids,
+                $exclude_ids,
+                $matching_pinned_ids
+            )
+        );
 
         $regular_posts_limit = $is_unlimited ? -1 : max( 0, $posts_per_page - $actual_pinned_rendered );
 


### PR DESCRIPTION
## Summary
- ensure the regular posts query excludes all pinned post IDs, not only the ones already rendered

## Testing
- php -l mon-affichage-article/mon-affichage-articles.php

------
https://chatgpt.com/codex/tasks/task_e_68d2bd099b5c832e89bf548fbed15f4e