### PR TITLE
Implement async module selector for mon-affichage block

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Utiliser le shortcode :
 1. Depuis l'éditeur Gutenberg, ajouter le bloc **Tuiles – LCV**.
 2. Sélectionner l'instance `mon_affichage` à afficher via le panneau latéral.
 3. Ajuster les principaux réglages (mode d'affichage, filtres, pagination...) depuis les contrôles du bloc.
+4. Utiliser le champ de recherche du panneau **Module** pour retrouver un contenu `mon_affichage`. Les résultats sont chargés par lots (20 éléments) depuis l'API REST et le bouton « Charger plus de résultats » permet de parcourir l'ensemble des contenus disponibles.
 
 ### Attributs disponibles dans l'éditeur
 


### PR DESCRIPTION
## Summary
- replace the inspector SelectControl with a ComboboxControl that queries mon_affichage posts using REST search and pagination
- append paginated results while showing loading states so editors can browse every module instance
- document the new search-and-load-more workflow in the README for editorial teams

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc223525d8832e845dcb3c65bdaca9