### PR TITLE
Enforce publication status for shortcode instances

### DIFF
--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -66,6 +66,21 @@ final class Mon_Affichage_Articles {
             wp_send_json_error( __( 'Type de contenu invalide pour cette instance.', 'mon-articles' ), 400 );
         }
 
+        $post_status      = get_post_status( $instance_id );
+        $allowed_statuses = My_Articles_Shortcode::get_allowed_instance_statuses( $instance_id );
+
+        if ( empty( $post_status ) || ! in_array( $post_status, $allowed_statuses, true ) ) {
+            $error_code = (int) apply_filters( 'my_articles_unpublished_instance_error_code', 404, $instance_id, $post_status );
+            if ( $error_code <= 0 ) {
+                $error_code = 404;
+            }
+
+            wp_send_json_error(
+                array( 'message' => __( 'Instance non publiée.', 'mon-articles' ) ),
+                $error_code
+            );
+        }
+
         return $post_type;
     }
 

--- a/tests/ShortcodeVisibilityTest.php
+++ b/tests/ShortcodeVisibilityTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MonAffichageArticles\Tests;
+
+use My_Articles_Shortcode;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class ShortcodeVisibilityTest extends TestCase
+{
+    /** @var mixed */
+    private $shortcodeInstanceBackup;
+
+    /** @var array<string, mixed> */
+    private array $normalizedOptionsCacheBackup = array();
+
+    /** @var array<string, mixed> */
+    private array $matchingPinnedCacheBackup = array();
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        global $mon_articles_test_post_type_map, $mon_articles_test_post_status_map;
+
+        $mon_articles_test_post_type_map   = array();
+        $mon_articles_test_post_status_map = array();
+
+        $reflection = new ReflectionClass(My_Articles_Shortcode::class);
+
+        $instanceProperty = $reflection->getProperty('instance');
+        $instanceProperty->setAccessible(true);
+        $this->shortcodeInstanceBackup = $instanceProperty->getValue();
+        $instanceProperty->setValue(null, null);
+
+        $normalizedProperty = $reflection->getProperty('normalized_options_cache');
+        $normalizedProperty->setAccessible(true);
+        $this->normalizedOptionsCacheBackup = $normalizedProperty->getValue();
+        $normalizedProperty->setValue(null, array());
+
+        $matchingProperty = $reflection->getProperty('matching_pinned_ids_cache');
+        $matchingProperty->setAccessible(true);
+        $this->matchingPinnedCacheBackup = $matchingProperty->getValue();
+        $matchingProperty->setValue(null, array());
+    }
+
+    protected function tearDown(): void
+    {
+        global $mon_articles_test_post_type_map, $mon_articles_test_post_status_map;
+
+        $reflection = new ReflectionClass(My_Articles_Shortcode::class);
+
+        $instanceProperty = $reflection->getProperty('instance');
+        $instanceProperty->setAccessible(true);
+        $instanceProperty->setValue(null, $this->shortcodeInstanceBackup);
+
+        $normalizedProperty = $reflection->getProperty('normalized_options_cache');
+        $normalizedProperty->setAccessible(true);
+        $normalizedProperty->setValue(null, $this->normalizedOptionsCacheBackup);
+
+        $matchingProperty = $reflection->getProperty('matching_pinned_ids_cache');
+        $matchingProperty->setAccessible(true);
+        $matchingProperty->setValue(null, $this->matchingPinnedCacheBackup);
+
+        $mon_articles_test_post_type_map   = array();
+        $mon_articles_test_post_status_map = array();
+
+        parent::tearDown();
+    }
+
+    public function test_render_shortcode_returns_empty_string_when_instance_unpublished(): void
+    {
+        global $mon_articles_test_post_type_map, $mon_articles_test_post_status_map;
+
+        $instanceId = 4321;
+
+        $mon_articles_test_post_type_map[$instanceId]   = 'mon_affichage';
+        $mon_articles_test_post_status_map[$instanceId] = 'draft';
+
+        $shortcode = My_Articles_Shortcode::get_instance();
+
+        $output = $shortcode->render_shortcode(array('id' => (string) $instanceId));
+
+        $this->assertSame('', $output);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -93,6 +93,98 @@ if (!function_exists('post_type_exists')) {
     }
 }
 
+if (!function_exists('apply_filters')) {
+    function apply_filters($hook, $value)
+    {
+        return $value;
+    }
+}
+
+if (!function_exists('get_post_type')) {
+    function get_post_type($post = null)
+    {
+        global $mon_articles_test_post_type_map;
+
+        if (!is_array($mon_articles_test_post_type_map)) {
+            return null;
+        }
+
+        $post_id = is_numeric($post) ? (int) $post : 0;
+
+        return $mon_articles_test_post_type_map[$post_id] ?? null;
+    }
+}
+
+if (!function_exists('get_post_status')) {
+    function get_post_status($post = null)
+    {
+        global $mon_articles_test_post_status_map;
+
+        if (!is_array($mon_articles_test_post_status_map)) {
+            return false;
+        }
+
+        $post_id = is_numeric($post) ? (int) $post : 0;
+
+        return $mon_articles_test_post_status_map[$post_id] ?? false;
+    }
+}
+
+if (!function_exists('get_post_meta')) {
+    function get_post_meta($post_id, $key = '', $single = false)
+    {
+        global $mon_articles_test_post_meta_map;
+
+        if (!is_array($mon_articles_test_post_meta_map)) {
+            return $single ? '' : array();
+        }
+
+        $post_id = (int) $post_id;
+
+        if (!isset($mon_articles_test_post_meta_map[$post_id])) {
+            return $single ? '' : array();
+        }
+
+        if ('' === $key) {
+            return $mon_articles_test_post_meta_map[$post_id];
+        }
+
+        $value = $mon_articles_test_post_meta_map[$post_id][$key] ?? ($single ? '' : array());
+
+        return $value;
+    }
+}
+
+if (!function_exists('shortcode_atts')) {
+    function shortcode_atts($pairs, $atts, $shortcode = '')
+    {
+        $atts = (array) $atts;
+        $out = array();
+
+        foreach ((array) $pairs as $name => $default) {
+            if (array_key_exists($name, $atts)) {
+                $out[$name] = $atts[$name];
+            } else {
+                $out[$name] = $default;
+            }
+            unset($atts[$name]);
+        }
+
+        foreach ($atts as $name => $value) {
+            $out[$name] = $value;
+        }
+
+        return $out;
+    }
+}
+
+if (!function_exists('add_shortcode')) {
+    function add_shortcode($tag, $callback): void
+    {
+        // No-op for tests.
+    }
+}
+
 if (!function_exists('sanitize_hex_color')) {
     function sanitize_hex_color($color)
     {


### PR DESCRIPTION
## Summary
- prevent the shortcode from rendering instances whose post status is not explicitly allowed
- reject AJAX requests for unpublished shortcode instances and expose a filterable HTTP status code
- extend the PHPUnit suite with status-aware fixtures and new coverage for unpublished instances

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d841230618832ea0433f6154a515f3