### PR TITLE
Allow unlimited posts per page configuration

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -101,7 +101,7 @@ class My_Articles_Metaboxes {
         $this->render_field('counting_behavior', __('Comportement du comptage', 'mon-articles'), 'select', $opts, [ 'default' => 'exact', 'options' => [ 'exact' => 'Nombre exact', 'auto_fill' => 'Remplissage automatique (Grille complète)' ] ]);
         $this->render_field(
             'posts_per_page',
-            __('Nombre d\'articles souhaité', 'mon-articles'),
+            __('Nombre d\'articles souhaité (0 = illimité)', 'mon-articles'),
             'number',
             $opts,
             [
@@ -319,7 +319,10 @@ class My_Articles_Metaboxes {
         $sanitized['taxonomy'] = isset($input['taxonomy']) ? sanitize_key($input['taxonomy']) : '';
         $sanitized['term'] = isset($input['term']) ? sanitize_text_field( $input['term'] ) : '';
         $sanitized['counting_behavior'] = isset($input['counting_behavior']) && in_array($input['counting_behavior'], ['exact', 'auto_fill']) ? $input['counting_behavior'] : 'exact';
-        $sanitized['posts_per_page'] = isset( $input['posts_per_page'] ) ? max( 0, absint( $input['posts_per_page'] ) ) : 10;
+        $sanitized['posts_per_page'] = my_articles_sanitize_posts_per_page(
+            $input['posts_per_page'] ?? null,
+            10
+        );
         $sanitized['pagination_mode'] = isset($input['pagination_mode']) && in_array($input['pagination_mode'], ['none', 'load_more', 'numbered']) ? $input['pagination_mode'] : 'none';
         $sanitized['show_category_filter'] = isset( $input['show_category_filter'] ) ? 1 : 0;
         $sanitized['filter_alignment'] = isset($input['filter_alignment']) && in_array($input['filter_alignment'], ['left', 'center', 'right']) ? $input['filter_alignment'] : 'right';

--- a/mon-affichage-article/includes/class-my-articles-settings.php
+++ b/mon-affichage-article/includes/class-my-articles-settings.php
@@ -93,7 +93,10 @@ class My_Articles_Settings {
         $sanitized_input = [];
         $sanitized_input['display_mode'] = isset( $input['display_mode'] ) && in_array($input['display_mode'], ['grid', 'slideshow']) ? $input['display_mode'] : 'grid';
         $sanitized_input['default_category'] = isset( $input['default_category'] ) ? sanitize_text_field( $input['default_category'] ) : '';
-        $sanitized_input['posts_per_page'] = isset( $input['posts_per_page'] ) ? max( 0, absint( $input['posts_per_page'] ) ) : 10;
+        $sanitized_input['posts_per_page'] = my_articles_sanitize_posts_per_page(
+            $input['posts_per_page'] ?? null,
+            10
+        );
         $sanitized_input['desktop_columns'] = isset( $input['desktop_columns'] ) ? max( 1, absint( $input['desktop_columns'] ) ) : 3;
         $sanitized_input['mobile_columns'] = isset( $input['mobile_columns'] ) ? max( 1, absint( $input['mobile_columns'] ) ) : 1;
         $sanitized_input['gap_size'] = isset( $input['gap_size'] ) ? absint( $input['gap_size'] ) : 25;

--- a/mon-affichage-article/includes/helpers.php
+++ b/mon-affichage-article/includes/helpers.php
@@ -49,6 +49,28 @@ if ( ! function_exists( 'my_articles_sanitize_color' ) ) {
     }
 }
 
+if ( ! function_exists( 'my_articles_sanitize_posts_per_page' ) ) {
+    /**
+     * Sanitize a posts per page value while allowing the unlimited flag.
+     *
+     * The metabox and the settings page both interpret the value "0" as an
+     * instruction to display an unlimited number of posts. The sanitizer needs
+     * to keep that value intact instead of falling back to the default.
+     *
+     * @param mixed $value   Raw value coming from user input.
+     * @param int   $default Default value to use when no input is provided.
+     *
+     * @return int A non-negative integer (0 preserves the unlimited behaviour).
+     */
+    function my_articles_sanitize_posts_per_page( $value, $default = 10 ) {
+        if ( '' === $value || null === $value ) {
+            return max( 0, (int) $default );
+        }
+
+        return max( 0, absint( $value ) );
+    }
+}
+
 if ( ! function_exists( 'my_articles_normalize_internal_url' ) ) {
     /**
      * Sanitize a URL while ensuring it targets the current site domain.


### PR DESCRIPTION
## Summary
- Ensure the posts-per-page sanitizers preserve the value 0 for unlimited displays by reusing a dedicated helper.
- Reword the metabox label so administrators know that setting the field to 0 activates the unlimited behaviour.

## Testing
- php -l mon-affichage-article/includes/helpers.php
- php -l mon-affichage-article/includes/class-my-articles-metaboxes.php
- php -l mon-affichage-article/includes/class-my-articles-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68d5b1629d30832eb0d9e7a3125fdc31