### PR TITLE
Add configurable ARIA labels and busy state handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Options principales :
 - **Pagination** : modes `load_more` (bouton « Charger plus ») ou `numbered` (pagination classique).
 - **Articles épinglés** : possibilité d'épingler certains articles, avec option d'ignorer les filtres.
 - **Lazy load** : chargement différé des images pour optimiser les performances.
+- **Étiquette ARIA** : personnalisez le libellé utilisé par les lecteurs d'écran (par défaut, le titre du module est utilisé).
 
 > ℹ️ **Diaporama et mode illimité** : lorsque `display_mode` vaut `slideshow`, la récupération des contenus respecte toujours le plafond défini par l'option `unlimited_query_cap` (50 par défaut via le filtre `my_articles_unlimited_batch_size`). Cela évite de charger un nombre excessif d'articles d'un coup tout en conservant un mode quasi illimité.
 
@@ -58,6 +59,7 @@ mon-affichage-article/
 
 - Le mode diaporama expose désormais un carrousel conforme aux recommandations ARIA (région labellisée, boutons de navigation et pagination explicitement décrits).
 - La navigation clavier est activée par défaut dans Swiper et les messages d’assistance sont personnalisés pour les lecteurs d’écran.
+- Chaque module est annoncé comme région dynamique (`role="region"`, `aria-live="polite"`, `aria-busy`) et peut utiliser une étiquette ARIA personnalisée pour faciliter l’identification par les lecteurs d’écran. Les modules existants héritent automatiquement de leur titre tant que le champ dédié reste vide.
 
 ## Hooks AJAX
 

--- a/mon-affichage-article/assets/js/filter.js
+++ b/mon-affichage-article/assets/js/filter.js
@@ -182,6 +182,9 @@
             },
             beforeSend: function () {
                 contentArea.css('opacity', 0.5);
+                if (wrapper && wrapper.length) {
+                    wrapper.attr('aria-busy', 'true');
+                }
                 clearFeedback(wrapper);
             },
             success: function (response) {
@@ -332,6 +335,12 @@
                 }
 
                 showError(wrapper, errorMessage);
+            },
+            complete: function () {
+                contentArea.css('opacity', 1);
+                if (wrapper && wrapper.length) {
+                    wrapper.attr('aria-busy', 'false');
+                }
             }
         });
     });

--- a/mon-affichage-article/assets/js/load-more.js
+++ b/mon-affichage-article/assets/js/load-more.js
@@ -205,6 +205,9 @@
                 var loadingText = loadMoreSettings.loadingText || originalButtonText;
                 button.text(loadingText);
                 button.prop('disabled', true);
+                if (wrapper && wrapper.length) {
+                    wrapper.attr('aria-busy', 'true');
+                }
                 clearFeedback(wrapper);
             },
             success: function (response) {
@@ -328,6 +331,11 @@
                 button.prop('disabled', false);
                 showError(wrapper, errorMessage);
                 console.error(errorMessage);
+            },
+            complete: function () {
+                if (wrapper && wrapper.length) {
+                    wrapper.attr('aria-busy', 'false');
+                }
             }
         });
     });

