### PR TITLE
Add Jest coverage for article filters and load-more interactions

### DIFF
--- a/mon-affichage-article/assets/js/__tests__/filter.test.js
+++ b/mon-affichage-article/assets/js/__tests__/filter.test.js
@@ -1,0 +1,124 @@
+const $ = require('jquery');
+
+global.$ = $;
+global.jQuery = $;
+
+describe('filter.js', () => {
+    let filterModule;
+
+    beforeEach(() => {
+        jest.resetModules();
+        document.body.innerHTML = '';
+        $(document).off('click', '.my-articles-filter-nav button, .my-articles-filter-nav a');
+        global.myArticlesFilter = {
+            ajax_url: '/fake-endpoint',
+            nonce: 'nonce-value',
+            errorText: 'Erreur générique'
+        };
+        global.myArticlesLoadMore = {
+            loadMoreText: 'Charger plus'
+        };
+        $.ajax = jest.fn();
+
+        filterModule = require('../filter.js');
+    });
+
+    afterEach(() => {
+        delete global.myArticlesFilter;
+        delete global.myArticlesLoadMore;
+        $(document).off('click', '.my-articles-filter-nav button, .my-articles-filter-nav a');
+        jest.restoreAllMocks();
+    });
+
+    test('buildFilterFeedbackMessage returns expected labels', () => {
+        const { buildFilterFeedbackMessage } = filterModule;
+
+        expect(buildFilterFeedbackMessage(0)).toBe('Aucun article à afficher.');
+        expect(buildFilterFeedbackMessage(1)).toBe('1 article affiché.');
+        expect(buildFilterFeedbackMessage(5)).toBe('5 articles affichés.');
+    });
+
+    test('updateInstanceQueryParams updates URL parameters', () => {
+        const { updateInstanceQueryParams } = filterModule;
+
+        const mockReplace = jest.fn();
+        const mockWindow = {
+            location: { href: 'https://example.com/?foo=bar' },
+            history: { replaceState: mockReplace }
+        };
+
+        updateInstanceQueryParams('123', { 'my_articles_cat_123': 'news', remove: null }, mockWindow);
+
+        expect(mockReplace).toHaveBeenCalledWith(null, '', 'https://example.com/?foo=bar&my_articles_cat_123=news');
+    });
+
+    test('clicking a filter updates content, feedback and history', () => {
+        jest.spyOn(window.history, 'replaceState');
+        window.history.replaceState({}, '', '/?initial=1');
+
+        document.body.innerHTML = `
+            <div class="my-articles-wrapper" data-instance-id="123">
+                <div class="my-articles-filter-nav">
+                    <ul>
+                        <li class="active"><button data-category="all" aria-pressed="true">Tous</button></li>
+                        <li><button data-category="news">Actualités</button></li>
+                    </ul>
+                </div>
+                <div class="my-articles-grid-content">
+                    <article class="my-article-item">Ancien article</article>
+                </div>
+                <div class="my-articles-load-more-container">
+                    <button class="my-articles-load-more-btn" data-instance-id="123" data-paged="2" data-total-pages="3" data-pinned-ids="" data-category="">
+                        Charger plus
+                    </button>
+                </div>
+            </div>
+        `;
+
+        const wrapper = $('.my-articles-wrapper');
+        const contentArea = wrapper.find('.my-articles-grid-content');
+        const targetButton = wrapper.find('.my-articles-filter-nav li').eq(1).find('button');
+
+        $.ajax.mockImplementation((options) => {
+            if (options.beforeSend) {
+                options.beforeSend();
+            }
+
+            const response = {
+                success: true,
+                data: {
+                    html: '<article class="my-article-item">Article 1</article><article class="my-article-item">Article 2</article>',
+                    total_pages: 3,
+                    next_page: 2,
+                    pinned_ids: '10,20'
+                }
+            };
+
+            if (options.success) {
+                options.success(response);
+            }
+
+            return Promise.resolve(response);
+        });
+
+        targetButton.trigger('click');
+
+        expect($.ajax).toHaveBeenCalled();
+        expect(wrapper.attr('aria-busy')).toBe('false');
+        expect(contentArea.attr('aria-busy')).toBe('false');
+
+        const feedback = wrapper.find('.my-articles-feedback');
+        expect(feedback.text()).toBe('2 articles affichés.');
+
+        const loadMoreBtn = wrapper.find('.my-articles-load-more-btn');
+        expect(loadMoreBtn.attr('data-category')).toBe('news');
+        expect(loadMoreBtn.prop('disabled')).toBe(false);
+        expect(loadMoreBtn.attr('data-paged')).toBe('2');
+
+        const activeItem = wrapper.find('.my-articles-filter-nav li').eq(1);
+        expect(activeItem.hasClass('active')).toBe(true);
+        expect(activeItem.find('button').attr('aria-pressed')).toBe('true');
+
+        expect(window.history.replaceState).toHaveBeenCalled();
+    });
+});

