### PR TITLE
Add list display mode option and test coverage

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-settings.php
+++ b/mon-affichage-article/includes/class-my-articles-settings.php
@@ -91,7 +91,7 @@ class My_Articles_Settings {
 
     public function sanitize( $input ) {
         $sanitized_input = [];
-        $sanitized_input['display_mode'] = isset( $input['display_mode'] ) && in_array($input['display_mode'], ['grid', 'slideshow']) ? $input['display_mode'] : 'grid';
+        $sanitized_input['display_mode'] = isset( $input['display_mode'] ) && in_array($input['display_mode'], ['grid', 'slideshow', 'list']) ? $input['display_mode'] : 'grid';
         $sanitized_input['default_category'] = isset( $input['default_category'] ) ? sanitize_text_field( $input['default_category'] ) : '';
         $sanitized_input['posts_per_page'] = isset( $input['posts_per_page'] )
             ? min( 50, max( 0, absint( $input['posts_per_page'] ) ) )
@@ -126,6 +126,7 @@ class My_Articles_Settings {
         <select id="display_mode" name="<?php echo esc_attr($this->option_name); ?>[display_mode]">
             <option value="grid" <?php selected($current_mode, 'grid'); ?>><?php esc_html_e('Grille', 'mon-articles'); ?></option>
             <option value="slideshow" <?php selected($current_mode, 'slideshow'); ?>><?php esc_html_e('Diaporama', 'mon-articles'); ?></option>
+            <option value="list" <?php selected($current_mode, 'list'); ?>><?php esc_html_e('Liste', 'mon-articles'); ?></option>
         </select>
         <p class="description"><?php esc_html_e('Choisissez comment afficher les articles.', 'mon-articles'); ?></p>
         <?php

--- a/tests/MyArticlesSettingsSanitizeTest.php
+++ b/tests/MyArticlesSettingsSanitizeTest.php
@@ -70,6 +70,18 @@ final class MyArticlesSettingsSanitizeTest extends TestCase
         );
     }
 
+    public function test_sanitize_preserves_list_display_mode(): void
+    {
+        $settings = My_Articles_Settings::get_instance();
+        $result = $settings->sanitize(array('display_mode' => 'list'));
+
+        self::assertSame(
+            'list',
+            $result['display_mode'] ?? null,
+            'The sanitize routine should allow the list display mode to persist.'
+        );
+    }
+
     public function test_normalize_instance_options_treats_zero_as_unlimited(): void
     {
         $options = My_Articles_Shortcode::normalize_instance_options(


### PR DESCRIPTION
## Summary
- allow the settings sanitizer to persist the new list display mode
- expose the list display mode as a selectable option in the settings UI
- add unit coverage ensuring the list display mode survives sanitization

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dc222fbf70832e8d3eba3535608cea