### PR TITLE
Ensure swiper empty state slide wrapper

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -932,18 +932,21 @@ class My_Articles_Shortcode {
         }
     }
 
-    public function get_empty_state_html( $wrap_for_swiper = false ) {
-        $html = '<p style="text-align: center; width: 100%; padding: 20px;">' . esc_html__( 'Aucun article trouvé dans cette catégorie.', 'mon-articles' ) . '</p>';
+    public function get_empty_state_html() {
+        return '<p style="text-align: center; width: 100%; padding: 20px;">' . esc_html__( 'Aucun article trouvé dans cette catégorie.', 'mon-articles' ) . '</p>';
+    }
 
-        if ( $wrap_for_swiper ) {
-            $html = '<div class="swiper-slide swiper-slide-empty">' . $html . '</div>';
-        }
-
-        return $html;
+    public function get_empty_state_slide_html() {
+        return '<div class="swiper-slide swiper-slide-empty">' . $this->get_empty_state_html() . '</div>';
     }
 
     private function render_empty_state_message( $wrap_for_swiper = false ) {
-        echo $this->get_empty_state_html( $wrap_for_swiper );
+        if ( $wrap_for_swiper ) {
+            echo $this->get_empty_state_slide_html();
+            return;
+        }
+
+        echo $this->get_empty_state_html();
     }
 
     public function render_article_item($options, $is_pinned = false) {

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -156,7 +156,11 @@ final class Mon_Affichage_Articles {
         }
 
         if ( 0 === $displayed_posts_count ) {
-            $html = $shortcode_instance->get_empty_state_html( $wrap_slides );
+            if ( $wrap_slides ) {
+                $html = $shortcode_instance->get_empty_state_slide_html();
+            } else {
+                $html = $shortcode_instance->get_empty_state_html();
+            }
         }
 
         return array(


### PR DESCRIPTION
## Summary
- wrap empty state markup in a swiper slide when AJAX responses expect slides
- centralize empty state slide helper so all swiper outputs share the same structure

## Testing
- php -l mon-affichage-article/mon-affichage-articles.php
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68d5ad44c508832e80e5f3dbd1da7ced