### PR TITLE
Fix color picker alpha attribute detection

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -220,7 +220,7 @@ class My_Articles_Metaboxes {
                 }
                 break;
             case 'color':
-                $alpha = $args['alpha'] ?? false ? 'data-alpha-enabled="true"' : '';
+                $alpha = ! empty( $args['alpha'] ) ? 'data-alpha-enabled="true"' : '';
                 printf('<input type="text" id="%s" name="%s" value="%s" class="my-color-picker" %s />', esc_attr($id), $name, esc_attr($value), $alpha);
                 break;
             case 'select':


### PR DESCRIPTION
## Summary
- ensure the color field alpha flag explicitly checks for a truthy value before adding the data attribute

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2e02f1a68832e90965e154fb6d831