### PR TITLE
Improve responsive layout handling

### DIFF
--- a/mon-affichage-article/assets/css/styles.css
+++ b/mon-affichage-article/assets/css/styles.css
@@ -88,6 +88,7 @@
 .my-articles-grid-content {
     display: grid;
     grid-gap: var(--my-articles-gap);
+    grid-template-columns: repeat(auto-fit, minmax(var(--my-articles-min-card-width), 1fr));
 }
 
 .my-articles-list-content .my-article-item {
@@ -224,28 +225,6 @@
 
 .my-article-item .article-meta a:hover {
     color: var(--my-articles-meta-hover-color);
-}
-
-.my-articles-grid-content {
-    grid-template-columns: repeat(var(--my-articles-cols-mobile), 1fr);
-}
-
-@media (min-width: 768px) {
-    .my-articles-grid-content {
-        grid-template-columns: repeat(var(--my-articles-cols-tablet), 1fr);
-    }
-}
-
-@media (min-width: 1024px) {
-    .my-articles-grid-content {
-        grid-template-columns: repeat(var(--my-articles-cols-desktop), 1fr);
-    }
-}
-
-@media (min-width: 1536px) {
-    .my-articles-grid-content {
-        grid-template-columns: repeat(var(--my-articles-cols-ultrawide), 1fr);
-    }
 }
 
 @media (max-width: 767px) {

--- a/mon-affichage-article/assets/js/responsive-layout.js
+++ b/mon-affichage-article/assets/js/responsive-layout.js
@@ -1,0 +1,170 @@
+// Fichier: assets/js/responsive-layout.js
+(function () {
+    'use strict';
+
+    const MIN_CARD_WIDTH_FALLBACK = 220;
+    const BREAKPOINTS = [
+        { key: 'mobile', minViewport: 0 },
+        { key: 'tablet', minViewport: 768 },
+        { key: 'desktop', minViewport: 1024 },
+        { key: 'ultrawide', minViewport: 1536 },
+    ];
+    const COLUMN_KEYS = BREAKPOINTS.map(function (breakpoint) {
+        return breakpoint.key;
+    });
+    const SWIPER_BREAKPOINTS = {
+        tablet: 768,
+        desktop: 1024,
+        ultrawide: 1536,
+    };
+
+    const managedWrappers = new Set();
+    const raf = (typeof window !== 'undefined' && window.requestAnimationFrame)
+        ? window.requestAnimationFrame.bind(window)
+        : function (callback) {
+            return setTimeout(callback, 16);
+        };
+    let resizeHandle = null;
+
+    function toPositiveInt(value, fallback) {
+        const parsed = parseInt(value, 10);
+        return parsed > 0 ? parsed : fallback;
+    }
+
+    function getConfiguredColumns(wrapper) {
+        return {
+            mobile: toPositiveInt(wrapper.dataset.colsMobile, 1),
+            tablet: toPositiveInt(wrapper.dataset.colsTablet, 1),
+            desktop: toPositiveInt(wrapper.dataset.colsDesktop, 1),
+            ultrawide: toPositiveInt(wrapper.dataset.colsUltrawide, 1),
+        };
+    }
+
+    function getBaseMinCardWidth(wrapper) {
+        return toPositiveInt(wrapper.dataset.minCardWidth, MIN_CARD_WIDTH_FALLBACK);
+    }
+
+    function getActiveBreakpoint(viewportWidth) {
+        let active = BREAKPOINTS[0].key;
+
+        BREAKPOINTS.forEach(function (breakpoint) {
+            if (viewportWidth >= breakpoint.minViewport) {
+                active = breakpoint.key;
+            }
+        });
+
+        return active;
+    }
+
+    function updateSwiperConfiguration(instanceId, effectiveColumns) {
+        if (!instanceId) {
+            return;
+        }
+
+        const settingsName = 'myArticlesSwiperSettings_' + instanceId;
+        const settings = window[settingsName];
+
+        if (settings) {
+            settings.columns_mobile = effectiveColumns.mobile;
+            settings.columns_tablet = effectiveColumns.tablet;
+            settings.columns_desktop = effectiveColumns.desktop;
+            settings.columns_ultrawide = effectiveColumns.ultrawide;
+        }
+
+        if (!window.mySwiperInstances || !window.mySwiperInstances[instanceId]) {
+            return;
+        }
+
+        const swiper = window.mySwiperInstances[instanceId];
+        if (!swiper) {
+            return;
+        }
+
+        swiper.params.slidesPerView = effectiveColumns.mobile;
+        swiper.params.breakpoints = swiper.params.breakpoints || {};
+
+        Object.keys(SWIPER_BREAKPOINTS).forEach(function (key) {
+            const breakpointValue = SWIPER_BREAKPOINTS[key];
+            const slides = effectiveColumns[key];
+
+            swiper.params.breakpoints[breakpointValue] = swiper.params.breakpoints[breakpointValue] || {};
+            swiper.params.breakpoints[breakpointValue].slidesPerView = slides;
+        });
+
+        if (typeof swiper.update === 'function') {
+            swiper.update();
+        }
+    }
+
+    function updateWrapper(wrapper) {
+        if (!wrapper) {
+            return;
+        }
+
+        const width = wrapper.clientWidth;
+        if (!width) {
+            return;
+        }
+
+        const columnsConfig = getConfiguredColumns(wrapper);
+        const baseMinWidth = getBaseMinCardWidth(wrapper);
+        const baseEffective = Math.max(1, Math.floor(width / baseMinWidth));
+
+        const effectiveColumns = {};
+        COLUMN_KEYS.forEach(function (key) {
+            const configured = columnsConfig[key];
+            const effective = Math.max(1, Math.min(configured, baseEffective));
+            effectiveColumns[key] = effective;
+            wrapper.style.setProperty('--my-articles-cols-' + key, effective);
+        });
+
+        const viewportWidth = window.innerWidth || document.documentElement.clientWidth || width;
+        const activeKey = getActiveBreakpoint(viewportWidth);
+        const activeColumns = effectiveColumns[activeKey] || effectiveColumns.mobile || 1;
+        const derivedMinWidth = Math.max(baseMinWidth, Math.floor(width / activeColumns) || baseMinWidth);
+
+        wrapper.style.setProperty('--my-articles-min-card-width', derivedMinWidth + 'px');
+        wrapper.dataset.activeCols = String(activeColumns);
+
+        if (wrapper.classList.contains('my-articles-slideshow')) {
+            updateSwiperConfiguration(wrapper.dataset.instanceId, effectiveColumns);
+        }
+    }
+
+    function scheduleGlobalUpdate() {
+        if (resizeHandle !== null) {
+            return;
+        }
+
+        resizeHandle = raf(function () {
+            resizeHandle = null;
+            managedWrappers.forEach(updateWrapper);
+        });
+    }
+
+    function initWrapper(wrapper) {
+        if (!wrapper || managedWrappers.has(wrapper)) {
+            return;
+        }
+
+        managedWrappers.add(wrapper);
+
+        if (typeof ResizeObserver !== 'undefined') {
+            const observer = new ResizeObserver(function () {
+                updateWrapper(wrapper);
+            });
+            observer.observe(wrapper);
+            wrapper.__myArticlesResizeObserver = observer;
+        }
+
+        updateWrapper(wrapper);
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        const wrappers = document.querySelectorAll('.my-articles-wrapper');
+        wrappers.forEach(initWrapper);
+
+        window.addEventListener('resize', scheduleGlobalUpdate);
+        window.addEventListener('orientationchange', scheduleGlobalUpdate);
+    });
+})();

--- a/mon-affichage-article/includes/class-my-articles-enqueue.php
+++ b/mon-affichage-article/includes/class-my-articles-enqueue.php
@@ -27,6 +27,7 @@ class My_Articles_Enqueue {
         wp_register_style('my-articles-styles', MY_ARTICLES_PLUGIN_URL . 'assets/css/styles.css', [], MY_ARTICLES_VERSION);
         wp_register_script('swiper-js', $vendor_url . 'swiper/swiper-bundle.min.js', [], '11.0.0', true);
         wp_register_script('lazysizes', $vendor_url . 'lazysizes/lazysizes.min.js', [], '5.3.2', true);
+        wp_register_script('my-articles-responsive-layout', MY_ARTICLES_PLUGIN_URL . 'assets/js/responsive-layout.js', [], MY_ARTICLES_VERSION, true);
         if (function_exists('wp_script_add_data')) {
             wp_script_add_data('lazysizes', 'async', true);
         }


### PR DESCRIPTION
## Summary
- register and enqueue a responsive layout helper script alongside existing front-end assets
- expose min card width metadata on the wrapper and adjust inline styles and grid CSS to use auto-fit behaviour
- add a ResizeObserver-driven script to clamp columns and update Swiper settings based on available width

## Testing
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php
- php -l mon-affichage-article/includes/class-my-articles-enqueue.php

------
https://chatgpt.com/codex/tasks/task_e_68d2c9a6b388832eb6c44d86da4675af