### PR TITLE
Use global settings as defaults for shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Pour vérifier la prise en charge d'un slug de taxonomie égal à `"0"` :
 2. Configurez un module **Tuiles – LCV** afin qu'il utilise ce terme comme valeur par défaut et activez, si besoin, le filtre de catégories en frontal.
 3. Affichez le module côté public et vérifiez que les articles associés au terme `0` apparaissent bien, que le filtre est sélectionné et que la pagination/chargement additionnel respecte ce terme.
 
+Pour valider la prise en compte des réglages globaux :
+
+1. Modifiez un ou plusieurs réglages dans le menu **Tuiles – LCV** (par exemple le mode d'affichage ou les couleurs).
+2. Créez un nouveau contenu de type **mon_affichage** sans surcharger ces options dans la metabox.
+3. Affichez le shortcode correspondant en frontal et vérifiez que le rendu reflète les réglages globaux enregistrés.
+
 Pour valider la gestion d'un identifiant d'instance invalide lors des appels AJAX :
 
 1. Déclenchez les actions `filter_articles` et `load_more_articles` avec un identifiant qui ne correspond pas à un contenu de type `mon_affichage`.

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -20,7 +20,7 @@ class My_Articles_Shortcode {
     }
 
     public static function get_default_options() {
-        return [
+        $defaults = [
             'post_type' => 'post',
             'taxonomy' => '',
             'term' => '',
@@ -59,6 +59,34 @@ class My_Articles_Shortcode {
             'meta_color' => '#6b7280', 'meta_color_hover' => '#000000', 'pagination_color' => '#333333',
             'shadow_color' => 'rgba(0,0,0,0.07)', 'shadow_color_hover' => 'rgba(0,0,0,0.12)',
         ];
+
+        $saved_options = get_option( 'my_articles_options', array() );
+
+        if ( ! is_array( $saved_options ) ) {
+            $saved_options = array();
+        }
+
+        $aliases = array(
+            'desktop_columns'     => 'columns_desktop',
+            'mobile_columns'      => 'columns_mobile',
+            'module_margin_left'  => 'module_padding_left',
+            'module_margin_right' => 'module_padding_right',
+        );
+
+        foreach ( $aliases as $stored_key => $option_key ) {
+            if ( array_key_exists( $stored_key, $saved_options ) ) {
+                $saved_options[ $option_key ] = $saved_options[ $stored_key ];
+            }
+        }
+
+        if ( ! empty( $saved_options['default_category'] ) ) {
+            $saved_options['taxonomy'] = 'category';
+            $saved_options['term']     = sanitize_title( (string) $saved_options['default_category'] );
+        }
+
+        $saved_options = array_intersect_key( $saved_options, $defaults );
+
+        return wp_parse_args( $saved_options, $defaults );
     }
 
     public static function normalize_instance_options( $raw_options, $context = array() ) {


### PR DESCRIPTION
## Summary
- load the saved global configuration when building shortcode defaults and map aliases between global and instance option keys
- fall back to category defaults captured in the global settings when relevant
- document a manual test ensuring that updated global settings are reflected in new shortcode instances

## Testing
- `php -l mon-affichage-article/includes/class-my-articles-shortcode.php`


------
https://chatgpt.com/codex/tasks/task_e_68d2d1eafa74832e881092d0eca2974a