### PR TITLE
Handle zero-length excerpt trimming and add regression test

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -1171,14 +1171,38 @@ class My_Articles_Shortcode {
                     <?php if ($options['show_date']) echo '<span class="article-date">' . esc_html(get_the_date()) . '</span>'; ?>
                 </div>
             <?php endif; ?>
-            <?php if (!empty($options['show_excerpt'])): ?>
+            <?php
+            if (!empty($options['show_excerpt'])) {
+                $excerpt_length  = isset($options['excerpt_length']) ? (int) $options['excerpt_length'] : 0;
+                $raw_excerpt     = get_the_excerpt();
+                $trimmed_excerpt = '';
+                $has_read_more   = ! empty($options['excerpt_more_text']);
+
+                if ($excerpt_length > 0) {
+                    $trimmed_excerpt = wp_trim_words($raw_excerpt, $excerpt_length, $excerpt_more);
+                }
+
+                $has_excerpt_content = '' !== trim(strip_tags($trimmed_excerpt));
+
+                if ($has_excerpt_content || $has_read_more) {
+                    ?>
                 <div class="my-article-excerpt">
-                    <?php echo wp_kses_post(wp_trim_words(get_the_excerpt(), (int)$options['excerpt_length'], $excerpt_more)); ?>
-                    <?php if (!empty($options['excerpt_more_text'])): ?>
+                    <?php
+                    if ($has_excerpt_content) {
+                        echo wp_kses_post($trimmed_excerpt);
+                    }
+
+                    if ($has_read_more) {
+                        ?>
                         <a href="<?php echo $escaped_link; ?>" class="my-article-read-more"><?php echo esc_html($options['excerpt_more_text']); ?></a>
-                    <?php endif; ?>
+                        <?php
+                    }
+                    ?>
                 </div>
-            <?php endif; ?>
+                <?php
+                }
+            }
+            ?>
         </div>
         <?php
     }

--- a/tests/RenderArticleItemTest.php
+++ b/tests/RenderArticleItemTest.php
@@ -77,5 +77,33 @@ final class RenderArticleItemTest extends TestCase
         $this->assertStringContainsString('loading="lazy"', $html);
         $this->assertStringNotContainsString('loading="eager"', $html);
     }
+
+    public function test_excerpt_length_zero_omits_ellipsis_but_keeps_read_more(): void
+    {
+        $reflection = new \ReflectionClass(My_Articles_Shortcode::class);
+        $shortcode = $reflection->newInstanceWithoutConstructor();
+
+        $options = array(
+            'display_mode'       => 'list',
+            'show_category'      => false,
+            'show_author'        => false,
+            'show_date'          => false,
+            'show_excerpt'       => true,
+            'excerpt_length'     => 0,
+            'excerpt_more_text'  => 'Lire la suite',
+            'resolved_taxonomy'  => '',
+            'enable_lazy_load'   => false,
+            'pinned_show_badge'  => false,
+        );
+
+        ob_start();
+        $shortcode->render_article_item($options, false);
+        $output = ob_get_clean();
+
+        $this->assertIsString($output);
+        $this->assertStringContainsString('<div class="my-article-excerpt">', $output);
+        $this->assertStringContainsString('class="my-article-read-more"', $output);
+        $this->assertStringNotContainsString('…', $output);
+    }
 }
 


### PR DESCRIPTION
## Summary
- skip trimming excerpts and suppress the ellipsis when the configured length is less than one while still rendering the read-more link
- only render the excerpt container when there is excerpt content or an explicit read-more link
- cover the zero-length excerpt scenario with a PHPUnit test to prevent regressions

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dc354009ac832ebc99e29fa0e1fc18