### PR TITLE
Ensure AJAX referer and pagination URLs stay on site domain

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -742,6 +742,12 @@ class My_Articles_Shortcode {
             return '';
         }
 
+        $site_home   = home_url();
+        $site_host   = wp_parse_url( $site_home, PHP_URL_HOST );
+        $site_host   = is_string( $site_host ) ? strtolower( $site_host ) : '';
+        $site_scheme = wp_parse_url( $site_home, PHP_URL_SCHEME );
+        $site_scheme = is_string( $site_scheme ) ? strtolower( $site_scheme ) : '';
+
         if ( empty( $base_url ) ) {
             global $wp;
             $base_url = home_url( add_query_arg( array(), $wp->request ) );
@@ -758,6 +764,18 @@ class My_Articles_Shortcode {
         }
 
         if ( empty( $base_url ) ) {
+            return '';
+        }
+
+        $base_host = wp_parse_url( $base_url, PHP_URL_HOST );
+        $base_host = is_string( $base_host ) ? strtolower( $base_host ) : '';
+        if ( '' !== $site_host && ( '' === $base_host || $site_host !== $base_host ) ) {
+            return '';
+        }
+
+        $base_scheme = wp_parse_url( $base_url, PHP_URL_SCHEME );
+        $base_scheme = is_string( $base_scheme ) ? strtolower( $base_scheme ) : '';
+        if ( '' !== $site_scheme && '' !== $base_scheme && $site_scheme !== $base_scheme ) {
             return '';
         }
 

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -76,7 +76,13 @@ final class Mon_Affichage_Articles {
         $category_slug = isset( $_POST['category'] ) ? sanitize_text_field( wp_unslash( $_POST['category'] ) ) : '';
         $raw_current_url = isset( $_POST['current_url'] ) ? wp_unslash( $_POST['current_url'] ) : '';
 
-        $sanitize_referer = static function ( $url ) {
+        $home_url  = home_url();
+        $site_host = wp_parse_url( $home_url, PHP_URL_HOST );
+        $site_host = is_string( $site_host ) ? strtolower( $site_host ) : '';
+        $site_scheme = wp_parse_url( $home_url, PHP_URL_SCHEME );
+        $site_scheme = is_string( $site_scheme ) ? strtolower( $site_scheme ) : '';
+
+        $sanitize_referer = static function ( $url ) use ( $site_host, $site_scheme ) {
             if ( ! is_string( $url ) || '' === $url ) {
                 return '';
             }
@@ -89,6 +95,18 @@ final class Mon_Affichage_Articles {
             $hash_position = strpos( $clean_url, '#' );
             if ( false !== $hash_position ) {
                 $clean_url = substr( $clean_url, 0, $hash_position );
+            }
+
+            $referer_host = wp_parse_url( $clean_url, PHP_URL_HOST );
+            $referer_host = is_string( $referer_host ) ? strtolower( $referer_host ) : '';
+            if ( '' !== $site_host && ( '' === $referer_host || $site_host !== $referer_host ) ) {
+                return '';
+            }
+
+            $referer_scheme = wp_parse_url( $clean_url, PHP_URL_SCHEME );
+            $referer_scheme = is_string( $referer_scheme ) ? strtolower( $referer_scheme ) : '';
+            if ( '' !== $site_scheme && '' !== $referer_scheme && $site_scheme !== $referer_scheme ) {
+                return '';
             }
 
             return $clean_url;


### PR DESCRIPTION
## Summary
- sanitize the AJAX referer URL by ensuring the host (and scheme when provided) matches the site domain before use
- add host and scheme validation to numbered pagination generation so external bases are ignored

## Testing
- php -l mon-affichage-article/mon-affichage-articles.php
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68d2d1596b04832eb2a6f0b670e5b56f