### PR TITLE
Align inline style selectors with wrapper display modes

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -1308,9 +1308,9 @@ class My_Articles_Shortcode {
             padding-right: {$module_padding_right}px;
         }
         #my-articles-wrapper-{$id} .my-article-item { background-color: {$vignette_bg_color}; }
-        #my-articles-wrapper-{$id} .my-articles-grid .my-article-item .article-title-wrapper,
-        #my-articles-wrapper-{$id} .my-articles-slideshow .my-article-item .article-title-wrapper,
-        #my-articles-wrapper-{$id} .my-articles-list .my-article-item .article-content-wrapper { background-color: {$title_wrapper_bg}; }
+        #my-articles-wrapper-{$id}.my-articles-grid .my-article-item .article-title-wrapper,
+        #my-articles-wrapper-{$id}.my-articles-slideshow .my-article-item .article-title-wrapper,
+        #my-articles-wrapper-{$id}.my-articles-list .my-article-item .article-content-wrapper { background-color: {$title_wrapper_bg}; }
         ";
 
         wp_add_inline_style( 'my-articles-styles', $dynamic_css );

--- a/tests/RenderArticlesForResponseTest.php
+++ b/tests/RenderArticlesForResponseTest.php
@@ -78,4 +78,30 @@ class RenderArticlesForResponseTest extends TestCase
         $this->assertSame('', $result['html']);
         $this->assertSame(0, $result['displayed_posts_count']);
     }
+
+    public function test_title_wrapper_background_color_updates_all_display_modes(): void
+    {
+        global $mon_articles_inline_styles;
+        $mon_articles_inline_styles = array();
+
+        $options = array(
+            'title_wrapper_bg_color' => '#112233',
+        );
+
+        $reflection = new ReflectionClass(\My_Articles_Shortcode::class);
+        $shortcode = $reflection->newInstanceWithoutConstructor();
+
+        $method = $reflection->getMethod('render_inline_styles');
+        $method->setAccessible(true);
+        $method->invoke($shortcode, $options, 42);
+
+        $this->assertArrayHasKey('my-articles-styles', $mon_articles_inline_styles);
+        $this->assertNotEmpty($mon_articles_inline_styles['my-articles-styles']);
+
+        $css = implode("\n", $mon_articles_inline_styles['my-articles-styles']);
+
+        $this->assertStringContainsString('#my-articles-wrapper-42.my-articles-grid .my-article-item .article-title-wrapper,', $css);
+        $this->assertStringContainsString('#my-articles-wrapper-42.my-articles-slideshow .my-article-item .article-title-wrapper,', $css);
+        $this->assertStringContainsString('#my-articles-wrapper-42.my-articles-list .my-article-item .article-content-wrapper { background-color: #112233; }', $css);
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -37,6 +37,60 @@ if (!function_exists('add_action')) {
     }
 }
 
+if (!function_exists('sanitize_hex_color')) {
+    function sanitize_hex_color($color)
+    {
+        if (!is_string($color)) {
+            return '';
+        }
+
+        $color = trim($color);
+
+        if (preg_match('/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/', $color) === 1) {
+            return strtolower($color);
+        }
+
+        return '';
+    }
+}
+
+if (!function_exists('wp_add_inline_style')) {
+    function wp_add_inline_style($handle, $data)
+    {
+        global $mon_articles_inline_styles;
+
+        if (!isset($mon_articles_inline_styles)) {
+            $mon_articles_inline_styles = array();
+        }
+
+        if (!isset($mon_articles_inline_styles[$handle])) {
+            $mon_articles_inline_styles[$handle] = array();
+        }
+
+        $mon_articles_inline_styles[$handle][] = $data;
+
+        return true;
+    }
+}
+
+if (!function_exists('get_option')) {
+    function get_option($name, $default = false)
+    {
+        return $default;
+    }
+}
+
+if (!function_exists('sanitize_title')) {
+    function sanitize_title($title)
+    {
+        $title = strtolower((string) $title);
+        $title = preg_replace('/[^a-z0-9]+/', '-', $title);
+        $title = trim((string) $title, '-');
+
+        return (string) $title;
+    }
+}
+
 if (!function_exists('wp_parse_args')) {
     function wp_parse_args($args, $defaults = array())
     {
@@ -112,3 +166,5 @@ if (!class_exists('WP_Query')) {
 }
 
 require_once __DIR__ . '/../mon-affichage-article/mon-affichage-articles.php';
+require_once __DIR__ . '/../mon-affichage-article/includes/helpers.php';
+require_once __DIR__ . '/../mon-affichage-article/includes/class-my-articles-shortcode.php';


### PR DESCRIPTION
## Summary
- update the inline CSS selectors to target display-mode classes applied to the wrapper element
- stub WordPress helpers in the test bootstrap and add coverage for the title wrapper background color across display modes

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d66fa79cd8832ea5e94f6b3f264177