### PR TITLE
Fix alpha flag for color picker

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -220,7 +220,7 @@ class My_Articles_Metaboxes {
                 }
                 break;
             case 'color':
-                $alpha = $args['alpha'] ?? false ? 'data-alpha-enabled="true"' : '';
+                $alpha = ! empty( $args['alpha'] ) ? 'data-alpha-enabled="true"' : '';
                 printf('<input type="text" id="%s" name="%s" value="%s" class="my-color-picker" %s />', esc_attr($id), $name, esc_attr($value), $alpha);
                 break;
             case 'select':


### PR DESCRIPTION
## Summary
- ensure color fields with an alpha option render the expected data attribute for the WordPress color picker

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2d4d793c0832ea4a362d72f8206b0