### PR TITLE
Improve slideshow accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ mon-affichage-article/
 - **Tests PHP** : `composer test`
 - **Tests JS** : `npm run test:js`
 
+## Accessibilité
+
+- Le mode diaporama expose désormais un carrousel conforme aux recommandations ARIA (région labellisée, boutons de navigation et pagination explicitement décrits).
+- La navigation clavier est activée par défaut dans Swiper et les messages d’assistance sont personnalisés pour les lecteurs d’écran.
+
 ## Hooks AJAX
 
 - `filter_articles`

--- a/mon-affichage-article/assets/js/__tests__/slideshow-preloader.test.js
+++ b/mon-affichage-article/assets/js/__tests__/slideshow-preloader.test.js
@@ -1,7 +1,21 @@
-const { preloadNeighbouringSlides } = require('../swiper-init');
+describe('slideshow utilities', () => {
+    afterEach(() => {
+        jest.resetModules();
+        delete global.Swiper;
+        if (typeof window !== 'undefined') {
+            Object.keys(window)
+                .filter((key) => key.indexOf('myArticlesSwiperSettings_') === 0)
+                .forEach((key) => {
+                    delete window[key];
+                });
+            delete window.mySwiperInstances;
+        }
+    });
 
-describe('slideshow preloader', () => {
     it('ignores undefined neighbouring slides without throwing', () => {
+        jest.resetModules();
+        const { preloadNeighbouringSlides } = require('../swiper-init');
+
         const neighbour = {
             dataset: {},
             querySelectorAll: jest.fn(() => []),
@@ -23,5 +37,62 @@ describe('slideshow preloader', () => {
         }).not.toThrow();
 
         expect(neighbour.querySelectorAll).toHaveBeenCalledWith('[data-src], [data-srcset], [data-background-image]');
+    });
+
+    it('configures keyboard navigation and accessibility messages on init', () => {
+        document.body.innerHTML = '';
+        const wrapper = document.createElement('div');
+        wrapper.id = 'my-articles-wrapper-123';
+        wrapper.className = 'my-articles-wrapper my-articles-slideshow';
+        wrapper.dataset.instanceId = '123';
+
+        const container = document.createElement('div');
+        container.className = 'swiper-container';
+        wrapper.appendChild(container);
+        document.body.appendChild(wrapper);
+
+        const swiperInstance = { destroy: jest.fn(), slides: [] };
+        const swiperConstructor = jest.fn(() => swiperInstance);
+        global.Swiper = swiperConstructor;
+
+        window.myArticlesSwiperSettings_123 = {
+            columns_mobile: 1,
+            columns_tablet: 2,
+            columns_desktop: 3,
+            columns_ultrawide: 4,
+            gap_size: 16,
+            container_selector: '#my-articles-wrapper-123 .swiper-container',
+            a11y_prev_slide_message: 'Précédente',
+            a11y_next_slide_message: 'Suivante',
+            a11y_first_slide_message: 'Première',
+            a11y_last_slide_message: 'Dernière',
+            a11y_pagination_bullet_message: 'Aller à {{index}}',
+            a11y_slide_label_message: 'Diapositive {{index}}/{{slidesLength}}',
+            a11y_container_message: 'Navigation clavier activée',
+            a11y_container_role_description: 'Carrousel',
+            a11y_item_role_description: 'Diapositive',
+        };
+
+        jest.resetModules();
+        const { initSwiperForWrapper } = require('../swiper-init');
+        const result = initSwiperForWrapper(wrapper);
+
+        expect(result).toBe(swiperInstance);
+        expect(swiperConstructor).toHaveBeenCalledWith('#my-articles-wrapper-123 .swiper-container', expect.objectContaining({
+            keyboard: { enabled: true, onlyInViewport: true },
+            watchOverflow: true,
+            a11y: expect.objectContaining({
+                enabled: true,
+                prevSlideMessage: 'Précédente',
+                nextSlideMessage: 'Suivante',
+                firstSlideMessage: 'Première',
+                lastSlideMessage: 'Dernière',
+                paginationBulletMessage: 'Aller à {{index}}',
+                slideLabelMessage: 'Diapositive {{index}}/{{slidesLength}}',
+                containerMessage: 'Navigation clavier activée',
+                containerRoleDescriptionMessage: 'Carrousel',
+                itemRoleDescriptionMessage: 'Diapositive',
+            }),
+        }));
     });
 });

--- a/mon-affichage-article/assets/js/swiper-init.js
+++ b/mon-affichage-article/assets/js/swiper-init.js
@@ -161,6 +161,11 @@
             slidesPerView: settings.columns_mobile,
             spaceBetween: settings.gap_size,
             loop: true,
+            watchOverflow: true,
+            keyboard: {
+                enabled: true,
+                onlyInViewport: true,
+            },
             pagination: {
                 el: settings.container_selector + ' .swiper-pagination',
                 clickable: true,
@@ -168,6 +173,18 @@
             navigation: {
                 nextEl: settings.container_selector + ' .swiper-button-next',
                 prevEl: settings.container_selector + ' .swiper-button-prev',
+            },
+            a11y: {
+                enabled: true,
+                prevSlideMessage: settings.a11y_prev_slide_message,
+                nextSlideMessage: settings.a11y_next_slide_message,
+                firstSlideMessage: settings.a11y_first_slide_message,
+                lastSlideMessage: settings.a11y_last_slide_message,
+                paginationBulletMessage: settings.a11y_pagination_bullet_message,
+                slideLabelMessage: settings.a11y_slide_label_message,
+                containerMessage: settings.a11y_container_message,
+                containerRoleDescriptionMessage: settings.a11y_container_role_description,
+                itemRoleDescriptionMessage: settings.a11y_item_role_description,
             },
             breakpoints: {
                 768: { slidesPerView: settings.columns_tablet, spaceBetween: settings.gap_size },

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -1046,6 +1046,13 @@ class My_Articles_Shortcode {
     private function render_slideshow($pinned_query, $regular_query, $options, $posts_per_page) {
         $is_unlimited       = (int) $posts_per_page <= 0;
         $total_posts_needed = $is_unlimited ? PHP_INT_MAX : (int) $posts_per_page;
+
+        $carousel_label        = esc_attr( __( 'Carrousel des articles', 'mon-articles' ) );
+        $pagination_label      = esc_attr( __( 'Pagination du carrousel', 'mon-articles' ) );
+        $next_slide_label      = esc_attr( __( 'Aller à la diapositive suivante', 'mon-articles' ) );
+        $previous_slide_label  = esc_attr( __( 'Revenir à la diapositive précédente', 'mon-articles' ) );
+
+        echo '<div class="swiper-accessibility-wrapper" role="region" aria-roledescription="carousel" aria-label="' . $carousel_label . '">';
         echo '<div class="swiper-container"><div class="swiper-wrapper">';
         $post_count = 0;
 
@@ -1073,7 +1080,12 @@ class My_Articles_Shortcode {
             $this->render_empty_state_message( true );
         }
 
-        echo '</div><div class="swiper-pagination"></div><div class="swiper-button-next"></div><div class="swiper-button-prev"></div></div>';
+        echo '</div>';
+        echo '<div class="swiper-pagination" aria-label="' . $pagination_label . '"></div>';
+        echo '<div class="swiper-button-next" aria-label="' . $next_slide_label . '"></div>';
+        echo '<div class="swiper-button-prev" aria-label="' . $previous_slide_label . '"></div>';
+        echo '</div>';
+        echo '</div>';
 
         if ( $pinned_query instanceof WP_Query || $regular_query instanceof WP_Query ) {
             wp_reset_postdata();
@@ -1286,7 +1298,25 @@ class My_Articles_Shortcode {
         wp_enqueue_style('swiper-css');
         wp_enqueue_script('swiper-js');
         wp_enqueue_script('my-articles-swiper-init', MY_ARTICLES_PLUGIN_URL . 'assets/js/swiper-init.js', ['swiper-js', 'my-articles-responsive-layout'], MY_ARTICLES_VERSION, true);
-        wp_localize_script('my-articles-swiper-init', 'myArticlesSwiperSettings_' . $instance_id, [ 'columns_mobile' => $options['columns_mobile'], 'columns_tablet' => $options['columns_tablet'], 'columns_desktop' => $options['columns_desktop'], 'columns_ultrawide' => $options['columns_ultrawide'], 'gap_size' => $options['gap_size'], 'container_selector' => '#my-articles-wrapper-' . $instance_id . ' .swiper-container' ]);
+        $localized_settings = array(
+            'columns_mobile'                    => $options['columns_mobile'],
+            'columns_tablet'                    => $options['columns_tablet'],
+            'columns_desktop'                   => $options['columns_desktop'],
+            'columns_ultrawide'                 => $options['columns_ultrawide'],
+            'gap_size'                          => $options['gap_size'],
+            'container_selector'                => '#my-articles-wrapper-' . $instance_id . ' .swiper-container',
+            'a11y_prev_slide_message'           => __( 'Diapositive précédente', 'mon-articles' ),
+            'a11y_next_slide_message'           => __( 'Diapositive suivante', 'mon-articles' ),
+            'a11y_first_slide_message'          => __( 'Première diapositive', 'mon-articles' ),
+            'a11y_last_slide_message'           => __( 'Dernière diapositive', 'mon-articles' ),
+            'a11y_pagination_bullet_message'    => __( 'Aller à la diapositive {{index}}', 'mon-articles' ),
+            'a11y_slide_label_message'          => __( 'Diapositive {{index}} sur {{slidesLength}}', 'mon-articles' ),
+            'a11y_container_message'            => __( 'Ce carrousel est navigable au clavier : utilisez les flèches pour changer de diapositive.', 'mon-articles' ),
+            'a11y_container_role_description'   => __( 'Carrousel d\'articles', 'mon-articles' ),
+            'a11y_item_role_description'        => __( 'Diapositive', 'mon-articles' ),
+        );
+
+        wp_localize_script('my-articles-swiper-init', 'myArticlesSwiperSettings_' . $instance_id, $localized_settings);
     }
     
     /**

--- a/tests/RenderArticlesContainerTest.php
+++ b/tests/RenderArticlesContainerTest.php
@@ -78,4 +78,24 @@ final class RenderArticlesContainerTest extends TestCase
             array('render_grid'),
         );
     }
+
+    public function test_render_slideshow_outputs_accessibility_attributes(): void
+    {
+        $reflection = new \ReflectionClass(My_Articles_Shortcode::class);
+        $shortcode = $reflection->newInstanceWithoutConstructor();
+
+        $method = $reflection->getMethod('render_slideshow');
+        $method->setAccessible(true);
+
+        ob_start();
+        $method->invoke($shortcode, null, null, array(), 0);
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString('role="region"', $html);
+        $this->assertStringContainsString('aria-roledescription="carousel"', $html);
+        $this->assertStringContainsString('aria-label="Carrousel des articles"', $html);
+        $this->assertStringContainsString('class="swiper-pagination" aria-label="Pagination du carrousel"', $html);
+        $this->assertStringContainsString('class="swiper-button-next" aria-label="Aller à la diapositive suivante"', $html);
+        $this->assertStringContainsString('class="swiper-button-prev" aria-label="Revenir à la diapositive précédente"', $html);
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -432,6 +432,16 @@ if (!function_exists('has_post_thumbnail')) {
     }
 }
 
+if (!function_exists('get_the_terms')) {
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    function get_the_terms($post_id, $taxonomy)
+    {
+        return array();
+    }
+}
+
 if (!function_exists('wp_get_attachment_image_src')) {
     function wp_get_attachment_image_src($attachment_id, $size = 'thumbnail')
     {


### PR DESCRIPTION
## Summary
- wrap the slideshow markup in an ARIA-labelled region and expose navigation controls with descriptive aria-labels
- localize accessibility strings, enable keyboard navigation, and extend Swiper initialisation tests
- document the new accessibility expectations in the README and cover markup with PHPUnit

## Testing
- composer test
- npm run test:js

------
https://chatgpt.com/codex/tasks/task_e_68dd201c6da8832e90c4027cced3caea