### PR TITLE
Améliorations AJAX et mutualisation du message vide

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-enqueue.php
+++ b/mon-affichage-article/includes/class-my-articles-enqueue.php
@@ -23,13 +23,14 @@ class My_Articles_Enqueue {
     public function register_plugin_styles_scripts() {
         $vendor_url = MY_ARTICLES_PLUGIN_URL . 'assets/vendor/';
 
-        wp_register_style('swiper-css', $vendor_url . 'swiper/swiper-bundle.min.css', [], '11.0.0');
-        wp_register_style('my-articles-styles', MY_ARTICLES_PLUGIN_URL . 'assets/css/styles.css', [], MY_ARTICLES_VERSION);
-        wp_register_script('swiper-js', $vendor_url . 'swiper/swiper-bundle.min.js', [], '11.0.0', true);
-        wp_register_script('lazysizes', $vendor_url . 'lazysizes/lazysizes.min.js', [], '5.3.2', true);
-        wp_register_script('my-articles-responsive-layout', MY_ARTICLES_PLUGIN_URL . 'assets/js/responsive-layout.js', [], MY_ARTICLES_VERSION, true);
-        if (function_exists('wp_script_add_data')) {
-            wp_script_add_data('lazysizes', 'async', true);
+        wp_register_style( 'swiper-css', $vendor_url . 'swiper/swiper-bundle.min.css', array(), '11.0.0' );
+        wp_register_style( 'my-articles-styles', MY_ARTICLES_PLUGIN_URL . 'assets/css/styles.css', array(), MY_ARTICLES_VERSION );
+        wp_register_script( 'swiper-js', $vendor_url . 'swiper/swiper-bundle.min.js', array(), '11.0.0', true );
+        wp_register_script( 'lazysizes', $vendor_url . 'lazysizes/lazysizes.min.js', array(), '5.3.2', true );
+        wp_register_script( 'my-articles-responsive-layout', MY_ARTICLES_PLUGIN_URL . 'assets/js/responsive-layout.js', array(), MY_ARTICLES_VERSION, true );
+
+        if ( function_exists( 'wp_script_add_data' ) ) {
+            wp_script_add_data( 'lazysizes', 'async', true );
         }
     }
 }

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -930,8 +930,12 @@ class My_Articles_Shortcode {
         }
     }
 
+    public function get_empty_state_html() {
+        return '<p style="text-align: center; width: 100%; padding: 20px;">' . esc_html__( 'Aucun article trouvé dans cette catégorie.', 'mon-articles' ) . '</p>';
+    }
+
     private function render_empty_state_message() {
-        echo '<p style="text-align: center; width: 100%; padding: 20px;">' . esc_html__( 'Aucun article trouvé dans cette catégorie.', 'mon-articles' ) . '</p>';
+        echo $this->get_empty_state_html();
     }
 
     public function render_article_item($options, $is_pinned = false) {
@@ -940,11 +944,12 @@ class My_Articles_Shortcode {
         $display_mode = $options['display_mode'] ?? 'grid';
         $taxonomy = $options['resolved_taxonomy'] ?? self::resolve_taxonomy( $options );
         $enable_lazy_load = !empty($options['enable_lazy_load']);
+        $excerpt_more = __( '…', 'mon-articles' );
         ?>
         <div class="<?php echo esc_attr($item_classes); ?>">
             <?php
             if ($display_mode === 'list') {
-                $this->render_article_common_block($options, $is_pinned, $taxonomy, $enable_lazy_load, 'article-content-wrapper', '...');
+                $this->render_article_common_block($options, $is_pinned, $taxonomy, $enable_lazy_load, 'article-content-wrapper', $excerpt_more);
             } else {
                 $this->render_article_common_block($options, $is_pinned, $taxonomy, $enable_lazy_load, 'article-title-wrapper', '');
             }

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -84,7 +84,7 @@ final class Mon_Affichage_Articles {
         }
 
         if ( ! $instance_id ) {
-            wp_send_json_error( __( 'ID d\'instance manquant.', 'mon-articles' ) );
+            wp_send_json_error( __( 'ID d\'instance manquant.', 'mon-articles' ), 400 );
         }
 
         $this->assert_valid_instance_post_type( $instance_id );
@@ -100,7 +100,7 @@ final class Mon_Affichage_Articles {
         );
 
         if ( ! empty( $options['allowed_filter_term_slugs'] ) && empty( $options['is_requested_category_valid'] ) ) {
-            wp_send_json_error( __( 'Catégorie non autorisée.', 'mon-articles' ) );
+            wp_send_json_error( __( 'Catégorie non autorisée.', 'mon-articles' ), 403 );
         }
 
         $display_mode      = $options['display_mode'];
@@ -182,7 +182,7 @@ final class Mon_Affichage_Articles {
         }
 
         if ( 0 === $displayed_posts_count ) {
-            echo '<p style="text-align: center; width: 100%; padding: 20px;">' . esc_html__( 'Aucun article trouvé dans cette catégorie.', 'mon-articles' ) . '</p>';
+            echo $shortcode_instance->get_empty_state_html();
         }
 
         if ( $pinned_query instanceof WP_Query ) {
@@ -247,7 +247,7 @@ final class Mon_Affichage_Articles {
         $category = isset( $_POST['category'] ) ? sanitize_text_field( wp_unslash( $_POST['category'] ) ) : '';
 
         if ( ! $instance_id ) {
-            wp_send_json_error( __( 'ID d\'instance manquant.', 'mon-articles' ) );
+            wp_send_json_error( __( 'ID d\'instance manquant.', 'mon-articles' ), 400 );
         }
 
         $this->assert_valid_instance_post_type( $instance_id );
@@ -263,7 +263,7 @@ final class Mon_Affichage_Articles {
         );
 
         if ( ! empty( $options['allowed_filter_term_slugs'] ) && empty( $options['is_requested_category_valid'] ) ) {
-            wp_send_json_error( __( 'Catégorie non autorisée.', 'mon-articles' ) );
+            wp_send_json_error( __( 'Catégorie non autorisée.', 'mon-articles' ), 403 );
         }
 
         $seen_pinned_ids = array();
@@ -331,7 +331,7 @@ final class Mon_Affichage_Articles {
         }
 
         if ( 0 === $displayed_posts_count ) {
-            echo '<p style="text-align: center; width: 100%; padding: 20px;">' . esc_html__( 'Aucun article trouvé dans cette catégorie.', 'mon-articles' ) . '</p>';
+            echo $shortcode_instance->get_empty_state_html();
         }
 
         $html = ob_get_clean();
@@ -477,6 +477,7 @@ final class Mon_Affichage_Articles {
 
         if ( ! empty( $include_param ) ) {
             $term_args['include'] = array_values( array_unique( array_filter( $include_param ) ) );
+            $term_args['orderby'] = 'include';
         } else {
             $term_args['number'] = $per_page;
             $term_args['offset'] = ( $page - 1 ) * $per_page;


### PR DESCRIPTION
## Summary
- ajoute des codes HTTP explicites aux réponses d'erreur AJAX et réutilise le même HTML pour l'état vide
- respecte l'ordre de sélection des termes via orderby=include et localise le texte d'ellipse des extraits
- harmonise l'enregistrement des assets avec le style WordPress

## Testing
- php -l mon-affichage-articles.php
- php -l includes/class-my-articles-shortcode.php
- php -l includes/class-my-articles-enqueue.php

------
https://chatgpt.com/codex/tasks/task_e_68d42f2975d4832ebdceb0a4656091c0