### PR TITLE
Add admin column warnings for layout widths

### DIFF
--- a/mon-affichage-article/assets/js/admin-options.js
+++ b/mon-affichage-article/assets/js/admin-options.js
@@ -26,6 +26,97 @@
         }
     }
 
+    var columnSelectors = '#columns_mobile, #columns_tablet, #columns_desktop, #columns_ultrawide';
+    var columnsConfigDefaults = {
+        minColumnWidth: 240,
+        warningThreshold: 960,
+        warningClass: 'my-articles-columns-warning--active',
+        warningMessage: '',
+        infoMessage: ''
+    };
+    var columnsConfig = $.extend({}, columnsConfigDefaults, window.myArticlesAdminOptions || {});
+
+    columnsConfig.minColumnWidth = parseFloat(columnsConfig.minColumnWidth) || columnsConfigDefaults.minColumnWidth;
+    columnsConfig.warningThreshold = parseFloat(columnsConfig.warningThreshold) || (columnsConfig.minColumnWidth * 4);
+
+    function formatColumnsMessage(template, columns, estimatedWidth) {
+        if (typeof template !== 'string' || !template.length) {
+            return '';
+        }
+
+        return template
+            .replace(/%1\$[sd]/g, columns)
+            .replace(/%2\$[sd]/g, estimatedWidth);
+    }
+
+    function updateColumnWarning($input) {
+        if (!$input || !$input.length) {
+            return;
+        }
+
+        var columns = parseInt($input.val(), 10);
+
+        if (isNaN(columns) || columns < 0) {
+            columns = 0;
+        }
+
+        var estimatedWidth = Math.round(columns * columnsConfig.minColumnWidth);
+        var $container = $input.closest('.my-articles-columns-warning');
+
+        if (!$container.length) {
+            return;
+        }
+
+        var $message = $container.find('.my-articles-columns-warning__message');
+
+        if (!$message.length) {
+            $message = $('<p>', {
+                class: 'my-articles-columns-warning__message',
+                'aria-live': 'polite'
+            });
+
+            $container.append($message);
+        }
+
+        var shouldWarn = estimatedWidth > columnsConfig.warningThreshold && columns > 0;
+
+        if (shouldWarn) {
+            if (columnsConfig.warningClass) {
+                $container.addClass(columnsConfig.warningClass);
+            }
+
+            if (columnsConfig.warningMessage) {
+                $message.text(formatColumnsMessage(columnsConfig.warningMessage, columns, estimatedWidth));
+            } else {
+                $message.text('');
+            }
+        } else {
+            if (columnsConfig.warningClass) {
+                $container.removeClass(columnsConfig.warningClass);
+            }
+
+            if (columnsConfig.infoMessage && columns > 0) {
+                $message.text(formatColumnsMessage(columnsConfig.infoMessage, columns, estimatedWidth));
+            } else {
+                $message.text('');
+            }
+        }
+    }
+
+    function initColumnsWarnings() {
+        if (!$(columnSelectors).length) {
+            return;
+        }
+
+        $(document).on('input change', columnSelectors, function() {
+            updateColumnWarning($(this));
+        });
+
+        $(columnSelectors).each(function() {
+            updateColumnWarning($(this));
+        });
+    }
+
     // Écouteurs d'événements
     $(document).on('change', '#pinned_show_badge', toggleBadgeOptions);
     $(document).on('change', '#show_excerpt', toggleExcerptOptions);
@@ -34,6 +125,7 @@
     $(document).ready(function() {
         toggleBadgeOptions();
         toggleExcerptOptions();
+        initColumnsWarnings();
     });
 
 })(jQuery);

--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -49,6 +49,19 @@ class My_Articles_Metaboxes {
                     'allCategoriesText' => __( 'Toutes les catégories', 'mon-articles' ),
                 ]
             );
+            wp_localize_script(
+                'my-articles-admin-options',
+                'myArticlesAdminOptions',
+                [
+                    'minColumnWidth'  => 240,
+                    'warningThreshold' => 960,
+                    'warningClass'    => 'my-articles-columns-warning--active',
+                    /* translators: 1: number of columns, 2: estimated width in pixels. */
+                    'warningMessage'  => __( 'Attention : %1$d colonnes nécessitent environ %2$spx de largeur. Réduisez le nombre de colonnes ou agrandissez la zone de contenu.', 'mon-articles' ),
+                    /* translators: 1: number of columns, 2: estimated width in pixels. */
+                    'infoMessage'     => __( 'Largeur estimée : %2$spx pour %1$d colonnes.', 'mon-articles' ),
+                ]
+            );
         }
     }
 
@@ -113,10 +126,26 @@ class My_Articles_Metaboxes {
 
         echo '<hr><h3>' . __('Mise en Page', 'mon-articles') . '</h3>';
         $this->render_field('display_mode', __('Mode d\'affichage', 'mon-articles'), 'select', $opts, [ 'default' => 'grid', 'options' => [ 'grid' => 'Grille', 'slideshow' => 'Diaporama', 'list' => 'Liste' ] ]);
+
+        echo '<div class="my-articles-columns-warning" data-field="columns_mobile">';
         $this->render_field('columns_mobile', __('Colonnes (Mobile < 768px)', 'mon-articles'), 'number', $opts, ['default' => 1, 'min' => 1, 'max' => 3, 'description' => 'Pour Grille et Diaporama']);
+        echo '<p class="my-articles-columns-warning__message" aria-live="polite"></p>';
+        echo '</div>';
+
+        echo '<div class="my-articles-columns-warning" data-field="columns_tablet">';
         $this->render_field('columns_tablet', __('Colonnes (Tablette ≥ 768px)', 'mon-articles'), 'number', $opts, ['default' => 2, 'min' => 1, 'max' => 4, 'description' => 'Pour Grille et Diaporama']);
+        echo '<p class="my-articles-columns-warning__message" aria-live="polite"></p>';
+        echo '</div>';
+
+        echo '<div class="my-articles-columns-warning" data-field="columns_desktop">';
         $this->render_field('columns_desktop', __('Colonnes (Desktop ≥ 1024px)', 'mon-articles'), 'number', $opts, ['default' => 3, 'min' => 1, 'max' => 6, 'description' => 'Pour Grille et Diaporama']);
+        echo '<p class="my-articles-columns-warning__message" aria-live="polite"></p>';
+        echo '</div>';
+
+        echo '<div class="my-articles-columns-warning" data-field="columns_ultrawide">';
         $this->render_field('columns_ultrawide', __('Colonnes (Ultra-Wide ≥ 1536px)', 'mon-articles'), 'number', $opts, ['default' => 4, 'min' => 1, 'max' => 8, 'description' => 'Pour Grille et Diaporama']);
+        echo '<p class="my-articles-columns-warning__message" aria-live="polite"></p>';
+        echo '</div>';
 
         echo '<hr><h3>' . __('Apparence & Performances', 'mon-articles') . '</h3>';
         $this->render_field('module_padding_left', __('Marge intérieure gauche (px)', 'mon-articles'), 'number', $opts, ['default' => 0, 'min' => 0, 'max' => 200]);


### PR DESCRIPTION
## Summary
- add localized configuration for admin column width warnings
- wrap responsive column fields with dedicated warning containers
- extend admin options script to surface width warnings for column inputs

## Testing
- php -l mon-affichage-article/includes/class-my-articles-metaboxes.php

------
https://chatgpt.com/codex/tasks/task_e_68d2c9b38704832e99fe644cf121617e