### PR TITLE
Clamp posts per page to UI limit

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -400,7 +400,9 @@ class My_Articles_Metaboxes {
         $sanitized['taxonomy'] = isset($input['taxonomy']) ? sanitize_key($input['taxonomy']) : '';
         $sanitized['term'] = isset($input['term']) ? sanitize_text_field( $input['term'] ) : '';
         $sanitized['counting_behavior'] = isset($input['counting_behavior']) && in_array($input['counting_behavior'], ['exact', 'auto_fill']) ? $input['counting_behavior'] : 'exact';
-        $sanitized['posts_per_page'] = isset( $input['posts_per_page'] ) ? max( 0, absint( $input['posts_per_page'] ) ) : 10;
+        $sanitized['posts_per_page'] = isset( $input['posts_per_page'] )
+            ? min( 50, max( 0, absint( $input['posts_per_page'] ) ) )
+            : 10;
         $sanitized['pagination_mode'] = isset($input['pagination_mode']) && in_array($input['pagination_mode'], ['none', 'load_more', 'numbered']) ? $input['pagination_mode'] : 'none';
         $sanitized['show_category_filter'] = isset( $input['show_category_filter'] ) ? 1 : 0;
         $sanitized['filter_alignment'] = isset($input['filter_alignment']) && in_array($input['filter_alignment'], ['left', 'center', 'right']) ? $input['filter_alignment'] : 'right';

--- a/mon-affichage-article/includes/class-my-articles-settings.php
+++ b/mon-affichage-article/includes/class-my-articles-settings.php
@@ -93,7 +93,9 @@ class My_Articles_Settings {
         $sanitized_input = [];
         $sanitized_input['display_mode'] = isset( $input['display_mode'] ) && in_array($input['display_mode'], ['grid', 'slideshow']) ? $input['display_mode'] : 'grid';
         $sanitized_input['default_category'] = isset( $input['default_category'] ) ? sanitize_text_field( $input['default_category'] ) : '';
-        $sanitized_input['posts_per_page'] = isset( $input['posts_per_page'] ) ? max( 0, absint( $input['posts_per_page'] ) ) : 10;
+        $sanitized_input['posts_per_page'] = isset( $input['posts_per_page'] )
+            ? min( 50, max( 0, absint( $input['posts_per_page'] ) ) )
+            : 10;
         $sanitized_input['desktop_columns'] = isset( $input['desktop_columns'] ) ? max( 1, absint( $input['desktop_columns'] ) ) : 3;
         $sanitized_input['mobile_columns'] = isset( $input['mobile_columns'] ) ? max( 1, absint( $input['mobile_columns'] ) ) : 1;
         $sanitized_input['gap_size'] = isset( $input['gap_size'] ) ? absint( $input['gap_size'] ) : 25;

--- a/tests/MyArticlesSettingsSanitizeTest.php
+++ b/tests/MyArticlesSettingsSanitizeTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MonAffichageArticles\Tests;
+
+use My_Articles_Settings;
+use My_Articles_Shortcode;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class MyArticlesSettingsSanitizeTest extends TestCase
+{
+    /** @var array<string, mixed> */
+    private array $normalizedOptionsCacheBackup = array();
+
+    public static function setUpBeforeClass(): void
+    {
+        if (!defined('MY_ARTICLES_VERSION')) {
+            define('MY_ARTICLES_VERSION', 'tests');
+        }
+
+        if (!defined('MY_ARTICLES_PLUGIN_URL')) {
+            define('MY_ARTICLES_PLUGIN_URL', 'http://example.com/wp-content/plugins/mon-affichage-articles/');
+        }
+
+        if (!class_exists(My_Articles_Settings::class)) {
+            require_once dirname(__DIR__) . '/mon-affichage-article/includes/class-my-articles-settings.php';
+        }
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->backupShortcodeCache();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreShortcodeCache();
+        parent::tearDown();
+    }
+
+    private function backupShortcodeCache(): void
+    {
+        $reflection = new ReflectionClass(My_Articles_Shortcode::class);
+        $property = $reflection->getProperty('normalized_options_cache');
+        $property->setAccessible(true);
+        $this->normalizedOptionsCacheBackup = (array) $property->getValue();
+        $property->setValue(null, array());
+    }
+
+    private function restoreShortcodeCache(): void
+    {
+        $reflection = new ReflectionClass(My_Articles_Shortcode::class);
+        $property = $reflection->getProperty('normalized_options_cache');
+        $property->setAccessible(true);
+        $property->setValue(null, $this->normalizedOptionsCacheBackup);
+    }
+
+    public function test_sanitize_caps_posts_per_page_at_ui_limit(): void
+    {
+        $settings = My_Articles_Settings::get_instance();
+        $result = $settings->sanitize(array('posts_per_page' => 120));
+
+        self::assertSame(
+            50,
+            $result['posts_per_page'] ?? null,
+            'The sanitize routine should clamp posts_per_page to the UI maximum.'
+        );
+    }
+
+    public function test_normalize_instance_options_treats_zero_as_unlimited(): void
+    {
+        $options = My_Articles_Shortcode::normalize_instance_options(
+            array('posts_per_page' => 0),
+            array('source' => __METHOD__)
+        );
+
+        self::assertTrue($options['is_unlimited'], 'A posts_per_page value of 0 should be treated as unlimited.');
+        self::assertSame(
+            -1,
+            $options['posts_per_page'],
+            'Unlimited instances should forward -1 to WP_Query.'
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- clamp the global posts_per_page option to the UI maximum when sanitizing settings
- enforce the same maximum when saving per-instance metabox values
- add PHPUnit coverage to ensure the limit applies while preserving the unlimited (0) behavior

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dad6ae8414832eb61ecfe39de5a013