### PR TITLE
Improve admin script loading for mon_affichage editor

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -23,46 +23,71 @@ class My_Articles_Metaboxes {
     }
 
     public function enqueue_admin_scripts( $hook ) {
-        if ( ('post.php' === $hook || 'post-new.php' === $hook) && 'mon_affichage' === get_post_type() ) {
-            wp_enqueue_style( 'wp-color-picker' );
-            wp_enqueue_style( 'select2-css', MY_ARTICLES_PLUGIN_URL . 'assets/vendor/select2/select2.min.css', [], '4.1.0-rc.0' );
-            
-            wp_enqueue_script( 'my-articles-admin-script', MY_ARTICLES_PLUGIN_URL . 'assets/js/admin.js', array( 'wp-color-picker' ), MY_ARTICLES_VERSION, true );
-            wp_enqueue_script( 'select2-js', MY_ARTICLES_PLUGIN_URL . 'assets/vendor/select2/select2.min.js', array('jquery'), '4.1.0-rc.0', true );
-            wp_enqueue_script( 'my-articles-admin-select2', MY_ARTICLES_PLUGIN_URL . 'assets/js/admin-select2.js', array('select2-js', 'jquery-ui-sortable'), MY_ARTICLES_VERSION, true );
-            wp_enqueue_script( 'my-articles-admin-options', MY_ARTICLES_PLUGIN_URL . 'assets/js/admin-options.js', array('jquery'), MY_ARTICLES_VERSION, true );
-            wp_enqueue_script( 'my-articles-dynamic-fields', MY_ARTICLES_PLUGIN_URL . 'assets/js/admin-dynamic-fields.js', array('jquery'), MY_ARTICLES_VERSION, true );
-
-            wp_localize_script(
-                'my-articles-admin-select2',
-                'myArticlesSelect2',
-                [
-                    'nonce'       => wp_create_nonce('my_articles_select2_nonce'),
-                    'placeholder' => esc_html__( 'Rechercher un contenu par son titre...', 'mon-articles' ),
-                ]
-            );
-            wp_localize_script(
-                'my-articles-dynamic-fields',
-                'myArticlesAdmin',
-                [
-                    'nonce'             => wp_create_nonce('my_articles_admin_nonce'),
-                    'allCategoriesText' => esc_html__( 'Toutes les catégories', 'mon-articles' ),
-                ]
-            );
-            wp_localize_script(
-                'my-articles-admin-options',
-                'myArticlesAdminOptions',
-                [
-                    'minColumnWidth'  => 240,
-                    'warningThreshold' => 960,
-                    'warningClass'    => 'my-articles-columns-warning--active',
-                    /* translators: 1: number of columns, 2: estimated width in pixels. */
-                    'warningMessage'  => esc_html__( 'Attention : %1$d colonnes nécessitent environ %2$spx de largeur. Réduisez le nombre de colonnes ou agrandissez la zone de contenu.', 'mon-articles' ),
-                    /* translators: 1: number of columns, 2: estimated width in pixels. */
-                    'infoMessage'     => esc_html__( 'Largeur estimée : %2$spx pour %1$d colonnes.', 'mon-articles' ),
-                ]
-            );
+        if ( 'post.php' !== $hook && 'post-new.php' !== $hook ) {
+            return;
         }
+
+        $post_type = '';
+
+        // Prefer the global $typenow when available.
+        if ( isset( $GLOBALS['typenow'] ) && is_string( $GLOBALS['typenow'] ) ) {
+            $post_type = $GLOBALS['typenow'];
+        }
+
+        if ( '' === $post_type && function_exists( 'get_current_screen' ) ) {
+            $screen = get_current_screen();
+
+            if ( $screen && isset( $screen->post_type ) ) {
+                $post_type = $screen->post_type;
+            }
+        }
+
+        if ( '' === $post_type && 'post.php' === $hook ) {
+            $post_type = (string) get_post_type();
+        }
+
+        if ( 'mon_affichage' !== $post_type ) {
+            return;
+        }
+
+        wp_enqueue_style( 'wp-color-picker' );
+        wp_enqueue_style( 'select2-css', MY_ARTICLES_PLUGIN_URL . 'assets/vendor/select2/select2.min.css', [], '4.1.0-rc.0' );
+
+        wp_enqueue_script( 'my-articles-admin-script', MY_ARTICLES_PLUGIN_URL . 'assets/js/admin.js', array( 'wp-color-picker' ), MY_ARTICLES_VERSION, true );
+        wp_enqueue_script( 'select2-js', MY_ARTICLES_PLUGIN_URL . 'assets/vendor/select2/select2.min.js', array('jquery'), '4.1.0-rc.0', true );
+        wp_enqueue_script( 'my-articles-admin-select2', MY_ARTICLES_PLUGIN_URL . 'assets/js/admin-select2.js', array('select2-js', 'jquery-ui-sortable'), MY_ARTICLES_VERSION, true );
+        wp_enqueue_script( 'my-articles-admin-options', MY_ARTICLES_PLUGIN_URL . 'assets/js/admin-options.js', array('jquery'), MY_ARTICLES_VERSION, true );
+        wp_enqueue_script( 'my-articles-dynamic-fields', MY_ARTICLES_PLUGIN_URL . 'assets/js/admin-dynamic-fields.js', array('jquery'), MY_ARTICLES_VERSION, true );
+
+        wp_localize_script(
+            'my-articles-admin-select2',
+            'myArticlesSelect2',
+            [
+                'nonce'       => wp_create_nonce('my_articles_select2_nonce'),
+                'placeholder' => esc_html__( 'Rechercher un contenu par son titre...', 'mon-articles' ),
+            ]
+        );
+        wp_localize_script(
+            'my-articles-dynamic-fields',
+            'myArticlesAdmin',
+            [
+                'nonce'             => wp_create_nonce('my_articles_admin_nonce'),
+                'allCategoriesText' => esc_html__( 'Toutes les catégories', 'mon-articles' ),
+            ]
+        );
+        wp_localize_script(
+            'my-articles-admin-options',
+            'myArticlesAdminOptions',
+            [
+                'minColumnWidth'  => 240,
+                'warningThreshold' => 960,
+                'warningClass'    => 'my-articles-columns-warning--active',
+                /* translators: 1: number of columns, 2: estimated width in pixels. */
+                'warningMessage'  => esc_html__( 'Attention : %1$d colonnes nécessitent environ %2$spx de largeur. Réduisez le nombre de colonnes ou agrandissez la zone de contenu.', 'mon-articles' ),
+                /* translators: 1: number of columns, 2: estimated width in pixels. */
+                'infoMessage'     => esc_html__( 'Largeur estimée : %2$spx pour %1$d colonnes.', 'mon-articles' ),
+            ]
+        );
     }
 
     public function add_admin_head_styles() {

--- a/tests/MyArticlesMetaboxesTest.php
+++ b/tests/MyArticlesMetaboxesTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+
+if (!function_exists('wp_enqueue_style')) {
+    /**
+     * @param string $handle
+     * @param string $src
+     * @param array<int, string> $deps
+     * @param string|bool $ver
+     * @param string $media
+     */
+    function wp_enqueue_style($handle, $src = '', $deps = array(), $ver = false, $media = 'all'): void
+    {
+        global $mon_articles_test_enqueued_styles;
+
+        if (!is_array($mon_articles_test_enqueued_styles)) {
+            $mon_articles_test_enqueued_styles = array();
+        }
+
+        $mon_articles_test_enqueued_styles[] = array(
+            'handle' => (string) $handle,
+            'src'    => (string) $src,
+            'deps'   => is_array($deps) ? array_values($deps) : array(),
+            'ver'    => is_string($ver) ? $ver : '',
+            'media'  => (string) $media,
+        );
+    }
+}
+
+if (!function_exists('wp_enqueue_script')) {
+    /**
+     * @param string $handle
+     * @param string $src
+     * @param array<int, string> $deps
+     * @param string|bool $ver
+     * @param bool $in_footer
+     */
+    function wp_enqueue_script($handle, $src = '', $deps = array(), $ver = false, $in_footer = false): void
+    {
+        global $mon_articles_test_enqueued_scripts;
+
+        if (!is_array($mon_articles_test_enqueued_scripts)) {
+            $mon_articles_test_enqueued_scripts = array();
+        }
+
+        $mon_articles_test_enqueued_scripts[] = array(
+            'handle'    => (string) $handle,
+            'src'       => (string) $src,
+            'deps'      => is_array($deps) ? array_values($deps) : array(),
+            'ver'       => is_string($ver) ? $ver : '',
+            'in_footer' => (bool) $in_footer,
+        );
+    }
+}
+
+if (!function_exists('wp_localize_script')) {
+    /**
+     * @param string $handle
+     * @param string $object_name
+     * @param array<string, mixed> $l10n
+     */
+    function wp_localize_script($handle, $object_name, $l10n): bool
+    {
+        global $mon_articles_test_localized_scripts;
+
+        if (!is_array($mon_articles_test_localized_scripts)) {
+            $mon_articles_test_localized_scripts = array();
+        }
+
+        $mon_articles_test_localized_scripts[] = array(
+            'handle'      => (string) $handle,
+            'object_name' => (string) $object_name,
+            'data'        => is_array($l10n) ? $l10n : array(),
+        );
+
+        return true;
+    }
+}
+
+if (!function_exists('wp_create_nonce')) {
+    function wp_create_nonce($action): string
+    {
+        return 'nonce-' . (string) $action;
+    }
+}
+
+if (!function_exists('get_current_screen')) {
+    function get_current_screen()
+    {
+        global $mon_articles_test_current_screen;
+
+        return $mon_articles_test_current_screen;
+    }
+}
+
+}
+
+namespace MonAffichageArticles\Tests {
+
+use My_Articles_Metaboxes;
+use PHPUnit\Framework\TestCase;
+
+final class MyArticlesMetaboxesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        global $mon_articles_test_enqueued_styles,
+            $mon_articles_test_enqueued_scripts,
+            $mon_articles_test_localized_scripts,
+            $mon_articles_test_current_screen,
+            $typenow;
+
+        if (!defined('MY_ARTICLES_VERSION')) {
+            define('MY_ARTICLES_VERSION', 'tests');
+        }
+
+        if (!defined('MY_ARTICLES_PLUGIN_URL')) {
+            define('MY_ARTICLES_PLUGIN_URL', 'http://example.com/wp-content/plugins/mon-affichage-articles/');
+        }
+
+        if (!class_exists(My_Articles_Metaboxes::class)) {
+            require_once dirname(__DIR__) . '/mon-affichage-article/includes/class-my-articles-metaboxes.php';
+        }
+
+        $mon_articles_test_enqueued_styles    = array();
+        $mon_articles_test_enqueued_scripts   = array();
+        $mon_articles_test_localized_scripts  = array();
+        $mon_articles_test_current_screen     = null;
+        $typenow                              = null;
+    }
+
+    public function test_enqueue_admin_scripts_loads_assets_for_new_mon_affichage_screen(): void
+    {
+        global $typenow,
+            $mon_articles_test_enqueued_styles,
+            $mon_articles_test_enqueued_scripts,
+            $mon_articles_test_localized_scripts;
+
+        $typenow = 'mon_affichage';
+
+        $metaboxes = My_Articles_Metaboxes::get_instance();
+        $metaboxes->enqueue_admin_scripts('post-new.php');
+
+        $style_handles = array_map(
+            static fn (array $item): string => $item['handle'] ?? '',
+            $mon_articles_test_enqueued_styles
+        );
+
+        $script_handles = array_map(
+            static fn (array $item): string => $item['handle'] ?? '',
+            $mon_articles_test_enqueued_scripts
+        );
+
+        $localized_handles = array_map(
+            static fn (array $item): string => $item['handle'] ?? '',
+            $mon_articles_test_localized_scripts
+        );
+
+        self::assertSame(
+            array('wp-color-picker', 'select2-css'),
+            $style_handles,
+            'Expected admin styles to be enqueued for the mon_affichage screen.'
+        );
+
+        self::assertSame(
+            array(
+                'my-articles-admin-script',
+                'select2-js',
+                'my-articles-admin-select2',
+                'my-articles-admin-options',
+                'my-articles-dynamic-fields',
+            ),
+            $script_handles,
+            'Expected admin scripts to be enqueued for the mon_affichage screen.'
+        );
+
+        sort($localized_handles);
+
+        self::assertSame(
+            array(
+                'my-articles-admin-options',
+                'my-articles-admin-select2',
+                'my-articles-dynamic-fields',
+            ),
+            $localized_handles,
+            'Expected localization data to be attached to the required handles.'
+        );
+    }
+}
+
+}
+


### PR DESCRIPTION
## Summary
- refine the metabox admin enqueue routine to detect the mon_affichage post type using $typenow, the current screen, and a post.php fallback
- add a PHPUnit test to confirm the required assets load on the post-new.php?post_type=mon_affichage screen

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d920fae048832e820ecf0adcb1b595