### PR TITLE
Share URL state helper between filter and load more scripts

### DIFF
--- a/mon-affichage-article/assets/js/filter.js
+++ b/mon-affichage-article/assets/js/filter.js
@@ -3,6 +3,9 @@
     'use strict';
 
     var filterSettings = (typeof myArticlesFilter !== 'undefined') ? myArticlesFilter : {};
+    var updateInstanceQueryParams = (typeof window !== 'undefined' && window.MyArticlesUtils && typeof window.MyArticlesUtils.updateInstanceQueryParams === 'function')
+        ? window.MyArticlesUtils.updateInstanceQueryParams
+        : function () {};
 
     function getFeedbackElement(wrapper) {
         var feedback = wrapper.find('.my-articles-feedback');
@@ -31,47 +34,6 @@
     function showError(wrapper, message) {
         var feedback = getFeedbackElement(wrapper);
         feedback.text(message).addClass('is-error').show();
-    }
-
-    function updateInstanceQueryParams(instanceId, params) {
-        if (typeof window === 'undefined' || !window.history) {
-            return;
-        }
-
-        var historyApi = window.history;
-        var historyMethod = null;
-
-        if (typeof historyApi.replaceState === 'function') {
-            historyMethod = 'replaceState';
-        } else if (typeof historyApi.pushState === 'function') {
-            historyMethod = 'pushState';
-        }
-
-        if (!historyMethod) {
-            return;
-        }
-
-        try {
-            var currentUrl = window.location && window.location.href ? window.location.href : '';
-            if (!currentUrl) {
-                return;
-            }
-
-            var url = new URL(currentUrl);
-
-            Object.keys(params || {}).forEach(function (key) {
-                var value = params[key];
-                if (value === null || typeof value === 'undefined' || value === '') {
-                    url.searchParams.delete(key);
-                } else {
-                    url.searchParams.set(key, value);
-                }
-            });
-
-            historyApi[historyMethod](null, '', url.toString());
-        } catch (error) {
-            // Silencieusement ignorer les erreurs (navigateurs plus anciens)
-        }
     }
 
     $(document).on('click', '.my-articles-filter-nav a', function (e) {

--- a/mon-affichage-article/assets/js/load-more.js
+++ b/mon-affichage-article/assets/js/load-more.js
@@ -3,6 +3,9 @@
     'use strict';
 
     var loadMoreSettings = (typeof myArticlesLoadMore !== 'undefined') ? myArticlesLoadMore : {};
+    var updateInstanceQueryParams = (typeof window !== 'undefined' && window.MyArticlesUtils && typeof window.MyArticlesUtils.updateInstanceQueryParams === 'function')
+        ? window.MyArticlesUtils.updateInstanceQueryParams
+        : function () {};
 
     function getFeedbackElement(wrapper) {
         var feedback = wrapper.find('.my-articles-feedback');
@@ -31,47 +34,6 @@
     function showError(wrapper, message) {
         var feedback = getFeedbackElement(wrapper);
         feedback.text(message).addClass('is-error').show();
-    }
-
-    function updateInstanceQueryParams(instanceId, params) {
-        if (typeof window === 'undefined' || !window.history) {
-            return;
-        }
-
-        var historyApi = window.history;
-        var historyMethod = null;
-
-        if (typeof historyApi.replaceState === 'function') {
-            historyMethod = 'replaceState';
-        } else if (typeof historyApi.pushState === 'function') {
-            historyMethod = 'pushState';
-        }
-
-        if (!historyMethod) {
-            return;
-        }
-
-        try {
-            var currentUrl = window.location && window.location.href ? window.location.href : '';
-            if (!currentUrl) {
-                return;
-            }
-
-            var url = new URL(currentUrl);
-
-            Object.keys(params || {}).forEach(function (key) {
-                var value = params[key];
-                if (value === null || typeof value === 'undefined' || value === '') {
-                    url.searchParams.delete(key);
-                } else {
-                    url.searchParams.set(key, value);
-                }
-            });
-
-            historyApi[historyMethod](null, '', url.toString());
-        } catch (error) {
-            // Silencieusement ignorer les erreurs pour les navigateurs ne supportant pas l'API
-        }
     }
 
     $(document).on('click', '.my-articles-load-more-btn', function (e) {

--- a/mon-affichage-article/assets/js/utils/url-state.js
+++ b/mon-affichage-article/assets/js/utils/url-state.js
@@ -1,0 +1,49 @@
+// Fichier: assets/js/utils/url-state.js
+(function (global) {
+    'use strict';
+
+    if (!global) {
+        return;
+    }
+
+    function updateInstanceQueryParams(instanceId, params) {
+        if (typeof global.history === 'undefined') {
+            return;
+        }
+
+        var historyApi = global.history;
+        var historyMethod = null;
+
+        if (typeof historyApi.replaceState === 'function') {
+            historyMethod = 'replaceState';
+        } else if (typeof historyApi.pushState === 'function') {
+            historyMethod = 'pushState';
+        }
+
+        if (!historyMethod || !global.location || !global.location.href) {
+            return;
+        }
+
+        try {
+            var url = new URL(global.location.href);
+
+            Object.keys(params || {}).forEach(function (key) {
+                var value = params[key];
+
+                if (value === null || typeof value === 'undefined' || value === '') {
+                    url.searchParams.delete(key);
+                } else {
+                    url.searchParams.set(key, value);
+                }
+            });
+
+            historyApi[historyMethod](null, '', url.toString());
+        } catch (error) {
+            // Silencieusement ignorer les erreurs (navigateurs plus anciens ou URL invalide)
+        }
+    }
+
+    global.MyArticlesUtils = global.MyArticlesUtils || {};
+    global.MyArticlesUtils.updateInstanceQueryParams = updateInstanceQueryParams;
+
+})(typeof window !== 'undefined' ? window : null);

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -763,8 +763,20 @@ class My_Articles_Shortcode {
         $resolved_taxonomy = $options['resolved_taxonomy'];
         $available_categories = $options['available_categories'];
 
+        $should_enqueue_url_state = !empty($options['show_category_filter']) || 'load_more' === $options['pagination_mode'];
+
+        if ( $should_enqueue_url_state ) {
+            wp_enqueue_script(
+                'my-articles-url-state',
+                MY_ARTICLES_PLUGIN_URL . 'assets/js/utils/url-state.js',
+                [],
+                MY_ARTICLES_VERSION,
+                true
+            );
+        }
+
         if ( !empty($options['show_category_filter']) ) {
-            wp_enqueue_script('my-articles-filter', MY_ARTICLES_PLUGIN_URL . 'assets/js/filter.js', ['jquery'], MY_ARTICLES_VERSION, true);
+            wp_enqueue_script('my-articles-filter', MY_ARTICLES_PLUGIN_URL . 'assets/js/filter.js', ['jquery', 'my-articles-url-state'], MY_ARTICLES_VERSION, true);
             wp_localize_script(
                 'my-articles-filter',
                 'myArticlesFilter',
@@ -777,7 +789,7 @@ class My_Articles_Shortcode {
         }
 
         if ( $options['pagination_mode'] === 'load_more' ) {
-            wp_enqueue_script('my-articles-load-more', MY_ARTICLES_PLUGIN_URL . 'assets/js/load-more.js', ['jquery'], MY_ARTICLES_VERSION, true);
+            wp_enqueue_script('my-articles-load-more', MY_ARTICLES_PLUGIN_URL . 'assets/js/load-more.js', ['jquery', 'my-articles-url-state'], MY_ARTICLES_VERSION, true);
             wp_localize_script(
                 'my-articles-load-more',
                 'myArticlesLoadMore',


### PR DESCRIPTION
## Summary
- add a shared URL-state utility to update instance query parameters
- switch the filter and load-more scripts to use the shared helper
- enqueue the new script for shortcodes that need filter or load-more behavior

## Testing
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68dc353c4258832eb41da130f4bedd0a