### PR TITLE
Scope inline styles to wrapper display classes

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -1308,9 +1308,9 @@ class My_Articles_Shortcode {
             padding-right: {$module_padding_right}px;
         }
         #my-articles-wrapper-{$id} .my-article-item { background-color: {$vignette_bg_color}; }
-        #my-articles-wrapper-{$id} .my-articles-grid .my-article-item .article-title-wrapper,
-        #my-articles-wrapper-{$id} .my-articles-slideshow .my-article-item .article-title-wrapper,
-        #my-articles-wrapper-{$id} .my-articles-list .my-article-item .article-content-wrapper { background-color: {$title_wrapper_bg}; }
+        #my-articles-wrapper-{$id}.my-articles-grid .my-article-item .article-title-wrapper,
+        #my-articles-wrapper-{$id}.my-articles-slideshow .my-article-item .article-title-wrapper,
+        #my-articles-wrapper-{$id}.my-articles-list .my-article-item .article-content-wrapper { background-color: {$title_wrapper_bg}; }
         ";
 
         wp_add_inline_style( 'my-articles-styles', $dynamic_css );

--- a/tests/RenderInlineStylesTest.php
+++ b/tests/RenderInlineStylesTest.php
@@ -44,8 +44,8 @@ final class RenderInlineStylesTest extends TestCase
         $this->assertStringContainsString('#my-articles-wrapper-321 {', $css);
         $this->assertStringContainsString('background-color: #123456;', $css);
         $this->assertStringContainsString('#my-articles-wrapper-321 .my-article-item { background-color: #654321; }', $css);
-        $this->assertStringContainsString('#my-articles-wrapper-321 .my-articles-grid .my-article-item .article-title-wrapper,', $css);
-        $this->assertStringContainsString('#my-articles-wrapper-321 .my-articles-slideshow .my-article-item .article-title-wrapper,', $css);
-        $this->assertStringContainsString('#my-articles-wrapper-321 .my-articles-list .my-article-item .article-content-wrapper { background-color: #abcdef; }', $css);
+        $this->assertStringContainsString('#my-articles-wrapper-321.my-articles-grid .my-article-item .article-title-wrapper,', $css);
+        $this->assertStringContainsString('#my-articles-wrapper-321.my-articles-slideshow .my-article-item .article-title-wrapper,', $css);
+        $this->assertStringContainsString('#my-articles-wrapper-321.my-articles-list .my-article-item .article-content-wrapper { background-color: #abcdef; }', $css);
     }
 }


### PR DESCRIPTION
## Summary
- scope the inline style selectors for grid, slideshow, and list displays to the wrapper element
- extend the inline style test to assert the updated selectors and background color output for every mode

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d675af5acc832e823db2c35228ee8f