### PR TITLE
Increase default meta font size and enforce mobile minimum

### DIFF
--- a/mon-affichage-article/assets/css/styles.css
+++ b/mon-affichage-article/assets/css/styles.css
@@ -245,6 +245,14 @@
         margin-bottom: 15px;
         flex-basis: auto;
     }
+
+    .my-article-item .article-meta {
+        font-size: clamp(14px, var(--my-articles-meta-font-size), var(--my-articles-meta-font-size));
+    }
+
+    .my-article-item .my-article-excerpt {
+        font-size: clamp(14px, var(--my-articles-excerpt-font-size), var(--my-articles-excerpt-font-size));
+    }
 }
 
 .my-articles-load-more-container {

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -399,7 +399,7 @@ class My_Articles_Shortcode {
             'list_content_padding_top' => 0, 'list_content_padding_right' => 0,
             'list_content_padding_bottom' => 0, 'list_content_padding_left' => 0,
             'border_radius' => 12, 'title_font_size' => 16,
-            'meta_font_size' => 12, 'show_category' => 1, 'show_author' => 1, 'show_date' => 1,
+            'meta_font_size' => 14, 'show_category' => 1, 'show_author' => 1, 'show_date' => 1,
             'show_excerpt' => 0,
             'excerpt_length' => 25,
             'excerpt_more_text' => 'Lire la suite',


### PR DESCRIPTION
## Summary
- raise the default meta font size option to 14px to improve baseline readability
- clamp the meta and excerpt font sizes on small screens so they cannot shrink below 14px while still respecting user settings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc5c7e66c4832ea34fb483c611e900