--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -233,6 +233,34 @@ class My_Articles_Metaboxes {
         echo '<p class="my-articles-columns-warning__message" aria-live="polite"></p>';
         echo '</div>';
 
+        echo '<hr><h3>' . esc_html__( 'Accessibilité', 'mon-articles' ) . '</h3>';
+
+        $default_aria_label = '';
+        if ( isset( $post->ID ) ) {
+            $default_aria_label = trim( wp_strip_all_tags( get_the_title( $post ) ) );
+        }
+
+        if ( '' === $default_aria_label ) {
+            $default_aria_label = __( 'Module d\'articles', 'mon-articles' );
+        }
+
+        /* translators: %s: module title. */
+        $aria_description = sprintf(
+            esc_html__( 'Texte lu par les lecteurs d’écran pour identifier ce module. Laissez vide pour utiliser le titre du module (« %s »).', 'mon-articles' ),
+            $default_aria_label
+        );
+
+        $this->render_field(
+            'aria_label',
+            esc_html__( 'Étiquette ARIA', 'mon-articles' ),
+            'text',
+            $opts,
+            [
+                'placeholder' => $default_aria_label,
+                'description' => $aria_description,
+            ]
+        );
+
         echo '<hr><h3>' . esc_html__('Apparence & Performances', 'mon-articles') . '</h3>';
         $this->render_field('module_padding_left', esc_html__('Marge intérieure gauche (px)', 'mon-articles'), 'number', $opts, ['default' => 0, 'min' => 0, 'max' => 200]);
         $this->render_field('module_padding_right', esc_html__('Marge intérieure droite (px)', 'mon-articles'), 'number', $opts, ['default' => 0, 'min' => 0, 'max' => 200]);
@@ -290,7 +318,11 @@ class My_Articles_Metaboxes {
 
         switch ($type) {
             case 'text':
-                printf('<input type="text" id="%s" name="%s" value="%s" class="regular-text" />', esc_attr($id), $name, esc_attr($value));
+                $placeholder_attr = '';
+                if ( isset( $args['placeholder'] ) && '' !== $args['placeholder'] ) {
+                    $placeholder_attr = ' placeholder="' . esc_attr( $args['placeholder'] ) . '"';
+                }
+                printf('<input type="text" id="%s" name="%s" value="%s" class="regular-text"%s />', esc_attr($id), $name, esc_attr($value), $placeholder_attr);
                 if (isset($args['description'])) {
                     echo '<p class="description">' . esc_html($args['description']) . '</p>';
                 }
@@ -433,6 +465,13 @@ class My_Articles_Metaboxes {
         $sanitized['ignore_native_sticky'] = isset( $input['ignore_native_sticky'] ) ? 1 : 0;
         $sanitized['enable_lazy_load'] = isset( $input['enable_lazy_load'] ) ? 1 : 0;
         $sanitized['enable_debug_mode'] = isset( $input['enable_debug_mode'] ) ? 1 : 0;
+
+        $aria_label = '';
+        if ( isset( $input['aria_label'] ) && is_string( $input['aria_label'] ) ) {
+            $aria_label = sanitize_text_field( $input['aria_label'] );
+            $aria_label = trim( $aria_label );
+        }
+        $sanitized['aria_label'] = $aria_label;
 
         $sanitized['display_mode'] = in_array($input['display_mode'] ?? 'grid', ['grid', 'slideshow', 'list']) ? $input['display_mode'] : 'grid';
         $sanitized['columns_mobile'] = isset( $input['columns_mobile'] ) ? max( 1, absint( $input['columns_mobile'] ) ) : 1;

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -387,6 +387,7 @@ class My_Articles_Shortcode {
             'show_category_filter' => 0,
             'filter_alignment' => 'right',
             'filter_categories' => array(),
+            'aria_label' => '',
             'pinned_posts' => array(),
             'pinned_border_color' => '#eab308',
             'pinned_posts_ignore_filter' => 0,
@@ -477,6 +478,12 @@ class My_Articles_Shortcode {
 
         $defaults = self::get_default_options();
         $options  = wp_parse_args( (array) $raw_options, $defaults );
+
+        $aria_label = '';
+        if ( isset( $options['aria_label'] ) && is_string( $options['aria_label'] ) ) {
+            $aria_label = trim( sanitize_text_field( $options['aria_label'] ) );
+        }
+        $options['aria_label'] = $aria_label;
 
         $allowed_display_modes = array( 'grid', 'list', 'slideshow' );
         $display_mode          = $options['display_mode'] ?? $defaults['display_mode'];
@@ -719,6 +726,23 @@ class My_Articles_Shortcode {
             $options_meta = array_merge( $options_meta, $overrides );
         }
 
+        $default_aria_label = trim( wp_strip_all_tags( get_the_title( $id ) ) );
+        if ( '' === $default_aria_label ) {
+            /* translators: %d: module (post) ID. */
+            $default_aria_label = sprintf( __( 'Module d\'articles %d', 'mon-articles' ), $id );
+        }
+
+        $resolved_aria_label = '';
+        if ( isset( $options_meta['aria_label'] ) && is_string( $options_meta['aria_label'] ) ) {
+            $resolved_aria_label = trim( sanitize_text_field( $options_meta['aria_label'] ) );
+        }
+
+        if ( '' === $resolved_aria_label ) {
+            $resolved_aria_label = sanitize_text_field( $default_aria_label );
+        }
+
+        $options_meta['aria_label'] = $resolved_aria_label;
+
         $has_filter_categories = false;
         if ( isset( $options_meta['filter_categories'] ) ) {
             $raw_filter_categories = $options_meta['filter_categories'];
@@ -865,6 +889,10 @@ class My_Articles_Shortcode {
             'data-cols-desktop'    => $columns_desktop,
             'data-cols-ultrawide'  => $columns_ultrawide,
             'data-min-card-width'  => $min_card_width,
+            'role'                 => 'region',
+            'aria-live'            => 'polite',
+            'aria-label'           => $resolved_aria_label,
+            'aria-busy'            => 'false',
         );
 
         $wrapper_attribute_strings = array();


### PR DESCRIPTION
## Summary
- add an optional “Étiquette ARIA” field to the module metabox with sanitization and placeholder defaults
- expose aria attributes on the shortcode wrapper and reuse the resolved label during rendering
- toggle aria-busy in the filter/load-more scripts and document the new accessibility option

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dd41ee97b0832ea41c46515cbb7534