### PR TITLE
Improve mobile ergonomics of article filters and pagination

### DIFF
--- a/mon-affichage-article/assets/css/styles.css
+++ b/mon-affichage-article/assets/css/styles.css
@@ -48,6 +48,38 @@
     font: inherit;
 }
 
+@media (max-width: 767px) {
+    .my-articles-filter-nav li a,
+    .my-articles-filter-nav li button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 10px 18px;
+        font-size: 15px;
+        margin: 5px 5px 0 0;
+    }
+
+    .my-articles-load-more-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 12px 24px;
+        font-size: 16px;
+    }
+
+    .my-articles-pagination .page-numbers {
+        min-height: 44px;
+        padding: 10px 16px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 15px;
+        margin: 5px 4px 0;
+    }
+}
+
 .my-articles-filter-nav li.active a,
 .my-articles-filter-nav li.active button,
 .my-articles-filter-nav li a:hover,


### PR DESCRIPTION
## Summary
- increase the tap target size and spacing of the filter navigation buttons on mobile viewports
- enlarge the load more and pagination controls to avoid overlaps on small screens

## Testing
- Visual check at 360x640 viewport

------
https://chatgpt.com/codex/tasks/task_e_68dc5c7b9338832e8166624e288e06d7