### PR TITLE
Fix slideshow spacing to prevent overflow

### DIFF
--- a/mon-affichage-article/assets/css/styles.css
+++ b/mon-affichage-article/assets/css/styles.css
@@ -97,8 +97,20 @@
 /* *** CORRECTIF SLIDESHOW & HAUTEURS (v9) *** */
 .my-articles-slideshow .swiper-container {
     padding: 20px;
-    margin: -20px;
+    margin: 0;
+    box-sizing: border-box;
     overflow: clip;
+}
+
+.my-articles-slideshow .swiper-container .swiper-button-prev,
+.my-articles-slideshow .swiper-container .swiper-button-next {
+    right: 20px;
+    left: auto;
+}
+
+.my-articles-slideshow .swiper-container .swiper-button-prev {
+    left: 20px;
+    right: auto;
 }
 
 .my-articles-slideshow .swiper-slide {


### PR DESCRIPTION
## Summary
- replace the negative margin on the slideshow container with border-box padding to prevent overflow
- align the swiper navigation buttons with the adjusted container spacing

## Testing
- browser_container.run_playwright_script (viewport 375px, confirms no horizontal scroll)


------
https://chatgpt.com/codex/tasks/task_e_68dd0ebb2590832ead0208d1dcb36418