### PR TITLE
Handle load-more mode validation

### DIFF
--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -380,7 +380,23 @@ final class Mon_Affichage_Articles {
             );
         }
 
+        $pagination_mode = isset( $options['pagination_mode'] ) ? $options['pagination_mode'] : 'none';
+
+        if ( 'load_more' !== $pagination_mode ) {
+            wp_send_json_error(
+                array( 'message' => __( 'Le chargement progressif est désactivé pour cette instance.', 'mon-articles' ) ),
+                400
+            );
+        }
+
         $display_mode = $options['display_mode'];
+
+        if ( ! in_array( $display_mode, array( 'grid', 'list' ), true ) ) {
+            wp_send_json_error(
+                array( 'message' => __( 'Le mode d\'affichage sélectionné est incompatible avec "Charger plus".', 'mon-articles' ) ),
+                400
+            );
+        }
 
         $seen_pinned_ids = array();
         if ( ! empty( $pinned_ids_str ) ) {


### PR DESCRIPTION
## Summary
- return an error from the load more AJAX handler when the instance is not configured for the load-more pagination mode
- guard against incompatible display modes for the load more endpoint
- cover the new behavior with a regression test that ensures no WP_Query calls are triggered when load more is disabled

## Testing
- composer test -- --filter LoadMoreArticlesCallbackTest

------
https://chatgpt.com/codex/tasks/task_e_68dc451f97ac832ea1b326d2ed70c187