### PR TITLE
Add regression test for shortcode inline styles

### DIFF
--- a/tests/RenderInlineStylesTest.php
+++ b/tests/RenderInlineStylesTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MonAffichageArticles\Tests;
+
+use My_Articles_Shortcode;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class RenderInlineStylesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        global $wp_styles;
+
+        $wp_styles = new \WP_Styles();
+    }
+
+    public function test_render_inline_styles_records_scoped_css(): void
+    {
+        $options = array(
+            'module_bg_color' => '#123456',
+            'vignette_bg_color' => '#654321',
+            'title_wrapper_bg_color' => '#ABCDEF',
+        );
+
+        $reflection = new ReflectionClass(My_Articles_Shortcode::class);
+        $instance = $reflection->newInstanceWithoutConstructor();
+        $method = $reflection->getMethod('render_inline_styles');
+        $method->setAccessible(true);
+
+        $method->invoke($instance, $options, 321);
+
+        global $wp_styles;
+
+        $this->assertArrayHasKey('my-articles-styles', $wp_styles->inline_styles);
+        $this->assertNotEmpty($wp_styles->inline_styles['my-articles-styles']);
+
+        $css = implode("\n", $wp_styles->inline_styles['my-articles-styles']);
+
+        $this->assertStringContainsString('#my-articles-wrapper-321 {', $css);
+        $this->assertStringContainsString('background-color: #123456;', $css);
+        $this->assertStringContainsString('#my-articles-wrapper-321 .my-article-item { background-color: #654321; }', $css);
+        $this->assertStringContainsString('#my-articles-wrapper-321 .my-articles-grid .my-article-item .article-title-wrapper,', $css);
+        $this->assertStringContainsString('#my-articles-wrapper-321 .my-articles-slideshow .my-article-item .article-title-wrapper,', $css);
+        $this->assertStringContainsString('#my-articles-wrapper-321 .my-articles-list .my-article-item .article-content-wrapper { background-color: #abcdef; }', $css);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,10 +30,83 @@ if (!function_exists('plugin_dir_url')) {
     }
 }
 
+if (!function_exists('sanitize_hex_color')) {
+    function sanitize_hex_color($color)
+    {
+        if (!is_string($color)) {
+            return null;
+        }
+
+        $color = trim($color);
+
+        if ('' === $color || '#' !== $color[0]) {
+            return null;
+        }
+
+        $hex = substr($color, 1);
+
+        if (!preg_match('/^([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/', $hex)) {
+            return null;
+        }
+
+        return '#' . strtolower($hex);
+    }
+}
+
 if (!function_exists('add_action')) {
     function add_action(...$args): void
     {
         // No-op for tests.
+    }
+}
+
+if (!function_exists('get_option')) {
+    function get_option(string $option, $default = false)
+    {
+        return $default;
+    }
+}
+
+if (!class_exists('WP_Styles')) {
+    class WP_Styles
+    {
+        /** @var array<string, array<int, string>> */
+        public array $inline_styles = array();
+
+        public function add_inline_style(string $handle, string $data): bool
+        {
+            if ('' === $handle) {
+                return false;
+            }
+
+            if (!isset($this->inline_styles[$handle])) {
+                $this->inline_styles[$handle] = array();
+            }
+
+            $this->inline_styles[$handle][] = $data;
+
+            return true;
+        }
+    }
+}
+
+if (!function_exists('wp_styles')) {
+    function wp_styles(): WP_Styles
+    {
+        global $wp_styles;
+
+        if (!$wp_styles instanceof WP_Styles) {
+            $wp_styles = new WP_Styles();
+        }
+
+        return $wp_styles;
+    }
+}
+
+if (!function_exists('wp_add_inline_style')) {
+    function wp_add_inline_style(string $handle, string $data): bool
+    {
+        return wp_styles()->add_inline_style($handle, $data);
     }
 }
 
@@ -112,3 +185,5 @@ if (!class_exists('WP_Query')) {
 }
 
 require_once __DIR__ . '/../mon-affichage-article/mon-affichage-articles.php';
+require_once __DIR__ . '/../mon-affichage-article/includes/helpers.php';
+require_once __DIR__ . '/../mon-affichage-article/includes/class-my-articles-shortcode.php';


### PR DESCRIPTION
## Summary
- add lightweight wp_add_inline_style scaffolding in the test bootstrap so inline CSS can be captured
- add a RenderInlineStylesTest that verifies wrapper-scoped selectors receive the configured colors

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d66fa80ad8832e8dbeecbb8a9c7315