### PR TITLE
Reset postdata after rendering shortcode queries

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -921,6 +921,10 @@ class My_Articles_Shortcode {
             $this->render_empty_state_message();
         }
 
+        if ( $pinned_query instanceof WP_Query || $regular_query instanceof WP_Query ) {
+            wp_reset_postdata();
+        }
+
         return $displayed_pinned_ids;
     }
 

--- a/tests/RenderArticlesContainerTest.php
+++ b/tests/RenderArticlesContainerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MonAffichageArticles\Tests;
+
+use My_Articles_Shortcode;
+use PHPUnit\Framework\TestCase;
+
+final class RenderArticlesContainerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        global $mon_articles_test_wp_reset_postdata_callback, $post;
+
+        $mon_articles_test_wp_reset_postdata_callback = null;
+        $post = null;
+    }
+
+    /**
+     * @dataProvider renderMethodProvider
+     */
+    public function test_render_methods_reset_global_post(string $methodName): void
+    {
+        global $post, $mon_articles_test_wp_reset_postdata_callback;
+
+        $initial_post = (object) array('ID' => 999);
+        $post = $initial_post;
+
+        $mon_articles_test_wp_reset_postdata_callback = static function () use ($initial_post): void {
+            global $post;
+            $post = $initial_post;
+        };
+
+        $reflection = new \ReflectionClass(My_Articles_Shortcode::class);
+        $shortcode = $reflection->newInstanceWithoutConstructor();
+
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        $pinned_query = new \WP_Query(
+            array(
+                array('ID' => 101),
+            )
+        );
+
+        $options = array(
+            'display_mode'      => 'list',
+            'show_category'     => false,
+            'show_author'       => false,
+            'show_date'         => false,
+            'show_excerpt'      => false,
+            'resolved_taxonomy' => '',
+            'enable_lazy_load'  => false,
+            'pinned_show_badge' => false,
+        );
+
+        if ('render_grid' === $methodName) {
+            $options['display_mode'] = 'grid';
+        }
+
+        ob_start();
+        $method->invoke($shortcode, $pinned_query, null, $options, 0);
+        ob_end_clean();
+
+        $this->assertSame($initial_post, $post);
+    }
+
+    /**
+     * @return array<int, array{string}>
+     */
+    public function renderMethodProvider(): array
+    {
+        return array(
+            array('render_list'),
+            array('render_grid'),
+        );
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -472,7 +472,11 @@ if (!function_exists('wp_trim_words')) {
 if (!function_exists('wp_reset_postdata')) {
     function wp_reset_postdata(): void
     {
-        // No-op for tests.
+        global $mon_articles_test_wp_reset_postdata_callback;
+
+        if (is_callable($mon_articles_test_wp_reset_postdata_callback)) {
+            call_user_func($mon_articles_test_wp_reset_postdata_callback);
+        }
     }
 }
 
@@ -533,16 +537,17 @@ if (!class_exists('WP_Query')) {
 
         public function the_post(): void
         {
-            global $mon_articles_test_current_post_id;
+            global $mon_articles_test_current_post_id, $post;
 
             if (!$this->have_posts()) {
                 return;
             }
 
-            $post = $this->posts[$this->current_index];
+            $post_data = $this->posts[$this->current_index];
             $this->current_index++;
 
-            $mon_articles_test_current_post_id = isset($post['ID']) ? (int) $post['ID'] : 0;
+            $mon_articles_test_current_post_id = isset($post_data['ID']) ? (int) $post_data['ID'] : 0;
+            $post = is_array($post_data) ? (object) $post_data : $post_data;
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure the shortcode container resets postdata after rendering WP_Query results
- update the test bootstrap to expose postdata reset callbacks and simulate global $post updates
- add coverage confirming the list and grid renderers leave the global $post unchanged

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d99f718e90832eac3e7cec1994e455