### PR TITLE
Optimise regular queries and secure debug script

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-enqueue.php
+++ b/mon-affichage-article/includes/class-my-articles-enqueue.php
@@ -28,6 +28,7 @@ class My_Articles_Enqueue {
         wp_register_script( 'swiper-js', $vendor_url . 'swiper/swiper-bundle.min.js', array(), '11.0.0', true );
         wp_register_script( 'lazysizes', $vendor_url . 'lazysizes/lazysizes.min.js', array(), '5.3.2', true );
         wp_register_script( 'my-articles-responsive-layout', MY_ARTICLES_PLUGIN_URL . 'assets/js/responsive-layout.js', array(), MY_ARTICLES_VERSION, true );
+        wp_register_script( 'my-articles-debug-helper', false, array(), MY_ARTICLES_VERSION, true );
 
         if ( function_exists( 'wp_script_add_data' ) ) {
             wp_script_add_data( 'lazysizes', 'async', true );

--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -306,7 +306,7 @@ class My_Articles_Metaboxes {
         
         $sanitized['post_type'] = my_articles_normalize_post_type( $input['post_type'] ?? '' );
         $sanitized['taxonomy'] = isset($input['taxonomy']) ? sanitize_key($input['taxonomy']) : '';
-        $sanitized['term'] = isset($input['term']) ? sanitize_text_field( wp_unslash( $input['term'] ) ) : '';
+        $sanitized['term'] = isset($input['term']) ? sanitize_text_field( $input['term'] ) : '';
         $sanitized['counting_behavior'] = isset($input['counting_behavior']) && in_array($input['counting_behavior'], ['exact', 'auto_fill']) ? $input['counting_behavior'] : 'exact';
         $sanitized['posts_per_page'] = isset( $input['posts_per_page'] ) ? max( 1, absint( $input['posts_per_page'] ) ) : 10;
         $sanitized['pagination_mode'] = isset($input['pagination_mode']) && in_array($input['pagination_mode'], ['none', 'load_more', 'numbered']) ? $input['pagination_mode'] : 'none';

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -223,11 +223,11 @@ class My_Articles_Shortcode {
             );
 
             if ( $effective_limit > 0 ) {
-                if ( $regular_posts_limit >= 0 ) {
+                if ( $regular_posts_limit > 0 ) {
                     $regular_query = self::build_regular_query(
                         $options,
                         array(
-                            'posts_per_page' => max( 1, $regular_posts_limit ),
+                            'posts_per_page' => $regular_posts_limit,
                             'post__not_in'   => $regular_excluded_ids,
                             'offset'         => $regular_offset,
                         ),
@@ -287,11 +287,11 @@ class My_Articles_Shortcode {
             }
 
             if ( $effective_limit > 0 ) {
-                if ( $regular_posts_limit >= 0 ) {
+                if ( $regular_posts_limit > 0 ) {
                     $regular_query = self::build_regular_query(
                         $options,
                         array(
-                            'posts_per_page' => max( 1, $regular_posts_limit ),
+                            'posts_per_page' => $regular_posts_limit,
                             'offset'         => $regular_offset,
                         ),
                         $options['term'] ?? ''
@@ -819,29 +819,26 @@ class My_Articles_Shortcode {
             }
         }
         
-        if (!empty($options['enable_debug_mode'])) {
+        if ( ! empty( $options['enable_debug_mode'] ) ) {
             echo '<div style="background: #fff; border: 2px solid red; padding: 15px; margin: 20px 0; text-align: left; color: #000; font-family: monospace; line-height: 1.6; clear: both;">';
             echo '<h4 style="margin: 0 0 10px 0;">-- DEBUG MODE --</h4>';
             echo '<ul>';
-            echo '<li>Réglage "Lazy Load" activé : <strong>' . (!empty($options['enable_lazy_load']) ? 'Oui' : 'Non') . '</strong></li>';
-            echo '<li>Statut du script lazysizes : <strong id="lazysizes-status-'.esc_attr($id).'" style="color: red;">En attente...</strong></li>';
+            echo '<li>Réglage "Lazy Load" activé : <strong>' . ( ! empty( $options['enable_lazy_load'] ) ? 'Oui' : 'Non' ) . '</strong></li>';
+            echo '<li>Statut du script lazysizes : <strong id="lazysizes-status-' . esc_attr( $id ) . '" style="color: red;">En attente...</strong></li>';
             echo '</ul>';
             echo '</div>';
-            echo "<script>
-                document.addEventListener('DOMContentLoaded', function() {
-                    var statusSpan = document.getElementById('lazysizes-status-".esc_attr($id)."');
-                    if (statusSpan) {
-                        setTimeout(function() {
-                            if (window.lazySizes) {
-                                statusSpan.textContent = '✅ Chargé et actif !';
-                                statusSpan.style.color = 'green';
-                            } else {
-                                statusSpan.textContent = '❌ ERREUR : Non trouvé !';
-                            }
-                        }, 500);
-                    }
-                });
-            </script>";
+
+            wp_enqueue_script( 'my-articles-debug-helper' );
+
+            $status_span_id = 'lazysizes-status-' . $id;
+            $debug_script   = sprintf(
+                "document.addEventListener('DOMContentLoaded',function(){var statusSpan=document.getElementById(%s);if(!statusSpan){return;}setTimeout(function(){if(window.lazySizes){statusSpan.textContent=%s;statusSpan.style.color='green';}else{statusSpan.textContent=%s;}},500);});",
+                wp_json_encode( $status_span_id ),
+                wp_json_encode( '✅ Chargé et actif !' ),
+                wp_json_encode( '❌ ERREUR : Non trouvé !' )
+            );
+
+            wp_add_inline_script( 'my-articles-debug-helper', $debug_script );
         }
         
         echo '</div>';


### PR DESCRIPTION
## Summary
- avoid launching additional regular queries when the calculated limit is zero
- stop double unslashing the saved taxonomy term in the metabox handler
- register a dedicated debug helper handle and inject the debug script via `wp_add_inline_script`

## Testing
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php
- php -l mon-affichage-article/includes/class-my-articles-metaboxes.php
- php -l mon-affichage-article/includes/class-my-articles-enqueue.php

------
https://chatgpt.com/codex/tasks/task_e_68d44c0fe940832ea90c454bd841ecab