### PR TITLE
Expose reusable article layout and swiper initializers

### DIFF
--- a/mon-affichage-article/assets/js/filter.js
+++ b/mon-affichage-article/assets/js/filter.js
@@ -109,6 +109,7 @@
             },
             success: function (response) {
                 if (response.success) {
+                    var wrapperElement = (wrapper && wrapper.length) ? wrapper.get(0) : null;
                     contentArea.html(response.data.html);
                     contentArea.css('opacity', 1);
                     clearFeedback(wrapper);
@@ -197,44 +198,12 @@
                         }
                     }
 
-                    if (wrapper.hasClass('my-articles-slideshow')) {
-                        if (typeof window.mySwiperInstances !== 'undefined' && window.mySwiperInstances[instanceId]) {
-                            window.mySwiperInstances[instanceId].destroy(true, true);
-                        }
+                    if (typeof window.myArticlesInitWrappers === 'function') {
+                        window.myArticlesInitWrappers(wrapperElement);
+                    }
 
-                        var settingsObjectName = 'myArticlesSwiperSettings_' + instanceId;
-                        if (typeof window[settingsObjectName] !== 'undefined') {
-                            var settings = window[settingsObjectName];
-
-                            window.mySwiperInstances = window.mySwiperInstances || {};
-
-                            window.mySwiperInstances[instanceId] = new Swiper(settings.container_selector, {
-                                slidesPerView: settings.columns_mobile,
-                                spaceBetween: settings.gap_size,
-                                loop: true,
-                                pagination: {
-                                    el: settings.container_selector + ' .swiper-pagination',
-                                    clickable: true,
-                                },
-                                navigation: {
-                                    nextEl: settings.container_selector + ' .swiper-button-next',
-                                    prevEl: settings.container_selector + ' .swiper-button-prev',
-                                },
-                                breakpoints: {
-                                    768: { slidesPerView: settings.columns_tablet, spaceBetween: settings.gap_size },
-                                    1024: { slidesPerView: settings.columns_desktop, spaceBetween: settings.gap_size },
-                                    1536: { slidesPerView: settings.columns_ultrawide, spaceBetween: settings.gap_size }
-                                },
-                                on: {
-                                    init: function () {
-                                        var mainWrapper = document.querySelector('#my-articles-wrapper-' + instanceId);
-                                        if (mainWrapper) {
-                                            mainWrapper.classList.add('swiper-initialized');
-                                        }
-                                    }
-                                }
-                            });
-                        }
+                    if (typeof window.myArticlesInitSwipers === 'function') {
+                        window.myArticlesInitSwipers(wrapperElement);
                     }
 
                     if (instanceId) {

--- a/mon-affichage-article/assets/js/load-more.js
+++ b/mon-affichage-article/assets/js/load-more.js
@@ -121,58 +121,19 @@
             success: function (response) {
                 if (response.success) {
                     var responseData = response.data || {};
+                    var wrapperElement = (wrapper && wrapper.length) ? wrapper.get(0) : null;
 
                     // Ajoute les nouveaux articles à la suite des anciens
                     if (typeof responseData.html !== 'undefined') {
                         contentArea.append(responseData.html);
+                    }
 
-                        if (wrapper.hasClass('my-articles-slideshow')) {
-                            var swiperInstance = null;
+                    if (typeof window.myArticlesInitWrappers === 'function') {
+                        window.myArticlesInitWrappers(wrapperElement);
+                    }
 
-                            if (typeof window.mySwiperInstances !== 'undefined' && instanceId && window.mySwiperInstances[instanceId]) {
-                                swiperInstance = window.mySwiperInstances[instanceId];
-                            }
-
-                            if (!swiperInstance || typeof swiperInstance.update !== 'function') {
-                                var settingsObjectName = 'myArticlesSwiperSettings_' + instanceId;
-
-                                if (typeof window[settingsObjectName] !== 'undefined') {
-                                    var settings = window[settingsObjectName];
-
-                                    window.mySwiperInstances = window.mySwiperInstances || {};
-                                    swiperInstance = new Swiper(settings.container_selector, {
-                                        slidesPerView: settings.columns_mobile,
-                                        spaceBetween: settings.gap_size,
-                                        loop: true,
-                                        pagination: {
-                                            el: settings.container_selector + ' .swiper-pagination',
-                                            clickable: true,
-                                        },
-                                        navigation: {
-                                            nextEl: settings.container_selector + ' .swiper-button-next',
-                                            prevEl: settings.container_selector + ' .swiper-button-prev',
-                                        },
-                                        breakpoints: {
-                                            768: { slidesPerView: settings.columns_tablet, spaceBetween: settings.gap_size },
-                                            1024: { slidesPerView: settings.columns_desktop, spaceBetween: settings.gap_size },
-                                            1536: { slidesPerView: settings.columns_ultrawide, spaceBetween: settings.gap_size }
-                                        },
-                                        on: {
-                                            init: function () {
-                                                var mainWrapper = document.querySelector('#my-articles-wrapper-' + instanceId);
-                                                if (mainWrapper) {
-                                                    mainWrapper.classList.add('swiper-initialized');
-                                                }
-                                            }
-                                        }
-                                    });
-
-                                    window.mySwiperInstances[instanceId] = swiperInstance;
-                                }
-                            } else {
-                                swiperInstance.update();
-                            }
-                        }
+                    if (typeof window.myArticlesInitSwipers === 'function') {
+                        window.myArticlesInitSwipers(wrapperElement);
                     }
 
                     if (typeof responseData.pinned_ids !== 'undefined') {

--- a/mon-affichage-article/assets/js/swiper-init.js
+++ b/mon-affichage-article/assets/js/swiper-init.js
@@ -1,42 +1,135 @@
 // Fichier: assets/js/swiper-init.js
-document.addEventListener('DOMContentLoaded', function () {
-    window.mySwiperInstances = window.mySwiperInstances || {};
+(function () {
+    'use strict';
 
-    const wrappers = document.querySelectorAll('.my-articles-wrapper.my-articles-slideshow');
-
-    wrappers.forEach(wrapper => {
-        const instanceId = wrapper.id.replace('my-articles-wrapper-', '');
-        const settingsObjectName = 'myArticlesSwiperSettings_' + instanceId;
-
-        if (typeof window[settingsObjectName] !== 'undefined') {
-            const settings = window[settingsObjectName];
-            
-            window.mySwiperInstances[instanceId] = new Swiper(settings.container_selector, {
-                slidesPerView: settings.columns_mobile,
-                spaceBetween: settings.gap_size,
-                loop: true,
-                pagination: {
-                    el: settings.container_selector + ' .swiper-pagination',
-                    clickable: true,
-                },
-                navigation: {
-                    nextEl: settings.container_selector + ' .swiper-button-next',
-                    prevEl: settings.container_selector + ' .swiper-button-prev',
-                },
-                breakpoints: {
-                    768: { slidesPerView: settings.columns_tablet, spaceBetween: settings.gap_size },
-                    1024: { slidesPerView: settings.columns_desktop, spaceBetween: settings.gap_size },
-                    1536: { slidesPerView: settings.columns_ultrawide, spaceBetween: settings.gap_size }
-                },
-                on: {
-                    init: function () {
-                        const mainWrapper = document.querySelector('#my-articles-wrapper-' + instanceId);
-                        if (mainWrapper) {
-                            mainWrapper.classList.add('swiper-initialized');
-                        }
-                    }
-                }
-            });
+    function getInstanceId(wrapper) {
+        if (!wrapper) {
+            return '';
         }
-    });
-});
+
+        if (wrapper.dataset && wrapper.dataset.instanceId) {
+            return wrapper.dataset.instanceId;
+        }
+
+        if (wrapper.id && wrapper.id.indexOf('my-articles-wrapper-') === 0) {
+            return wrapper.id.replace('my-articles-wrapper-', '');
+        }
+
+        return '';
+    }
+
+    function collectWrappers(target) {
+        const found = new Set();
+
+        function add(node) {
+            if (!node) {
+                return;
+            }
+
+            if (node.classList && node.classList.contains('my-articles-wrapper') && node.classList.contains('my-articles-slideshow')) {
+                found.add(node);
+            }
+
+            if (typeof node.querySelectorAll === 'function') {
+                node.querySelectorAll('.my-articles-wrapper.my-articles-slideshow').forEach(function (wrapper) {
+                    found.add(wrapper);
+                });
+            }
+        }
+
+        if (!target) {
+            document.querySelectorAll('.my-articles-wrapper.my-articles-slideshow').forEach(function (wrapper) {
+                found.add(wrapper);
+            });
+            return Array.from(found);
+        }
+
+        if (target.jquery) {
+            target.each(function (index, element) {
+                add(element);
+            });
+            return Array.from(found);
+        }
+
+        if (typeof target.length === 'number' && typeof target !== 'string') {
+            Array.prototype.forEach.call(target, function (item) {
+                add(item);
+            });
+            return Array.from(found);
+        }
+
+        add(target);
+        return Array.from(found);
+    }
+
+    function initSwiperForWrapper(wrapper) {
+        const instanceId = getInstanceId(wrapper);
+        if (!instanceId) {
+            return null;
+        }
+
+        const settingsObjectName = 'myArticlesSwiperSettings_' + instanceId;
+        const settings = window[settingsObjectName];
+        if (!settings) {
+            return null;
+        }
+
+        window.mySwiperInstances = window.mySwiperInstances || {};
+
+        const existingInstance = window.mySwiperInstances[instanceId];
+        if (existingInstance && typeof existingInstance.destroy === 'function') {
+            existingInstance.destroy(true, true);
+        }
+
+        if (wrapper.classList) {
+            wrapper.classList.remove('swiper-initialized');
+        }
+
+        const instance = new Swiper(settings.container_selector, {
+            slidesPerView: settings.columns_mobile,
+            spaceBetween: settings.gap_size,
+            loop: true,
+            pagination: {
+                el: settings.container_selector + ' .swiper-pagination',
+                clickable: true,
+            },
+            navigation: {
+                nextEl: settings.container_selector + ' .swiper-button-next',
+                prevEl: settings.container_selector + ' .swiper-button-prev',
+            },
+            breakpoints: {
+                768: { slidesPerView: settings.columns_tablet, spaceBetween: settings.gap_size },
+                1024: { slidesPerView: settings.columns_desktop, spaceBetween: settings.gap_size },
+                1536: { slidesPerView: settings.columns_ultrawide, spaceBetween: settings.gap_size },
+            },
+            on: {
+                init: function () {
+                    const mainWrapper = document.querySelector('#my-articles-wrapper-' + instanceId);
+                    if (mainWrapper) {
+                        mainWrapper.classList.add('swiper-initialized');
+                    }
+                },
+            },
+        });
+
+        window.mySwiperInstances[instanceId] = instance;
+        return instance;
+    }
+
+    function initSwipers(target) {
+        const wrappers = collectWrappers(target);
+        return wrappers.map(initSwiperForWrapper);
+    }
+
+    function handleDomReady() {
+        initSwipers();
+    }
+
+    window.myArticlesInitSwipers = initSwipers;
+
+    if (document.readyState !== 'loading') {
+        handleDomReady();
+    } else {
+        document.addEventListener('DOMContentLoaded', handleDomReady);
+    }
+})();

--- a/tests/REGRESSIONS.md
+++ b/tests/REGRESSIONS.md
@@ -1,0 +1,6 @@
+# Regression Notes
+
+## Reliable front-end initializers
+- **Context:** AJAX filters and load-more requests can inject new markup after the initial `DOMContentLoaded` event.
+- **Guardrail:** `window.myArticlesInitWrappers()` and `window.myArticlesInitSwipers()` can be re-run after content updates to restore responsive layouts and Swiper sliders.
+- **Verification:** Trigger the relevant AJAX action (filter or load-more) and call the exposed initializers in the success callback to confirm that grid breakpoints and sliders refresh correctly.


### PR DESCRIPTION
## Summary
- expose `window.myArticlesInitWrappers` so responsive wrappers can be re-initialized after AJAX updates while still running on DOM ready
- add a reusable `window.myArticlesInitSwipers` helper that (re)creates Swiper instances and wire it to immediate DOM readiness
- trigger the new initializers from filter/load-more flows and document the regression guard for reliable slider/layout setup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc354131d0832e86bb6621ad4be8c0