### PR TITLE
Clean up stale Swiper references before reinitialization

### DIFF
--- a/mon-affichage-article/assets/js/responsive-layout.js
+++ b/mon-affichage-article/assets/js/responsive-layout.js
@@ -76,7 +76,7 @@
         }
 
         const swiper = window.mySwiperInstances[instanceId];
-        if (!swiper) {
+        if (!swiper || !swiper.params) {
             return;
         }
 

--- a/mon-affichage-article/assets/js/swiper-init.js
+++ b/mon-affichage-article/assets/js/swiper-init.js
@@ -79,6 +79,7 @@
         const existingInstance = window.mySwiperInstances[instanceId];
         if (existingInstance && typeof existingInstance.destroy === 'function') {
             existingInstance.destroy(true, true);
+            delete window.mySwiperInstances[instanceId];
         }
 
         if (wrapper.classList) {


### PR DESCRIPTION
## Summary
- remove stale Swiper instance references before reinitializing wrappers
- guard responsive layout updates when a Swiper instance lacks params

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc59d226f0832ea0a86681581e712c