### PR TITLE
Switch category filter navigation to buttons

### DIFF
--- a/mon-affichage-article/assets/css/styles.css
+++ b/mon-affichage-article/assets/css/styles.css
@@ -32,7 +32,8 @@
 .my-articles-filter-nav.filter-align-center ul { justify-content: center; }
 .my-articles-filter-nav.filter-align-right ul { justify-content: flex-end; }
 
-.my-articles-filter-nav li a {
+.my-articles-filter-nav li a,
+.my-articles-filter-nav li button {
     display: block;
     padding: 5px 12px;
     margin: 0 0 5px 5px;
@@ -42,10 +43,16 @@
     border-radius: 4px;
     font-size: 13px;
     transition: all 0.2s ease;
+    border: none;
+    cursor: pointer;
+    font: inherit;
 }
 
 .my-articles-filter-nav li.active a,
-.my-articles-filter-nav li a:hover {
+.my-articles-filter-nav li.active button,
+.my-articles-filter-nav li a:hover,
+.my-articles-filter-nav li button:hover,
+.my-articles-filter-nav li button:focus-visible {
     color: #fff;
     background: #333;
 }

--- a/mon-affichage-article/assets/js/filter.js
+++ b/mon-affichage-article/assets/js/filter.js
@@ -74,11 +74,11 @@
         }
     }
 
-    $(document).on('click', '.my-articles-filter-nav a', function (e) {
+    $(document).on('click', '.my-articles-filter-nav button, .my-articles-filter-nav a', function (e) {
         e.preventDefault();
 
         var filterLink = $(this);
-        var filterItem = filterLink.parent();
+        var filterItem = filterLink.closest('li');
         var navList = filterItem.closest('ul');
         var previousActiveItem = navList.find('li.active').first();
         var categorySlug = filterLink.data('category');
@@ -91,7 +91,9 @@
         }
 
         navList.find('li').removeClass('active');
+        navList.find('button, a').attr('aria-pressed', 'false');
         filterItem.addClass('active');
+        filterLink.attr('aria-pressed', 'true');
 
         $.ajax({
             url: filterSettings.ajax_url,
@@ -245,8 +247,10 @@
                     }
                 } else {
                     filterItem.removeClass('active');
+                    filterLink.attr('aria-pressed', 'false');
                     if (previousActiveItem && previousActiveItem.length) {
                         previousActiveItem.addClass('active');
+                        previousActiveItem.find('button, a').first().attr('aria-pressed', 'true');
                     }
 
                     contentArea.css('opacity', 1);
@@ -259,8 +263,10 @@
             },
             error: function (jqXHR) {
                 filterItem.removeClass('active');
+                filterLink.attr('aria-pressed', 'false');
                 if (previousActiveItem && previousActiveItem.length) {
                     previousActiveItem.addClass('active');
+                    previousActiveItem.find('button, a').first().attr('aria-pressed', 'true');
                 }
 
                 contentArea.css('opacity', 1);

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -873,11 +873,11 @@ class My_Articles_Shortcode {
             echo '<nav class="my-articles-filter-nav ' . $alignment_class . '"><ul>';
             $default_cat   = $options['term'] ?? '';
             $is_all_active = '' === $default_cat || 'all' === $default_cat;
-            echo '<li class="' . ( $is_all_active ? 'active' : '' ) . '"><a href="#" data-category="all">' . esc_html__( 'Tout', 'mon-articles' ) . '</a></li>';
+            echo '<li class="' . ( $is_all_active ? 'active' : '' ) . '"><button type="button" data-category="all" aria-pressed="' . ( $is_all_active ? 'true' : 'false' ) . '">' . esc_html__( 'Tout', 'mon-articles' ) . '</button></li>';
 
             foreach ( $available_categories as $category ) {
                 $is_active = ( $default_cat === $category->slug );
-                echo '<li class="' . ( $is_active ? 'active' : '' ) . '"><a href="#" data-category="' . esc_attr( $category->slug ) . '">' . esc_html( $category->name ) . '</a></li>';
+                echo '<li class="' . ( $is_active ? 'active' : '' ) . '"><button type="button" data-category="' . esc_attr( $category->slug ) . '" aria-pressed="' . ( $is_active ? 'true' : 'false' ) . '">' . esc_html( $category->name ) . '</button></li>';
             }
 
             echo '</ul></nav>';


### PR DESCRIPTION
## Summary
- render category filters as real buttons while preserving data attributes and adding aria-pressed state
- update the filter script to listen to button activations and keep pagination/load-more integration intact
- refresh filter styles to target the new button elements without changing the visual design

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dc35371070832ea32331978c88cea5