--- a/mon-affichage-article/assets/js/__tests__/load-more.test.js
+++ b/mon-affichage-article/assets/js/__tests__/load-more.test.js
@@ -1,0 +1,124 @@
+const $ = require('jquery');
+
+global.$ = $;
+global.jQuery = $;
+
+describe('load-more.js', () => {
+    let loadMoreModule;
+
+    beforeEach(() => {
+        jest.resetModules();
+        document.body.innerHTML = '';
+        $(document).off('click', '.my-articles-load-more-btn');
+        global.myArticlesLoadMore = {
+            ajax_url: '/fake-endpoint',
+            nonce: 'nonce-value',
+            errorText: 'Erreur générique',
+            loadMoreText: 'Charger plus',
+            loadingText: 'Chargement...'
+        };
+        $.ajax = jest.fn();
+
+        loadMoreModule = require('../load-more.js');
+    });
+
+    afterEach(() => {
+        delete global.myArticlesLoadMore;
+        $(document).off('click', '.my-articles-load-more-btn');
+        jest.restoreAllMocks();
+    });
+
+    test('buildLoadMoreFeedbackMessage returns expected labels', () => {
+        const { buildLoadMoreFeedbackMessage } = loadMoreModule;
+
+        expect(buildLoadMoreFeedbackMessage(0, 0)).toBe('Aucun article à afficher.');
+        expect(buildLoadMoreFeedbackMessage(5, 2)).toBe('2 articles ajoutés. 5 articles affichés au total.');
+        expect(buildLoadMoreFeedbackMessage(1, 0)).toBe('Aucun article supplémentaire. 1 article affiché au total.');
+    });
+
+    test('updateInstanceQueryParams updates URL parameters', () => {
+        const { updateInstanceQueryParams } = loadMoreModule;
+
+        const mockReplace = jest.fn();
+        const mockWindow = {
+            location: { href: 'https://example.com/?foo=bar' },
+            history: { replaceState: mockReplace }
+        };
+
+        updateInstanceQueryParams('123', { 'paged_123': '3', foo: null }, mockWindow);
+
+        expect(mockReplace).toHaveBeenCalledWith(null, '', 'https://example.com/?paged_123=3');
+    });
+
+    test('clicking load more appends content, updates feedback and hides button when finished', () => {
+        jest.spyOn(window.history, 'replaceState');
+        window.history.replaceState({}, '', '/?initial=1');
+
+        document.body.innerHTML = `
+            <div class="my-articles-wrapper" data-instance-id="123">
+                <div class="my-articles-grid-content">
+                    <article class="my-article-item">Article initial</article>
+                </div>
+                <div class="my-articles-load-more-container">
+                    <button class="my-articles-load-more-btn"
+                        data-instance-id="123"
+                        data-paged="2"
+                        data-total-pages="2"
+                        data-pinned-ids=""
+                        data-category="news">
+                        Charger plus
+                    </button>
+                </div>
+            </div>
+        `;
+
+        const wrapper = $('.my-articles-wrapper');
+        const contentArea = wrapper.find('.my-articles-grid-content');
+        const button = wrapper.find('.my-articles-load-more-btn');
+
+        $.ajax.mockImplementation((options) => {
+            if (options.beforeSend) {
+                options.beforeSend();
+                expect(button.attr('aria-busy')).toBe('true');
+                expect(contentArea.attr('aria-busy')).toBe('true');
+                expect(wrapper.attr('aria-busy')).toBe('true');
+            }
+
+            const response = {
+                success: true,
+                data: {
+                    html: '<article class="my-article-item">Article ajouté</article>',
+                    total_pages: 2,
+                    next_page: 0,
+                    pinned_ids: '10,20'
+                }
+            };
+
+            if (options.success) {
+                options.success(response);
+            }
+
+            return Promise.resolve(response);
+        });
+
+        button.trigger('click');
+
+        expect($.ajax).toHaveBeenCalled();
+        expect(wrapper.attr('aria-busy')).toBe('false');
+        expect(contentArea.attr('aria-busy')).toBe('false');
+        expect(button.attr('aria-busy')).toBe('false');
+
+        const articles = contentArea.find('.my-article-item');
+        expect(articles.length).toBe(2);
+        expect(articles.eq(1).text()).toBe('Article ajouté');
+
+        const feedback = wrapper.find('.my-articles-feedback');
+        expect(feedback.text()).toBe('1 article ajouté. 2 articles affichés au total.');
+
+        expect(button.css('display')).toBe('none');
+        expect(button.prop('disabled')).toBe(false);
+        expect(button.attr('data-pinned-ids')).toBe('10,20');
+
+        expect(window.history.replaceState).toHaveBeenCalled();
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "devDependencies": {
         "jest": "^30.2.0",
-        "jest-environment-jsdom": "^30.2.0"
+        "jest-environment-jsdom": "^30.2.0",
+        "jquery": "^3.7.1"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -3441,6 +3442,13 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
+    },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
+    "jquery": "^3.7.1",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0"
   },


### PR DESCRIPTION
## Summary
- expose reusable utilities from the filter and load-more scripts and improve aria-busy handling
- add Jest test suites that simulate AJAX callbacks for the main filter and load-more behaviours
- add jquery as a dev dependency to support DOM simulations in the tests

## Testing
- npm run test:js

------
https://chatgpt.com/codex/tasks/task_e_68dd41efade8832e960a65e8b49f3606