### PR TITLE
Improve filter navigation accessibility

### DIFF
--- a/mon-affichage-article/assets/css/styles.css
+++ b/mon-affichage-article/assets/css/styles.css
@@ -32,7 +32,7 @@
 .my-articles-filter-nav.filter-align-center ul { justify-content: center; }
 .my-articles-filter-nav.filter-align-right ul { justify-content: flex-end; }
 
-.my-articles-filter-nav li a {
+.my-articles-filter-nav button {
     display: block;
     padding: 5px 12px;
     margin: 0 0 5px 5px;
@@ -42,12 +42,18 @@
     border-radius: 4px;
     font-size: 13px;
     transition: all 0.2s ease;
+    border: none;
+    cursor: pointer;
 }
 
-.my-articles-filter-nav li.active a,
-.my-articles-filter-nav li a:hover {
+.my-articles-filter-nav button:hover,
+.my-articles-filter-nav button:focus,
+.my-articles-filter-nav button:focus-visible,
+.my-articles-filter-nav li.active button,
+.my-articles-filter-nav button[aria-selected="true"] {
     color: #fff;
     background: #333;
+    outline: none;
 }
 
 /* *** CORRECTIF SLIDESHOW & HAUTEURS (v9) *** */

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -817,14 +817,14 @@ class My_Articles_Shortcode {
 
         if ( ! empty( $options['show_category_filter'] ) && ! empty( $resolved_taxonomy ) && ! empty( $available_categories ) ) {
             $alignment_class = 'filter-align-' . esc_attr( $options['filter_alignment'] );
-            echo '<nav class="my-articles-filter-nav ' . $alignment_class . '"><ul>';
+            echo '<nav class="my-articles-filter-nav ' . $alignment_class . '"><ul role="tablist">';
             $default_cat   = $options['term'] ?? '';
             $is_all_active = '' === $default_cat || 'all' === $default_cat;
-            echo '<li class="' . ( $is_all_active ? 'active' : '' ) . '"><a href="#" data-category="all">' . esc_html__( 'Tout', 'mon-articles' ) . '</a></li>';
+            echo '<li role="presentation" class="' . ( $is_all_active ? 'active' : '' ) . '"><button type="button" role="tab" aria-selected="' . ( $is_all_active ? 'true' : 'false' ) . '" data-category="all">' . esc_html__( 'Tout', 'mon-articles' ) . '</button></li>';
 
             foreach ( $available_categories as $category ) {
                 $is_active = ( $default_cat === $category->slug );
-                echo '<li class="' . ( $is_active ? 'active' : '' ) . '"><a href="#" data-category="' . esc_attr( $category->slug ) . '">' . esc_html( $category->name ) . '</a></li>';
+                echo '<li role="presentation" class="' . ( $is_active ? 'active' : '' ) . '"><button type="button" role="tab" aria-selected="' . ( $is_active ? 'true' : 'false' ) . '" data-category="' . esc_attr( $category->slug ) . '">' . esc_html( $category->name ) . '</button></li>';
             }
 
             echo '</ul></nav>';


### PR DESCRIPTION
## Summary
- replace the filter navigation links with buttons and add tab roles and aria-selected states
- update styles to target the new buttons and reflect selection state
- adjust filter JavaScript to work with buttons, manage aria-selected updates, and add keyboard activation support

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc07907bb8832e8c64d23345fd4875