### PR TITLE
Fix image loading attribute when lazy load disabled

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -1103,7 +1103,7 @@ class My_Articles_Shortcode {
             'class'    => 'attachment-large size-large wp-post-image',
             'alt'      => $title_attr,
             'decoding' => 'async',
-            'loading'  => 'lazy',
+            'loading'  => 'eager',
         );
 
         return wp_get_attachment_image( $image_id, $size, false, $attributes );

--- a/tests/RenderArticleItemTest.php
+++ b/tests/RenderArticleItemTest.php
@@ -49,5 +49,19 @@ final class RenderArticleItemTest extends TestCase
         $this->assertIsString($output);
         $this->assertStringNotContainsString('article-category', $output);
     }
+
+    public function test_thumbnail_loading_attribute_when_lazy_load_disabled(): void
+    {
+        $reflection = new \ReflectionClass(My_Articles_Shortcode::class);
+        $shortcode = $reflection->newInstanceWithoutConstructor();
+
+        $method = $reflection->getMethod('get_article_thumbnail_html');
+        $method->setAccessible(true);
+
+        $html = $method->invoke($shortcode, 456, 'Sample Title', false);
+
+        $this->assertStringContainsString('loading="eager"', $html);
+        $this->assertStringNotContainsString('loading="lazy"', $html);
+    }
 }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -229,6 +229,41 @@ if (!function_exists('has_post_thumbnail')) {
     }
 }
 
+if (!function_exists('wp_get_attachment_image_src')) {
+    function wp_get_attachment_image_src($attachment_id, $size = 'thumbnail')
+    {
+        return array('http://example.com/image-' . (int) $attachment_id . '.jpg', 800, 600);
+    }
+}
+
+if (!function_exists('wp_get_attachment_image_srcset')) {
+    function wp_get_attachment_image_srcset($attachment_id, $size = 'thumbnail')
+    {
+        return 'http://example.com/image-' . (int) $attachment_id . '-1x.jpg 1x';
+    }
+}
+
+if (!function_exists('wp_get_attachment_image')) {
+    function wp_get_attachment_image($attachment_id, $size = 'thumbnail', $icon = false, $attr = '')
+    {
+        $attributes_string = '';
+
+        if (is_array($attr)) {
+            foreach ($attr as $name => $value) {
+                if ('' === $name) {
+                    continue;
+                }
+
+                $attributes_string .= sprintf(' %s="%s"', esc_attr($name), esc_attr((string) $value));
+            }
+        }
+
+        $size_descriptor = is_array($size) ? 'custom' : (string) $size;
+
+        return sprintf('<img src="http://example.com/image-%d-%s.jpg"%s />', (int) $attachment_id, $size_descriptor, $attributes_string);
+    }
+}
+
 if (!function_exists('get_post_thumbnail_id')) {
     function get_post_thumbnail_id($post = null)
     {


### PR DESCRIPTION
## Summary
- set article thumbnail images to use eager loading when lazy loading is disabled
- add PHPUnit stubs for attachment image helpers and cover eager loading with a new unit test

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d7ce674128832eab396db6f676c87d