### PR TITLE
Allow slideshows to load all posts without forced pagination

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -489,7 +489,11 @@ class My_Articles_Shortcode {
         $unlimited_cap = (int) apply_filters( 'my_articles_unlimited_batch_size', 50, $options, $context );
         $options['unlimited_query_cap'] = max( 1, $unlimited_cap );
 
-        if ( $is_unlimited && ( $options['pagination_mode'] ?? 'none' ) === 'none' ) {
+        if (
+            $is_unlimited
+            && ( $options['pagination_mode'] ?? 'none' ) === 'none'
+            && 'slideshow' !== $options['display_mode']
+        ) {
             $options['pagination_mode'] = 'load_more';
         }
 
@@ -703,7 +707,7 @@ class My_Articles_Shortcode {
             array(
                 'paged'                   => $paged,
                 'pagination_strategy'     => 'page',
-                'enforce_unlimited_batch' => ! empty( $options['is_unlimited'] ),
+                'enforce_unlimited_batch' => ( ! empty( $options['is_unlimited'] ) && 'slideshow' !== $options['display_mode'] ),
             )
         );
 

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -242,7 +242,7 @@ final class Mon_Affichage_Articles {
             array(
                 'paged'                   => 1,
                 'pagination_strategy'     => 'page',
-                'enforce_unlimited_batch' => true,
+                'enforce_unlimited_batch' => ( ! empty( $options['is_unlimited'] ) && 'slideshow' !== $display_mode ),
             )
         );
 
@@ -390,7 +390,7 @@ final class Mon_Affichage_Articles {
                 'paged'                   => $paged,
                 'pagination_strategy'     => 'sequential',
                 'seen_pinned_ids'         => $seen_pinned_ids,
-                'enforce_unlimited_batch' => true,
+                'enforce_unlimited_batch' => ( ! empty( $options['is_unlimited'] ) && 'slideshow' !== $display_mode ),
             )
         );
 


### PR DESCRIPTION
## Summary
- stop forcing slideshow instances to switch to load-more pagination when using unlimited posts
- avoid passing the unlimited batch enforcement flag for slideshow rendering and AJAX endpoints so the full query executes

## Testing
- composer test *(fails: vendor/bin/phpunit not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dac8283af4832e9ed92b1121b31763