### PR TITLE
Ensure article thumbnails honour attachment alt text

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -1143,7 +1143,8 @@ class My_Articles_Shortcode {
                     if ( '' !== $thumbnail_html ) {
                         echo $thumbnail_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
                     } else {
-                        the_post_thumbnail('large');
+                        $fallback_alt = $this->resolve_thumbnail_alt_text( $image_id, $title_attr );
+                        the_post_thumbnail( 'large', array( 'alt' => $fallback_alt ) );
                     }
                 else: ?>
                     <?php $fallback_placeholder = MY_ARTICLES_PLUGIN_URL . 'assets/images/placeholder.svg'; ?>
@@ -1202,9 +1203,26 @@ class My_Articles_Shortcode {
         <?php
     }
 
+    private function resolve_thumbnail_alt_text( $image_id, $title_attr ) {
+        $raw_alt = get_post_meta( $image_id, '_wp_attachment_image_alt', true );
+
+        if ( ! is_string( $raw_alt ) ) {
+            $raw_alt = '';
+        } else {
+            $raw_alt = trim( $raw_alt );
+        }
+
+        if ( '' === $raw_alt ) {
+            $raw_alt = $title_attr;
+        }
+
+        return $raw_alt;
+    }
+
     private function get_article_thumbnail_html( $image_id, $title_attr, $enable_lazy_load ) {
         $size            = 'large';
         $placeholder_src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+        $alt_text        = $this->resolve_thumbnail_alt_text( $image_id, $title_attr );
 
         if ( $enable_lazy_load ) {
             $image_data = wp_get_attachment_image_src( $image_id, $size );
@@ -1222,7 +1240,7 @@ class My_Articles_Shortcode {
             $attributes = array(
                 'src'        => $placeholder_src,
                 'class'      => 'attachment-large size-large wp-post-image lazyload',
-                'alt'        => $title_attr,
+                'alt'        => $alt_text,
                 'data-sizes' => 'auto',
                 'data-src'   => $image_src,
                 'decoding'   => 'async',
@@ -1268,7 +1286,7 @@ class My_Articles_Shortcode {
 
         $attributes = array(
             'class'    => 'attachment-large size-large wp-post-image',
-            'alt'      => $title_attr,
+            'alt'      => $alt_text,
             'decoding' => 'async',
             'loading'  => 'eager',
         );

--- a/tests/RenderArticleItemTest.php
+++ b/tests/RenderArticleItemTest.php
@@ -13,9 +13,10 @@ final class RenderArticleItemTest extends TestCase
     {
         parent::tearDown();
 
-        global $mon_articles_test_term_list_callback;
+        global $mon_articles_test_term_list_callback, $mon_articles_test_post_meta_map;
 
         $mon_articles_test_term_list_callback = null;
+        $mon_articles_test_post_meta_map      = null;
     }
 
     public function test_render_article_item_ignores_wp_error_term_list(): void
@@ -76,6 +77,27 @@ final class RenderArticleItemTest extends TestCase
 
         $this->assertStringContainsString('loading="lazy"', $html);
         $this->assertStringNotContainsString('loading="eager"', $html);
+    }
+
+    public function test_thumbnail_uses_custom_alt_text(): void
+    {
+        global $mon_articles_test_post_meta_map;
+
+        $mon_articles_test_post_meta_map = array(
+            321 => array(
+                '_wp_attachment_image_alt' => 'Texte alternatif personnalisé',
+            ),
+        );
+
+        $reflection = new \ReflectionClass(My_Articles_Shortcode::class);
+        $shortcode = $reflection->newInstanceWithoutConstructor();
+
+        $method = $reflection->getMethod('get_article_thumbnail_html');
+        $method->setAccessible(true);
+
+        $html = $method->invoke($shortcode, 321, 'Titre de secours', false);
+
+        $this->assertStringContainsString('alt="Texte alternatif personnalisé"', $html);
     }
 
     public function test_excerpt_length_zero_omits_ellipsis_but_keeps_read_more(): void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -475,7 +475,7 @@ if (!function_exists('get_post_thumbnail_id')) {
 }
 
 if (!function_exists('the_post_thumbnail')) {
-    function the_post_thumbnail($size = 'post-thumbnail')
+    function the_post_thumbnail($size = 'post-thumbnail', $attr = '')
     {
         // No-op.
     }
@@ -498,6 +498,27 @@ if (!function_exists('get_the_term_list')) {
         }
 
         return '';
+    }
+}
+
+if (!function_exists('get_the_terms')) {
+    function get_the_terms($post_id, $taxonomy)
+    {
+        global $mon_articles_test_term_list_callback;
+
+        if (is_callable($mon_articles_test_term_list_callback)) {
+            $result = $mon_articles_test_term_list_callback($post_id, $taxonomy, '', '', '');
+
+            if ($result instanceof \WP_Error) {
+                return $result;
+            }
+
+            if (is_array($result)) {
+                return $result;
+            }
+        }
+
+        return array();
     }
 }
 


### PR DESCRIPTION
## Summary
- resolve thumbnail alt text from attachment metadata with a fallback to the post title
- pass the corrected alt text to both lazy and non-lazy thumbnail markup, including the fallback call to `the_post_thumbnail`
- extend thumbnail rendering tests and WordPress stubs to cover the new alt handling logic

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dd201d8b80832e9e66e1e9fec16932