### PR TITLE
Improve pagination sanitization and optimize queries

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-settings.php
+++ b/mon-affichage-article/includes/class-my-articles-settings.php
@@ -196,7 +196,7 @@ class My_Articles_Settings {
         if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( wp_unslash( $_POST['_wpnonce'] ), 'my_articles_reset_settings_nonce' ) ) { wp_die( 'La vérification a échoué.' ); }
         if ( ! current_user_can( 'manage_options' ) ) { wp_die( 'Permission refusée.' ); }
         delete_option( $this->option_name );
-        wp_redirect( admin_url( 'admin.php?page=my-articles-settings&status=reset' ) );
+        wp_safe_redirect( admin_url( 'admin.php?page=my-articles-settings&status=reset' ) );
         exit;
     }
 }

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -842,10 +842,17 @@ class My_Articles_Shortcode {
             $fallback_base = home_url( add_query_arg( array(), $request_path ) );
 
             if ( ! empty( $_GET ) ) {
-                $sanitized_query_args = array_map( 'sanitize_text_field', wp_unslash( $_GET ) );
+                $raw_query_args = wp_unslash( $_GET );
+                if ( is_array( $raw_query_args ) ) {
+                    $sanitized_query_args = map_deep( $raw_query_args, 'sanitize_text_field' );
+                } else {
+                    $sanitized_query_args = array();
+                }
+
                 if ( isset( $sanitized_query_args[ $paged_var ] ) ) {
                     unset( $sanitized_query_args[ $paged_var ] );
                 }
+
                 if ( ! empty( $sanitized_query_args ) ) {
                     $fallback_base = add_query_arg( $sanitized_query_args, $fallback_base );
                 }
@@ -865,7 +872,7 @@ class My_Articles_Shortcode {
         $query_string  = wp_parse_url( $base_url, PHP_URL_QUERY );
         if ( $query_string ) {
             wp_parse_str( $query_string, $existing_args );
-            $existing_args = array_map( 'sanitize_text_field', $existing_args );
+            $existing_args = map_deep( $existing_args, 'sanitize_text_field' );
 
             if ( ! empty( $existing_args ) ) {
                 $base_url = remove_query_arg( array_keys( $existing_args ), $base_url );

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -408,6 +408,8 @@ final class Mon_Affichage_Articles {
                 'posts_per_page' => -1,
                 'fields'         => 'ids',
                 'post__not_in'   => $exclude_ids,
+                'no_found_rows'  => true,
+                'update_post_meta_cache' => false,
             ];
 
             if ( empty( $options['pinned_posts_ignore_filter'] ) && '' !== $active_category && 'all' !== $active_category && '' !== $resolved_taxonomy ) {


### PR DESCRIPTION
## Summary
- preserve complex query parameters when building numbered pagination links by recursively sanitizing request data
- harden the admin reset handler by switching to wp_safe_redirect
- avoid unnecessary SQL_CALC_FOUND_ROWS/meta cache work in the pinned post lookup query

## Testing
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php
- php -l mon-affichage-article/includes/class-my-articles-settings.php
- php -l mon-affichage-article/mon-affichage-articles.php

------
https://chatgpt.com/codex/tasks/task_e_68d3be2ea9c0832e8cee5cb0688e551b