### PR TITLE
Ensure eager loading when lazy loading is disabled

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -1106,7 +1106,13 @@ class My_Articles_Shortcode {
             'loading'  => 'eager',
         );
 
-        return wp_get_attachment_image( $image_id, $size, false, $attributes );
+        $image_html = wp_get_attachment_image( $image_id, $size, false, $attributes );
+
+        if ( ! $enable_lazy_load && is_string( $image_html ) && '' !== $image_html && false !== strpos( $image_html, 'loading="lazy"' ) ) {
+            $image_html = str_replace( 'loading="lazy"', 'loading="eager"', $image_html );
+        }
+
+        return $image_html;
     }
 
     private function enqueue_swiper_scripts($options, $instance_id) {

--- a/tests/RenderArticleItemTest.php
+++ b/tests/RenderArticleItemTest.php
@@ -60,8 +60,22 @@ final class RenderArticleItemTest extends TestCase
 
         $html = $method->invoke($shortcode, 456, 'Sample Title', false);
 
-        $this->assertStringContainsString('loading="eager"', $html);
         $this->assertStringNotContainsString('loading="lazy"', $html);
+        $this->assertStringContainsString('loading="eager"', $html);
+    }
+
+    public function test_thumbnail_loading_attribute_when_lazy_load_enabled(): void
+    {
+        $reflection = new \ReflectionClass(My_Articles_Shortcode::class);
+        $shortcode = $reflection->newInstanceWithoutConstructor();
+
+        $method = $reflection->getMethod('get_article_thumbnail_html');
+        $method->setAccessible(true);
+
+        $html = $method->invoke($shortcode, 789, 'Lazy Title', true);
+
+        $this->assertStringContainsString('loading="lazy"', $html);
+        $this->assertStringNotContainsString('loading="eager"', $html);
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure the shortcode replaces any lazy loading attribute with eager when lazy loading is disabled
- add coverage to verify eager loading or absence of the attribute when lazy loading is disabled and that lazy loading remains when enabled

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d7d2ab45f4832eba35908278d7742a