### PR TITLE
Ensure slideshow remains visible until Swiper initialization

### DIFF
--- a/mon-affichage-article/assets/css/styles.css
+++ b/mon-affichage-article/assets/css/styles.css
@@ -6,9 +6,14 @@
 }
 
 .my-articles-wrapper.my-articles-slideshow {
+    visibility: visible;
+    opacity: 1;
+    transition: opacity 0.4s ease;
+}
+
+.my-articles-wrapper.my-articles-slideshow.swiper-is-loading {
     visibility: hidden;
     opacity: 0;
-    transition: opacity 0.4s ease;
 }
 
 .my-articles-wrapper.my-articles-slideshow.swiper-initialized {

--- a/mon-affichage-article/assets/js/swiper-init.js
+++ b/mon-affichage-article/assets/js/swiper-init.js
@@ -84,6 +84,7 @@
 
         if (wrapper.classList) {
             wrapper.classList.remove('swiper-initialized');
+            wrapper.classList.add('swiper-is-loading');
         }
 
         const instance = new Swiper(settings.container_selector, {
@@ -107,6 +108,7 @@
                 init: function () {
                     const mainWrapper = document.querySelector('#my-articles-wrapper-' + instanceId);
                     if (mainWrapper) {
+                        mainWrapper.classList.remove('swiper-is-loading');
                         mainWrapper.classList.add('swiper-initialized');
                     }
                 },


### PR DESCRIPTION
## Summary
- show the slideshow markup by default and only hide it while Swiper is preparing
- toggle the new loading class when the Swiper instance is created and initialized

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc5c83c7ec832e829b5626b2d6628e