### PR TITLE
Register plugin assets earlier for REST block previews

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-enqueue.php
+++ b/mon-affichage-article/includes/class-my-articles-enqueue.php
@@ -17,7 +17,9 @@ class My_Articles_Enqueue {
     }
 
     private function __construct() {
-        add_action( 'wp_enqueue_scripts', array( $this, 'register_plugin_styles_scripts' ) );
+        add_action( 'init', array( $this, 'register_plugin_styles_scripts' ) );
+        add_action( 'wp_enqueue_scripts', array( $this, 'ensure_assets_registered' ) );
+        add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
     }
 
     public function register_plugin_styles_scripts() {
@@ -33,5 +35,21 @@ class My_Articles_Enqueue {
         if ( function_exists( 'wp_script_add_data' ) ) {
             wp_script_add_data( 'lazysizes', 'async', true );
         }
+    }
+
+    public function ensure_assets_registered() {
+        $this->register_plugin_styles_scripts();
+    }
+
+    public function enqueue_block_editor_assets() {
+        $this->register_plugin_styles_scripts();
+
+        wp_enqueue_style( 'swiper-css' );
+        wp_enqueue_style( 'my-articles-styles' );
+
+        wp_enqueue_script( 'swiper-js' );
+        wp_enqueue_script( 'lazysizes' );
+        wp_enqueue_script( 'my-articles-responsive-layout' );
+        wp_enqueue_script( 'my-articles-debug-helper' );
     }
 }

--- a/tests/MyArticlesEnqueueTest.php
+++ b/tests/MyArticlesEnqueueTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+
+if (!function_exists('wp_enqueue_style')) {
+    /**
+     * @param string $handle
+     * @param string $src
+     * @param array<int, string> $deps
+     * @param string|bool $ver
+     * @param string $media
+     */
+    function wp_enqueue_style($handle, $src = '', $deps = array(), $ver = false, $media = 'all'): void
+    {
+        global $mon_articles_test_enqueued_styles;
+
+        if (!is_array($mon_articles_test_enqueued_styles)) {
+            $mon_articles_test_enqueued_styles = array();
+        }
+
+        $mon_articles_test_enqueued_styles[] = array(
+            'handle' => (string) $handle,
+            'src'    => (string) $src,
+            'deps'   => is_array($deps) ? array_values($deps) : array(),
+            'ver'    => is_string($ver) ? $ver : '',
+            'media'  => (string) $media,
+        );
+    }
+}
+
+if (!function_exists('wp_enqueue_script')) {
+    /**
+     * @param string $handle
+     * @param string $src
+     * @param array<int, string> $deps
+     * @param string|bool $ver
+     * @param bool $in_footer
+     */
+    function wp_enqueue_script($handle, $src = '', $deps = array(), $ver = false, $in_footer = false): void
+    {
+        global $mon_articles_test_enqueued_scripts;
+
+        if (!is_array($mon_articles_test_enqueued_scripts)) {
+            $mon_articles_test_enqueued_scripts = array();
+        }
+
+        $mon_articles_test_enqueued_scripts[] = array(
+            'handle'    => (string) $handle,
+            'src'       => (string) $src,
+            'deps'      => is_array($deps) ? array_values($deps) : array(),
+            'ver'       => is_string($ver) ? $ver : '',
+            'in_footer' => (bool) $in_footer,
+        );
+    }
+}
+
+}
+
+namespace MonAffichageArticles\Tests {
+
+use My_Articles_Enqueue;
+use PHPUnit\Framework\TestCase;
+
+final class MyArticlesEnqueueTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!defined('MY_ARTICLES_VERSION')) {
+            define('MY_ARTICLES_VERSION', 'tests');
+        }
+
+        if (!defined('MY_ARTICLES_PLUGIN_URL')) {
+            define('MY_ARTICLES_PLUGIN_URL', 'http://example.com/wp-content/plugins/mon-affichage-articles/');
+        }
+
+        require_once __DIR__ . '/../mon-affichage-article/includes/class-my-articles-enqueue.php';
+
+        global $mon_articles_test_registered_styles,
+            $mon_articles_test_registered_scripts,
+            $mon_articles_test_script_data,
+            $mon_articles_test_enqueued_styles,
+            $mon_articles_test_enqueued_scripts;
+
+        $mon_articles_test_registered_styles = array();
+        $mon_articles_test_registered_scripts = array();
+        $mon_articles_test_script_data       = array();
+        $mon_articles_test_enqueued_styles   = array();
+        $mon_articles_test_enqueued_scripts  = array();
+    }
+
+    public function test_registers_assets_during_init(): void
+    {
+        $enqueue = My_Articles_Enqueue::get_instance();
+        $enqueue->register_plugin_styles_scripts();
+
+        global $mon_articles_test_registered_styles,
+            $mon_articles_test_registered_scripts,
+            $mon_articles_test_script_data,
+            $mon_articles_test_enqueued_styles,
+            $mon_articles_test_enqueued_scripts;
+
+        $this->assertArrayHasKey('my-articles-styles', $mon_articles_test_registered_styles);
+        $this->assertSame(
+            'http://example.com/wp-content/plugins/mon-affichage-articles/assets/css/styles.css',
+            $mon_articles_test_registered_styles['my-articles-styles']['src']
+        );
+        $this->assertArrayHasKey('swiper-css', $mon_articles_test_registered_styles);
+
+        $this->assertArrayHasKey('swiper-js', $mon_articles_test_registered_scripts);
+        $this->assertArrayHasKey('lazysizes', $mon_articles_test_registered_scripts);
+        $this->assertTrue($mon_articles_test_registered_scripts['lazysizes']['in_footer']);
+        $this->assertArrayHasKey('my-articles-responsive-layout', $mon_articles_test_registered_scripts);
+        $this->assertArrayHasKey('my-articles-debug-helper', $mon_articles_test_registered_scripts);
+
+        $this->assertArrayHasKey('lazysizes', $mon_articles_test_script_data);
+        $this->assertArrayHasKey('async', $mon_articles_test_script_data['lazysizes']);
+        $this->assertTrue($mon_articles_test_script_data['lazysizes']['async']);
+
+        $this->assertSame(array(), $mon_articles_test_enqueued_styles);
+        $this->assertSame(array(), $mon_articles_test_enqueued_scripts);
+    }
+
+    public function test_block_editor_enqueue_uses_registered_handles(): void
+    {
+        $enqueue = My_Articles_Enqueue::get_instance();
+        $enqueue->register_plugin_styles_scripts();
+        $enqueue->enqueue_block_editor_assets();
+
+        global $mon_articles_test_enqueued_styles, $mon_articles_test_enqueued_scripts;
+
+        $enqueued_style_handles = array_map(
+            static function (array $entry): string {
+                return $entry['handle'];
+            },
+            $mon_articles_test_enqueued_styles
+        );
+        $enqueued_script_handles = array_map(
+            static function (array $entry): string {
+                return $entry['handle'];
+            },
+            $mon_articles_test_enqueued_scripts
+        );
+
+        $this->assertContains('my-articles-styles', $enqueued_style_handles);
+        $this->assertContains('swiper-css', $enqueued_style_handles);
+
+        $this->assertContains('swiper-js', $enqueued_script_handles);
+        $this->assertContains('lazysizes', $enqueued_script_handles);
+        $this->assertContains('my-articles-responsive-layout', $enqueued_script_handles);
+        $this->assertContains('my-articles-debug-helper', $enqueued_script_handles);
+    }
+}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -278,6 +278,84 @@ if (!function_exists('wp_add_inline_style')) {
     }
 }
 
