### PR TITLE
Handle unlimited slideshow batches and add test coverage

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -703,7 +703,7 @@ class My_Articles_Shortcode {
             array(
                 'paged'                   => $paged,
                 'pagination_strategy'     => 'page',
-                'enforce_unlimited_batch' => ! empty( $options['is_unlimited'] ),
+                'enforce_unlimited_batch' => ! empty( $options['is_unlimited'] ) && 'slideshow' !== $options['display_mode'],
             )
         );
 
@@ -778,14 +778,10 @@ class My_Articles_Shortcode {
         $displayed_pinned_ids = array();
 
         $posts_per_page_for_render    = $render_limit > 0 ? $render_limit : $effective_posts_per_page;
-        $posts_per_page_for_slideshow = $effective_posts_per_page;
+        $posts_per_page_for_slideshow = $is_unlimited ? 0 : $effective_posts_per_page;
 
         if ( $is_unlimited && 0 === $posts_per_page_for_render ) {
             $posts_per_page_for_render = 0;
-        }
-
-        if ( $is_unlimited && 0 === $posts_per_page_for_slideshow ) {
-            $posts_per_page_for_slideshow = 0;
         }
 
         if ($options['display_mode'] === 'slideshow') {

--- a/tests/SlideshowUnlimitedRenderingTest.php
+++ b/tests/SlideshowUnlimitedRenderingTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+
+if (!function_exists('wp_enqueue_style')) {
+    function wp_enqueue_style($handle, $src = '', $deps = array(), $ver = false, $media = 'all'): void
+    {
+        // No-op for tests.
+    }
+}
+
+if (!function_exists('wp_enqueue_script')) {
+    function wp_enqueue_script($handle, $src = '', $deps = array(), $ver = false, $in_footer = false): void
+    {
+        // No-op for tests.
+    }
+}
+
+if (!function_exists('wp_localize_script')) {
+    function wp_localize_script($handle, $object_name, $l10n): bool
+    {
+        return true;
+    }
+}
+
+if (!function_exists('wp_create_nonce')) {
+    function wp_create_nonce($action): string
+    {
+        return 'nonce-' . (string) $action;
+    }
+}
+
+if (!function_exists('admin_url')) {
+    function admin_url($path = '', $scheme = 'admin'): string
+    {
+        $path = ltrim((string) $path, '/');
+
+        return 'http://example.com/wp-admin/' . $path;
+    }
+}
+}
+
+namespace MonAffichageArticles\Tests {
+
+use My_Articles_Shortcode;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class SlideshowUnlimitedRenderingTest extends TestCase
+{
+    /** @var mixed */
+    private $shortcodeInstanceBackup;
+
+    /** @var array<string, mixed> */
+    private array $normalizedOptionsCacheBackup = array();
+
+    /** @var array<string, mixed> */
+    private array $matchingPinnedCacheBackup = array();
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        global $mon_articles_test_post_type_map,
+            $mon_articles_test_post_status_map,
+            $mon_articles_test_post_meta_map,
+            $mon_articles_test_wp_query_factory;
+
+        $mon_articles_test_post_type_map   = array();
+        $mon_articles_test_post_status_map = array();
+        $mon_articles_test_post_meta_map   = array();
+        $mon_articles_test_wp_query_factory = null;
+
+        $reflection = new ReflectionClass(My_Articles_Shortcode::class);
+
+        $instanceProperty = $reflection->getProperty('instance');
+        $instanceProperty->setAccessible(true);
+        $this->shortcodeInstanceBackup = $instanceProperty->getValue();
+        $instanceProperty->setValue(null, null);
+
+        $normalizedProperty = $reflection->getProperty('normalized_options_cache');
+        $normalizedProperty->setAccessible(true);
+        $this->normalizedOptionsCacheBackup = $normalizedProperty->getValue();
+        $normalizedProperty->setValue(null, array());
+
+        $matchingProperty = $reflection->getProperty('matching_pinned_ids_cache');
+        $matchingProperty->setAccessible(true);
+        $this->matchingPinnedCacheBackup = $matchingProperty->getValue();
+        $matchingProperty->setValue(null, array());
+    }
+
+    protected function tearDown(): void
+    {
+        global $mon_articles_test_post_type_map,
+            $mon_articles_test_post_status_map,
+            $mon_articles_test_post_meta_map,
+            $mon_articles_test_wp_query_factory;
+
+        $mon_articles_test_post_type_map   = array();
+        $mon_articles_test_post_status_map = array();
+        $mon_articles_test_post_meta_map   = array();
+        $mon_articles_test_wp_query_factory = null;
+
+        $reflection = new ReflectionClass(My_Articles_Shortcode::class);
+
+        $instanceProperty = $reflection->getProperty('instance');
+        $instanceProperty->setAccessible(true);
+        $instanceProperty->setValue(null, $this->shortcodeInstanceBackup);
+
+        $normalizedProperty = $reflection->getProperty('normalized_options_cache');
+        $normalizedProperty->setAccessible(true);
+        $normalizedProperty->setValue(null, $this->normalizedOptionsCacheBackup);
+
+        $matchingProperty = $reflection->getProperty('matching_pinned_ids_cache');
+        $matchingProperty->setAccessible(true);
+        $matchingProperty->setValue(null, $this->matchingPinnedCacheBackup);
+
+        parent::tearDown();
+    }
+
+    public function test_slideshow_unlimited_renders_all_posts(): void
+    {
+        global $mon_articles_test_post_type_map,
+            $mon_articles_test_post_status_map,
+            $mon_articles_test_post_meta_map,
+            $mon_articles_test_wp_query_factory;
+
+        $instanceId = 2468;
+
+        $pinnedPosts = array(
+            array('ID' => 501),
+            array('ID' => 502),
+        );
+
+        $regularPosts = array(
+            array('ID' => 601),
+            array('ID' => 602),
+            array('ID' => 603),
+        );
+
+        $mon_articles_test_post_type_map = array(
+            $instanceId => 'mon_affichage',
+            501 => 'post',
+            502 => 'post',
+            601 => 'post',
+            602 => 'post',
+            603 => 'post',
+        );
+
+        $mon_articles_test_post_status_map = array(
+            $instanceId => 'publish',
+        );
+
+        $mon_articles_test_post_meta_map = array(
+            $instanceId => array(
+                '_my_articles_settings' => array(
+                    'display_mode'          => 'slideshow',
+                    'posts_per_page'        => 0,
+                    'pagination_mode'       => 'none',
+                    'pinned_posts'          => array(501, 502),
+                    'show_category_filter'  => 0,
+                    'enable_lazy_load'      => 0,
+                    'show_category'         => 0,
+                    'show_author'           => 0,
+                    'show_date'             => 0,
+                    'show_excerpt'          => 0,
+                ),
+            ),
+        );
+
+        $mon_articles_test_wp_query_factory = static function (array $args) use ($pinnedPosts, $regularPosts) {
+            if (!empty($args['post__in'])) {
+                $posts = $pinnedPosts;
+
+                if (isset($args['fields']) && 'ids' === $args['fields']) {
+                    $posts = array_map(
+                        static function (array $post): int {
+                            return isset($post['ID']) ? (int) $post['ID'] : 0;
+                        },
+                        $pinnedPosts
+                    );
+                }
+                return array(
+                    'posts'       => $posts,
+                    'found_posts' => count($pinnedPosts),
+                );
+            }
+
+            return array(
+                'posts'       => $regularPosts,
+                'found_posts' => count($regularPosts),
+            );
+        };
+
+        $shortcode = My_Articles_Shortcode::get_instance();
+
+        $html = $shortcode->render_shortcode(array('id' => (string) $instanceId));
+
+        $this->assertStringContainsString('swiper-wrapper', $html);
+        $expectedSlides = count($pinnedPosts) + count($regularPosts);
+        $this->assertSame($expectedSlides, substr_count($html, '<div class="swiper-slide">'));
+    }
+}
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -298,6 +298,23 @@ if (!function_exists('absint')) {
     }
 }
 
+if (!function_exists('wp_list_pluck')) {
+    function wp_list_pluck($input_list, $field)
+    {
+        $values = array();
+
+        foreach ((array) $input_list as $item) {
+            if (is_array($item) && array_key_exists($field, $item)) {
+                $values[] = $item[$field];
+            } elseif (is_object($item) && isset($item->{$field})) {
+                $values[] = $item->{$field};
+            }
+        }
+
+        return $values;
+    }
+}
+
 if (!function_exists('get_permalink')) {
     function get_permalink($post = null)
     {
@@ -493,7 +510,7 @@ if (!class_exists('WP_Query')) {
     class WP_Query
     {
         /** @var array<int, array<string, mixed>> */
-        private array $posts;
+        public array $posts;
 
         private int $current_index = 0;
 


### PR DESCRIPTION
## Summary
- avoid forcing unlimited batch caps when rendering slideshow shortcodes
- ensure slideshow rendering treats unlimited configurations as a zero post-per-page limit
- expose WP_Query posts to the test harness, add a slideshow regression test, and stub wp_list_pluck

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68da7a334400832ea102c0720289cac1