### PR TITLE
Handle Swiper updates after loading more articles

### DIFF
--- a/mon-affichage-article/assets/js/load-more.js
+++ b/mon-affichage-article/assets/js/load-more.js
@@ -39,7 +39,7 @@
         var button = $(this);
         var wrapper = button.closest('.my-articles-wrapper');
         // CORRECTION : On cible le conteneur de la grille OU de la liste
-        var contentArea = wrapper.find('.my-articles-grid-content, .my-articles-list-content');
+        var contentArea = wrapper.find('.my-articles-grid-content, .my-articles-list-content, .swiper-wrapper');
 
         var originalButtonText = button.data('original-text');
         if (!originalButtonText) {
@@ -83,6 +83,54 @@
                     // Ajoute les nouveaux articles à la suite des anciens
                     if (typeof responseData.html !== 'undefined') {
                         contentArea.append(responseData.html);
+
+                        if (wrapper.hasClass('my-articles-slideshow')) {
+                            var swiperInstance = null;
+
+                            if (typeof window.mySwiperInstances !== 'undefined' && instanceId && window.mySwiperInstances[instanceId]) {
+                                swiperInstance = window.mySwiperInstances[instanceId];
+                            }
+
+                            if (!swiperInstance || typeof swiperInstance.update !== 'function') {
+                                var settingsObjectName = 'myArticlesSwiperSettings_' + instanceId;
+
+                                if (typeof window[settingsObjectName] !== 'undefined') {
+                                    var settings = window[settingsObjectName];
+
+                                    window.mySwiperInstances = window.mySwiperInstances || {};
+                                    swiperInstance = new Swiper(settings.container_selector, {
+                                        slidesPerView: settings.columns_mobile,
+                                        spaceBetween: settings.gap_size,
+                                        loop: true,
+                                        pagination: {
+                                            el: settings.container_selector + ' .swiper-pagination',
+                                            clickable: true,
+                                        },
+                                        navigation: {
+                                            nextEl: settings.container_selector + ' .swiper-button-next',
+                                            prevEl: settings.container_selector + ' .swiper-button-prev',
+                                        },
+                                        breakpoints: {
+                                            768: { slidesPerView: settings.columns_tablet, spaceBetween: settings.gap_size },
+                                            1024: { slidesPerView: settings.columns_desktop, spaceBetween: settings.gap_size },
+                                            1536: { slidesPerView: settings.columns_ultrawide, spaceBetween: settings.gap_size }
+                                        },
+                                        on: {
+                                            init: function () {
+                                                var mainWrapper = document.querySelector('#my-articles-wrapper-' + instanceId);
+                                                if (mainWrapper) {
+                                                    mainWrapper.classList.add('swiper-initialized');
+                                                }
+                                            }
+                                        }
+                                    });
+
+                                    window.mySwiperInstances[instanceId] = swiperInstance;
+                                }
+                            } else {
+                                swiperInstance.update();
+                            }
+                        }
                     }
 
                     if (typeof responseData.pinned_ids !== 'undefined') {


### PR DESCRIPTION
## Summary
- include the slideshow wrapper in the load-more content area
- refresh or recreate the Swiper instance after new slides are appended

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dbfb90e1cc832e9c45f092c9c21a7f