### PR TITLE
Allow unlimited posts per page

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -99,7 +99,18 @@ class My_Articles_Metaboxes {
         $this->render_field('taxonomy', __('Filtrer par taxonomie', 'mon-articles'), 'taxonomy_select', $opts);
         $this->render_field('term', __('Filtrer par catégorie/terme', 'mon-articles'), 'term_select', $opts);
         $this->render_field('counting_behavior', __('Comportement du comptage', 'mon-articles'), 'select', $opts, [ 'default' => 'exact', 'options' => [ 'exact' => 'Nombre exact', 'auto_fill' => 'Remplissage automatique (Grille complète)' ] ]);
-        $this->render_field('posts_per_page', __('Nombre d\'articles souhaité', 'mon-articles'), 'number', $opts, ['default' => 10, 'min' => 1, 'max' => 50, 'description' => 'Le nombre exact ou approximatif selon le comportement choisi.']);
+        $this->render_field(
+            'posts_per_page',
+            __('Nombre d\'articles souhaité', 'mon-articles'),
+            'number',
+            $opts,
+            [
+                'default'     => 10,
+                'min'         => 0,
+                'max'         => 50,
+                'description' => __( 'Le nombre exact ou approximatif selon le comportement choisi. Utilisez 0 pour un affichage illimité.', 'mon-articles' ),
+            ]
+        );
         $this->render_field('pagination_mode', __('Type de pagination', 'mon-articles'), 'select', $opts, [ 'default' => 'none', 'options' => [ 'none' => 'Aucune', 'load_more' => 'Bouton "Charger plus"', 'numbered' => 'Liens numérotés' ], 'description' => 'Ne s\'applique pas au mode Diaporama.' ]);
         $this->render_field('show_category_filter', __('Afficher le filtre de catégories', 'mon-articles'), 'checkbox', $opts, ['default' => 0]);
         $this->render_field('filter_alignment', __('Alignement du filtre', 'mon-articles'), 'select', $opts, [ 'default' => 'right', 'options' => ['left' => 'Gauche', 'center' => 'Centre', 'right' => 'Droite'] ]);
@@ -308,7 +319,7 @@ class My_Articles_Metaboxes {
         $sanitized['taxonomy'] = isset($input['taxonomy']) ? sanitize_key($input['taxonomy']) : '';
         $sanitized['term'] = isset($input['term']) ? sanitize_text_field( $input['term'] ) : '';
         $sanitized['counting_behavior'] = isset($input['counting_behavior']) && in_array($input['counting_behavior'], ['exact', 'auto_fill']) ? $input['counting_behavior'] : 'exact';
-        $sanitized['posts_per_page'] = isset( $input['posts_per_page'] ) ? max( 1, absint( $input['posts_per_page'] ) ) : 10;
+        $sanitized['posts_per_page'] = isset( $input['posts_per_page'] ) ? max( 0, absint( $input['posts_per_page'] ) ) : 10;
         $sanitized['pagination_mode'] = isset($input['pagination_mode']) && in_array($input['pagination_mode'], ['none', 'load_more', 'numbered']) ? $input['pagination_mode'] : 'none';
         $sanitized['show_category_filter'] = isset( $input['show_category_filter'] ) ? 1 : 0;
         $sanitized['filter_alignment'] = isset($input['filter_alignment']) && in_array($input['filter_alignment'], ['left', 'center', 'right']) ? $input['filter_alignment'] : 'right';

--- a/mon-affichage-article/includes/class-my-articles-settings.php
+++ b/mon-affichage-article/includes/class-my-articles-settings.php
@@ -93,7 +93,7 @@ class My_Articles_Settings {
         $sanitized_input = [];
         $sanitized_input['display_mode'] = isset( $input['display_mode'] ) && in_array($input['display_mode'], ['grid', 'slideshow']) ? $input['display_mode'] : 'grid';
         $sanitized_input['default_category'] = isset( $input['default_category'] ) ? sanitize_text_field( $input['default_category'] ) : '';
-        $sanitized_input['posts_per_page'] = isset( $input['posts_per_page'] ) ? max( 1, absint( $input['posts_per_page'] ) ) : 10;
+        $sanitized_input['posts_per_page'] = isset( $input['posts_per_page'] ) ? max( 0, absint( $input['posts_per_page'] ) ) : 10;
         $sanitized_input['desktop_columns'] = isset( $input['desktop_columns'] ) ? max( 1, absint( $input['desktop_columns'] ) ) : 3;
         $sanitized_input['mobile_columns'] = isset( $input['mobile_columns'] ) ? max( 1, absint( $input['mobile_columns'] ) ) : 1;
         $sanitized_input['gap_size'] = isset( $input['gap_size'] ) ? absint( $input['gap_size'] ) : 25;
@@ -147,7 +147,10 @@ class My_Articles_Settings {
         $this->render_color_input('pagination_color', '#333333');
     }
     
-    public function posts_per_page_callback() { $this->render_number_input('posts_per_page', 10, 1, 50); }
+    public function posts_per_page_callback() {
+        $this->render_number_input('posts_per_page', 10, 0, 50);
+        echo '<p class="description">' . esc_html__( 'Utilisez 0 pour afficher un nombre illimité d\'articles.', 'mon-articles' ) . '</p>';
+    }
     public function desktop_columns_callback() { $this->render_number_input('desktop_columns', 3, 1, 6); }
     public function mobile_columns_callback() { $this->render_number_input('mobile_columns', 1, 1, 3); }
     public function gap_size_callback() { $this->render_number_input('gap_size', 25, 0, 50); }


### PR DESCRIPTION
## Summary
- allow saving a value of 0 for posts per page in metabox and settings sanitizers
- update admin fields to accept zero and document the unlimited behaviour

## Testing
- php -l mon-affichage-article/includes/class-my-articles-metaboxes.php
- php -l mon-affichage-article/includes/class-my-articles-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68d59122418c832ea15b9f1b4a2ee976