### PR TITLE
Ensure "Tout" filter label is properly escaped

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -766,7 +766,7 @@ class My_Articles_Shortcode {
             echo '<nav class="my-articles-filter-nav ' . $alignment_class . '"><ul>';
             $default_cat   = $options['term'] ?? '';
             $is_all_active = '' === $default_cat || 'all' === $default_cat;
-            echo '<li class="' . ( $is_all_active ? 'active' : '' ) . '"><a href="#" data-category="all">' . __( 'Tout', 'mon-articles' ) . '</a></li>';
+            echo '<li class="' . ( $is_all_active ? 'active' : '' ) . '"><a href="#" data-category="all">' . esc_html__( 'Tout', 'mon-articles' ) . '</a></li>';
 
             foreach ( $available_categories as $category ) {
                 $is_active = ( $default_cat === $category->slug );


### PR DESCRIPTION
## Summary
- escape the "Tout" filter label using esc_html__ to prevent unescaped output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d91dfed330832e91be1788387b7124