### PR TITLE
Paginate mon_affichage uninstall cleanup

### DIFF
--- a/mon-affichage-article/uninstall.php
+++ b/mon-affichage-article/uninstall.php
@@ -5,17 +5,26 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 
 delete_option( 'my_articles_options' );
 
-$posts = get_posts(
-    array(
-        'post_type'      => 'mon_affichage',
-        'posts_per_page' => -1,
-        'post_status'    => 'any',
-        'fields'         => 'ids',
-    )
+$query_args = array(
+    'post_type'      => 'mon_affichage',
+    'posts_per_page' => 100,
+    'post_status'    => 'any',
+    'fields'         => 'ids',
+    'no_found_rows'  => true,
 );
 
-if ( ! empty( $posts ) ) {
+while ( true ) {
+    $posts_query = new WP_Query( $query_args );
+    $posts       = $posts_query->posts;
+
+    if ( empty( $posts ) ) {
+        wp_reset_postdata();
+        break;
+    }
+
     foreach ( $posts as $post_id ) {
         wp_delete_post( $post_id, true );
     }
+
+    wp_reset_postdata();
 }


### PR DESCRIPTION
## Summary
- replace the uninstall get_posts call with a paginated WP_Query
- continue to hard-delete each mon_affichage post that is found

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d91e039d60832e8d32e4f6f679dd6d