### PR TITLE
Add Gutenberg block for articles module

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,21 @@ Utiliser le shortcode :
 [mon_affichage_articles id="123"]
 ```
 
+## Utilisation dans l'éditeur de blocs
+
+1. Depuis l'éditeur Gutenberg, ajouter le bloc **Tuiles – LCV**.
+2. Sélectionner l'instance `mon_affichage` à afficher via le panneau latéral.
+3. Ajuster les principaux réglages (mode d'affichage, filtres, pagination...) depuis les contrôles du bloc.
+
+### Attributs disponibles dans l'éditeur
+
+- **display_mode** (`grid`, `list`, `slideshow`)
+- **posts_per_page** (nombre d'articles, `0` pour illimité)
+- **pagination_mode** (`none`, `load_more`, `numbered`)
+- **show_category_filter** (activation du filtre par taxonomie et alignement associé)
+- **show_category**, **show_author**, **show_date** (affichage des métadonnées)
+- **show_excerpt** et **excerpt_length** (affichage et longueur de l'extrait)
+
 Options principales :
 
 - **Filtre de catégorie** : afficher une liste de catégories si l'option est activée.

--- a/mon-affichage-article/blocks/mon-affichage-articles/block.json
+++ b/mon-affichage-article/blocks/mon-affichage-articles/block.json
@@ -1,0 +1,66 @@
+{
+    "apiVersion": 2,
+    "name": "mon-affichage/articles",
+    "title": "Tuiles – LCV",
+    "category": "widgets",
+    "icon": "screenoptions",
+    "description": "Afficher un module Tuiles – LCV directement dans l’éditeur de blocs.",
+    "keywords": [
+        "articles",
+        "tuiles",
+        "lcv"
+    ],
+    "textdomain": "mon-articles",
+    "supports": {
+        "html": false
+    },
+    "attributes": {
+        "instanceId": {
+            "type": "integer",
+            "default": 0
+        },
+        "display_mode": {
+            "type": "string",
+            "default": "grid"
+        },
+        "posts_per_page": {
+            "type": "integer",
+            "default": 10
+        },
+        "show_category_filter": {
+            "type": "boolean",
+            "default": false
+        },
+        "filter_alignment": {
+            "type": "string",
+            "default": "right"
+        },
+        "pagination_mode": {
+            "type": "string",
+            "default": "none"
+        },
+        "show_excerpt": {
+            "type": "boolean",
+            "default": false
+        },
+        "excerpt_length": {
+            "type": "integer",
+            "default": 25
+        },
+        "show_author": {
+            "type": "boolean",
+            "default": true
+        },
+        "show_date": {
+            "type": "boolean",
+            "default": true
+        },
+        "show_category": {
+            "type": "boolean",
+            "default": true
+        }
+    },
+    "editorScript": "file:./edit.js",
+    "editorStyle": "file:./editor.css",
+    "style": "file:./style.css"
+}

--- a/mon-affichage-article/blocks/mon-affichage-articles/edit.asset.php
+++ b/mon-affichage-article/blocks/mon-affichage-articles/edit.asset.php
@@ -1,0 +1,13 @@
+<?php
+return array(
+    'dependencies' => array(
+        'wp-blocks',
+        'wp-element',
+        'wp-components',
+        'wp-block-editor',
+        'wp-data',
+        'wp-i18n',
+        'wp-server-side-render',
+    ),
+    'version'      => defined( 'MY_ARTICLES_VERSION' ) ? MY_ARTICLES_VERSION : '1.0.0',
+);

--- a/mon-affichage-article/blocks/mon-affichage-articles/edit.js
+++ b/mon-affichage-article/blocks/mon-affichage-articles/edit.js
@@ -1,0 +1,242 @@
+(function (wp) {
+    var __ = wp.i18n.__;
+    var registerBlockType = wp.blocks.registerBlockType;
+    var InspectorControls = wp.blockEditor ? wp.blockEditor.InspectorControls : wp.editor.InspectorControls;
+    var useBlockProps = wp.blockEditor ? wp.blockEditor.useBlockProps : function () {
+        return {};
+    };
+    var PanelBody = wp.components.PanelBody;
+    var SelectControl = wp.components.SelectControl;
+    var ToggleControl = wp.components.ToggleControl;
+    var RangeControl = wp.components.RangeControl;
+    var Placeholder = wp.components.Placeholder;
+    var Spinner = wp.components.Spinner;
+    var Notice = wp.components.Notice;
+    var Fragment = wp.element.Fragment;
+    var el = wp.element.createElement;
+    var useSelect = wp.data.useSelect;
+    var ServerSideRender = wp.serverSideRender;
+
+    var MODULE_QUERY = {
+        per_page: 100,
+        orderby: 'title',
+        order: 'asc',
+        status: 'publish',
+        context: 'view',
+    };
+
+    registerBlockType('mon-affichage/articles', {
+        edit: function (props) {
+            var attributes = props.attributes;
+            var setAttributes = props.setAttributes;
+            var blockProps = useBlockProps({ className: 'my-articles-block' });
+
+            var data = useSelect(function (select) {
+                var core = select('core');
+                var dataStore = select('core/data');
+
+                return {
+                    instances: core.getEntityRecords('postType', 'mon_affichage', MODULE_QUERY),
+                    isResolving: dataStore.isResolving('core', 'getEntityRecords', ['postType', 'mon_affichage', MODULE_QUERY]),
+                    selectedInstance: attributes.instanceId ? core.getEntityRecord('postType', 'mon_affichage', attributes.instanceId) : null,
+                };
+            }, [attributes.instanceId]);
+
+            var instances = data && Array.isArray(data.instances) ? data.instances : [];
+            var instanceOptions = instances.map(function (post) {
+                var title = post && post.title && post.title.rendered ? post.title.rendered : __('(Sans titre)', 'mon-articles');
+                return { label: title, value: String(post.id) };
+            });
+            instanceOptions.unshift({ label: __('Sélectionner un module', 'mon-articles'), value: '0' });
+
+            var inspectorControls = el(
+                InspectorControls,
+                {},
+                el(
+                    PanelBody,
+                    { title: __('Module', 'mon-articles'), initialOpen: true },
+                    el(SelectControl, {
+                        label: __('Instance', 'mon-articles'),
+                        value: String(attributes.instanceId || 0),
+                        options: instanceOptions,
+                        onChange: function (value) {
+                            var parsed = parseInt(value, 10);
+                            setAttributes({ instanceId: parsed > 0 ? parsed : 0 });
+                        },
+                        help: __('Sélectionnez le contenu « mon_affichage » à afficher.', 'mon-articles'),
+                    })
+                ),
+                el(
+                    PanelBody,
+                    { title: __('Affichage', 'mon-articles'), initialOpen: false },
+                    el(SelectControl, {
+                        label: __('Mode d’affichage', 'mon-articles'),
+                        value: attributes.display_mode || 'grid',
+                        options: [
+                            { label: __('Grille', 'mon-articles'), value: 'grid' },
+                            { label: __('Liste', 'mon-articles'), value: 'list' },
+                            { label: __('Diaporama', 'mon-articles'), value: 'slideshow' },
+                        ],
+                        onChange: function (value) {
+                            setAttributes({ display_mode: value });
+                        },
+                    }),
+                    el(RangeControl, {
+                        label: __('Articles par page', 'mon-articles'),
+                        value: attributes.posts_per_page,
+                        min: 0,
+                        max: 24,
+                        allowReset: true,
+                        onChange: function (value) {
+                            if (typeof value !== 'number') {
+                                value = 0;
+                            }
+                            setAttributes({ posts_per_page: value });
+                        },
+                        help: __('Définissez 0 pour désactiver la limite.', 'mon-articles'),
+                    }),
+                    el(SelectControl, {
+                        label: __('Pagination', 'mon-articles'),
+                        value: attributes.pagination_mode || 'none',
+                        options: [
+                            { label: __('Aucune', 'mon-articles'), value: 'none' },
+                            { label: __('Bouton « Charger plus »', 'mon-articles'), value: 'load_more' },
+                            { label: __('Pagination numérotée', 'mon-articles'), value: 'numbered' },
+                        ],
+                        onChange: function (value) {
+                            setAttributes({ pagination_mode: value });
+                        },
+                    })
+                ),
+                el(
+                    PanelBody,
+                    { title: __('Méta-données', 'mon-articles'), initialOpen: false },
+                    el(ToggleControl, {
+                        label: __('Afficher le filtre de catégories', 'mon-articles'),
+                        checked: !!attributes.show_category_filter,
+                        onChange: function (value) {
+                            setAttributes({ show_category_filter: !!value });
+                        },
+                    }),
+                    el(SelectControl, {
+                        label: __('Alignement du filtre', 'mon-articles'),
+                        value: attributes.filter_alignment || 'right',
+                        options: [
+                            { label: __('Gauche', 'mon-articles'), value: 'left' },
+                            { label: __('Centre', 'mon-articles'), value: 'center' },
+                            { label: __('Droite', 'mon-articles'), value: 'right' },
+                        ],
+                        onChange: function (value) {
+                            setAttributes({ filter_alignment: value });
+                        },
+                        disabled: !attributes.show_category_filter,
+                    }),
+                    el(ToggleControl, {
+                        label: __('Afficher la catégorie', 'mon-articles'),
+                        checked: !!attributes.show_category,
+                        onChange: function (value) {
+                            setAttributes({ show_category: !!value });
+                        },
+                    }),
+                    el(ToggleControl, {
+                        label: __('Afficher l’auteur', 'mon-articles'),
+                        checked: !!attributes.show_author,
+                        onChange: function (value) {
+                            setAttributes({ show_author: !!value });
+                        },
+                    }),
+                    el(ToggleControl, {
+                        label: __('Afficher la date', 'mon-articles'),
+                        checked: !!attributes.show_date,
+                        onChange: function (value) {
+                            setAttributes({ show_date: !!value });
+                        },
+                    }),
+                    el(ToggleControl, {
+                        label: __('Afficher l’extrait', 'mon-articles'),
+                        checked: !!attributes.show_excerpt,
+                        onChange: function (value) {
+                            setAttributes({ show_excerpt: !!value });
+                        },
+                    }),
+                    el(RangeControl, {
+                        label: __('Longueur de l’extrait', 'mon-articles'),
+                        value: attributes.excerpt_length,
+                        min: 0,
+                        max: 100,
+                        onChange: function (value) {
+                            if (typeof value !== 'number') {
+                                value = 0;
+                            }
+                            setAttributes({ excerpt_length: value });
+                        },
+                        disabled: !attributes.show_excerpt,
+                    })
+                )
+            );
+
+            var previewContent;
+
+            if (!attributes.instanceId) {
+                var placeholderChildren = [];
+
+                if (data && data.isResolving) {
+                    placeholderChildren.push(el(Spinner, { key: 'spinner' }));
+                } else if (instances.length === 0) {
+                    placeholderChildren.push(
+                        el('p', { key: 'no-instances' }, __('Aucune instance « mon_affichage » n’a été trouvée.', 'mon-articles'))
+                    );
+                } else {
+                    placeholderChildren.push(
+                        el('p', { key: 'instructions' }, __('Sélectionnez un module dans la barre latérale.', 'mon-articles'))
+                    );
+                }
+
+                previewContent = el(
+                    Placeholder,
+                    {
+                        icon: 'screenoptions',
+                        label: __('Tuiles – LCV', 'mon-articles'),
+                        className: 'my-articles-block-placeholder',
+                    },
+                    placeholderChildren
+                );
+            } else if (data && data.isResolving && !data.selectedInstance) {
+                previewContent = el(Spinner, { key: 'spinner-loading' });
+            } else if (!data || !data.selectedInstance) {
+                previewContent = el(
+                    Notice,
+                    { status: 'warning', isDismissible: false },
+                    __('Le module sélectionné est introuvable.', 'mon-articles')
+                );
+            } else if (ServerSideRender) {
+                var title = data.selectedInstance.title && data.selectedInstance.title.rendered
+                    ? data.selectedInstance.title.rendered
+                    : __('(Sans titre)', 'mon-articles');
+
+                previewContent = el(
+                    'div',
+                    { className: 'my-articles-block-preview' },
+                    el('p', { className: 'my-articles-block-preview__title' }, title),
+                    el(ServerSideRender, { block: 'mon-affichage/articles', attributes: attributes })
+                );
+            } else {
+                previewContent = el(
+                    Notice,
+                    { status: 'warning', isDismissible: false },
+                    __('Le composant ServerSideRender est indisponible sur ce site.', 'mon-articles')
+                );
+            }
+
+            return el(
+                Fragment,
+                null,
+                inspectorControls,
+                el('div', blockProps, previewContent)
+            );
+        },
+        save: function () {
+            return null;
+        },
+    });
+})(window.wp);

--- a/mon-affichage-article/blocks/mon-affichage-articles/editor.css
+++ b/mon-affichage-article/blocks/mon-affichage-articles/editor.css
@@ -1,0 +1,14 @@
+.wp-block-mon-affichage-articles {
+    border: 1px dashed #d1d5db;
+    padding: 16px;
+}
+
+.wp-block-mon-affichage-articles .my-articles-block-preview {
+    background: #f9fafb;
+    padding: 12px;
+    border-radius: 6px;
+}
+
+.wp-block-mon-affichage-articles .my-articles-block-placeholder {
+    color: #4b5563;
+}

--- a/mon-affichage-article/blocks/mon-affichage-articles/style.css
+++ b/mon-affichage-article/blocks/mon-affichage-articles/style.css
@@ -1,0 +1,5 @@
+/* Styles spécifiques au bloc Tuiles – LCV. */
+.my-articles-block-placeholder {
+    text-align: center;
+    padding: 1.5rem;
+}

--- a/mon-affichage-article/includes/class-my-articles-block.php
+++ b/mon-affichage-article/includes/class-my-articles-block.php
@@ -1,0 +1,98 @@
+<?php
+// Fichier: includes/class-my-articles-block.php
+
+if ( ! defined( 'WPINC' ) ) {
+    die;
+}
+
+class My_Articles_Block {
+
+    private static $instance;
+
+    public static function get_instance() {
+        if ( ! isset( self::$instance ) ) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    private function __construct() {
+        add_action( 'init', array( $this, 'register_block' ) );
+    }
+
+    public function register_block() {
+        if ( ! function_exists( 'register_block_type' ) ) {
+            return;
+        }
+
+        register_block_type(
+            __DIR__ . '/../blocks/mon-affichage-articles',
+            array(
+                'render_callback' => array( $this, 'render_block' ),
+            )
+        );
+    }
+
+    public function render_block( $attributes = array(), $content = '' ) {
+        if ( ! class_exists( 'My_Articles_Shortcode' ) ) {
+            return '';
+        }
+
+        $attributes  = is_array( $attributes ) ? $attributes : array();
+        $instance_id = isset( $attributes['instanceId'] ) ? absint( $attributes['instanceId'] ) : 0;
+
+        if ( $instance_id <= 0 ) {
+            return '';
+        }
+
+        $overrides = $this->prepare_overrides( $attributes );
+
+        $shortcode_instance = My_Articles_Shortcode::get_instance();
+
+        return $shortcode_instance->render_shortcode(
+            array(
+                'id'        => $instance_id,
+                'overrides' => $overrides,
+            )
+        );
+    }
+
+    private function prepare_overrides( array $attributes ) {
+        $defaults  = My_Articles_Shortcode::get_default_options();
+        $overrides = array();
+
+        foreach ( $defaults as $key => $default_value ) {
+            if ( ! array_key_exists( $key, $attributes ) ) {
+                continue;
+            }
+
+            $raw_value = $attributes[ $key ];
+
+            if ( is_array( $default_value ) ) {
+                if ( is_array( $raw_value ) ) {
+                    $overrides[ $key ] = $raw_value;
+                }
+                continue;
+            }
+
+            if ( is_int( $default_value ) ) {
+                if ( is_bool( $raw_value ) ) {
+                    $overrides[ $key ] = $raw_value ? 1 : 0;
+                } else {
+                    $overrides[ $key ] = (int) $raw_value;
+                }
+                continue;
+            }
+
+            if ( is_float( $default_value ) ) {
+                $overrides[ $key ] = (float) $raw_value;
+                continue;
+            }
+
+            $overrides[ $key ] = (string) $raw_value;
+        }
+
+        return $overrides;
+    }
+}

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -36,6 +36,7 @@ final class Mon_Affichage_Articles {
         require_once MY_ARTICLES_PLUGIN_DIR . 'includes/class-my-articles-metaboxes.php';
         require_once MY_ARTICLES_PLUGIN_DIR . 'includes/class-my-articles-shortcode.php';
         require_once MY_ARTICLES_PLUGIN_DIR . 'includes/class-my-articles-enqueue.php';
+        require_once MY_ARTICLES_PLUGIN_DIR . 'includes/class-my-articles-block.php';
     }
 
     private function add_hooks() {
@@ -56,6 +57,7 @@ final class Mon_Affichage_Articles {
         My_Articles_Settings::get_instance();
         My_Articles_Metaboxes::get_instance();
         My_Articles_Shortcode::get_instance();
+        My_Articles_Block::get_instance();
         My_Articles_Enqueue::get_instance();
     }
 


### PR DESCRIPTION
## Summary
- register a Gutenberg block for the Tuiles – LCV module and load its server-side renderer
- add block assets (editor script/styles) and allow shortcode overrides to consume block attributes
- document the new block usage and available attributes in the README

## Testing
- php -l mon-affichage-article/includes/class-my-articles-block.php
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php
- php -l mon-affichage-article/mon-affichage-articles.php

------
https://chatgpt.com/codex/tasks/task_e_68dbfe4a9b70832e9bee161416290be7