### PR TITLE
Improve AJAX category sanitization and rendering reliability

### DIFF
--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -73,7 +73,7 @@ final class Mon_Affichage_Articles {
         check_ajax_referer( 'my_articles_filter_nonce', 'security' );
 
         $instance_id   = isset( $_POST['instance_id'] ) ? absint( wp_unslash( $_POST['instance_id'] ) ) : 0;
-        $category_slug = isset( $_POST['category'] ) ? sanitize_text_field( wp_unslash( $_POST['category'] ) ) : '';
+        $category_slug = isset( $_POST['category'] ) ? sanitize_title( wp_unslash( $_POST['category'] ) ) : '';
         $raw_current_url = isset( $_POST['current_url'] ) ? wp_unslash( $_POST['current_url'] ) : '';
 
         $home_url    = home_url();
@@ -244,7 +244,7 @@ final class Mon_Affichage_Articles {
         $instance_id = isset( $_POST['instance_id'] ) ? absint( wp_unslash( $_POST['instance_id'] ) ) : 0;
         $paged = isset( $_POST['paged'] ) ? absint( wp_unslash( $_POST['paged'] ) ) : 1;
         $pinned_ids_str = isset( $_POST['pinned_ids'] ) ? sanitize_text_field( wp_unslash( $_POST['pinned_ids'] ) ) : '';
-        $category = isset( $_POST['category'] ) ? sanitize_text_field( wp_unslash( $_POST['category'] ) ) : '';
+        $category = isset( $_POST['category'] ) ? sanitize_title( wp_unslash( $_POST['category'] ) ) : '';
 
         if ( ! $instance_id ) {
             wp_send_json_error( __( 'ID d\'instance manquant.', 'mon-articles' ), 400 );


### PR DESCRIPTION
## Summary
- normalize AJAX category slugs with `sanitize_title()` to align with shortcode option handling
- factor shared post rendering logic into a reusable helper for list and grid layouts
- avoid emitting empty lazy-load attributes when attachment URLs are unavailable

## Testing
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php
- php -l mon-affichage-article/mon-affichage-articles.php

------
https://chatgpt.com/codex/tasks/task_e_68d43612c214832e963e871d7f878887