+if (!function_exists('wp_register_style')) {
+    /**
+     * @param string $handle
+     * @param string $src
+     * @param array<int, string> $deps
+     * @param string|bool $ver
+     * @param string $media
+     */
+    function wp_register_style($handle, $src = '', $deps = array(), $ver = false, $media = 'all'): bool
+    {
+        global $mon_articles_test_registered_styles;
+
+        if (!is_array($mon_articles_test_registered_styles)) {
+            $mon_articles_test_registered_styles = array();
+        }
+
+        $mon_articles_test_registered_styles[(string) $handle] = array(
+            'src'   => (string) $src,
+            'deps'  => is_array($deps) ? array_values($deps) : array(),
+            'ver'   => is_string($ver) ? $ver : '',
+            'media' => (string) $media,
+        );
+
+        return true;
+    }
+}
+
+if (!function_exists('wp_register_script')) {
+    /**
+     * @param string $handle
+     * @param string|false $src
+     * @param array<int, string> $deps
+     * @param string|bool $ver
+     * @param bool $in_footer
+     */
+    function wp_register_script($handle, $src = '', $deps = array(), $ver = false, $in_footer = false): bool
+    {
+        global $mon_articles_test_registered_scripts;
+
+        if (!is_array($mon_articles_test_registered_scripts)) {
+            $mon_articles_test_registered_scripts = array();
+        }
+
+        $mon_articles_test_registered_scripts[(string) $handle] = array(
+            'src'       => (false === $src) ? false : (string) $src,
+            'deps'      => is_array($deps) ? array_values($deps) : array(),
+            'ver'       => is_string($ver) ? $ver : '',
+            'in_footer' => (bool) $in_footer,
+        );
+
+        return true;
+    }
+}
+
+if (!function_exists('wp_script_add_data')) {
+    /**
+     * @param string $handle
+     * @param string $key
+     * @param mixed $value
+     */
+    function wp_script_add_data($handle, $key, $value): bool
+    {
+        global $mon_articles_test_script_data;
+
+        if (!is_array($mon_articles_test_script_data)) {
+            $mon_articles_test_script_data = array();
+        }
+
+        if (!isset($mon_articles_test_script_data[(string) $handle])) {
+            $mon_articles_test_script_data[(string) $handle] = array();
+        }
+
+        $mon_articles_test_script_data[(string) $handle][(string) $key] = $value;
+
+        return true;
+    }
+}
+
 if (!function_exists('wp_parse_args')) {
     function wp_parse_args($args, $defaults = array())
     {


### PR DESCRIPTION
## Summary
- register the plugin's asset handles during `init` while keeping the existing frontend hook
- enqueue the block editor dependencies so REST previews receive required styles and scripts
- extend the test bootstrap with registration stubs and cover the new enqueue flow

## Testing
- composer install
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68dc353a56a4832e9c6d2c5fee294412