### PR TITLE
Localize feedback messages for filter and load more scripts

### DIFF
--- a/mon-affichage-article/assets/js/filter.js
+++ b/mon-affichage-article/assets/js/filter.js
@@ -74,12 +74,57 @@
         }
     }
 
-    function buildFilterFeedbackMessage(totalCount) {
-        if (totalCount > 0) {
-            return totalCount === 1 ? '1 article affiché.' : totalCount + ' articles affichés.';
+    function formatCountMessage(template, count) {
+        if (typeof template !== 'string' || template.length === 0) {
+            return '';
         }
 
-        return 'Aucun article à afficher.';
+        if (template.indexOf('%d') !== -1) {
+            return template.replace(/%d/g, String(count));
+        }
+
+        if (template.indexOf('%s') !== -1) {
+            return template.replace(/%s/g, String(count));
+        }
+
+        return template;
+    }
+
+    function resolveFilterLabel(key, fallback) {
+        if (filterSettings && Object.prototype.hasOwnProperty.call(filterSettings, key)) {
+            var value = filterSettings[key];
+            if (typeof value === 'string' && value.length > 0) {
+                return value;
+            }
+        }
+
+        return fallback;
+    }
+
+    function buildFilterFeedbackMessage(totalCount) {
+        var fallbackSingle = '%s article affiché.';
+        var fallbackPlural = '%s articles affichés.';
+        var fallbackNone = 'Aucun article à afficher.';
+
+        var singleLabel = resolveFilterLabel('countSingle', fallbackSingle);
+        var pluralLabel = resolveFilterLabel('countPlural', fallbackPlural);
+        var noneLabel = resolveFilterLabel('countNone', fallbackNone);
+
+        if (totalCount > 0) {
+            if (totalCount === 1) {
+                var formattedSingle = formatCountMessage(singleLabel, totalCount) || formatCountMessage(fallbackSingle, totalCount);
+                return formattedSingle || fallbackSingle.replace('%s', String(totalCount));
+            }
+
+            var formattedPlural = formatCountMessage(pluralLabel, totalCount) || formatCountMessage(fallbackPlural, totalCount);
+            if (formattedPlural) {
+                return formattedPlural;
+            }
+
+            return fallbackPlural.replace('%s', String(totalCount));
+        }
+
+        return noneLabel || fallbackNone;
     }
 
     function focusElement($element) {

--- a/mon-affichage-article/assets/js/load-more.js
+++ b/mon-affichage-article/assets/js/load-more.js
@@ -74,13 +74,78 @@
         }
     }
 
+    function formatLoadMoreTemplate(template, count) {
+        if (typeof template !== 'string' || template.length === 0) {
+            return '';
+        }
+
+        if (template.indexOf('%d') !== -1) {
+            return template.replace(/%d/g, String(count));
+        }
+
+        if (template.indexOf('%s') !== -1) {
+            return template.replace(/%s/g, String(count));
+        }
+
+        return template;
+    }
+
+    function resolveLoadMoreLabel(key, fallback) {
+        if (loadMoreSettings && Object.prototype.hasOwnProperty.call(loadMoreSettings, key)) {
+            var value = loadMoreSettings[key];
+            if (typeof value === 'string' && value.length > 0) {
+                return value;
+            }
+        }
+
+        return fallback;
+    }
+
     function buildLoadMoreFeedbackMessage(totalCount, addedCount) {
-        var totalLabel = totalCount === 1 ? '1 article affiché au total.' : totalCount + ' articles affichés au total.';
+        var fallbackTotalSingle = '%s article affiché au total.';
+        var fallbackTotalPlural = '%s articles affichés au total.';
+        var fallbackAddedSingle = '%s article ajouté.';
+        var fallbackAddedPlural = '%s articles ajoutés.';
+        var fallbackNoAdditional = 'Aucun article supplémentaire.';
+        var fallbackNone = 'Aucun article à afficher.';
+
+        var totalSingleLabel = resolveLoadMoreLabel('totalSingle', fallbackTotalSingle);
+        var totalPluralLabel = resolveLoadMoreLabel('totalPlural', fallbackTotalPlural);
+        var addedSingleLabel = resolveLoadMoreLabel('addedSingle', fallbackAddedSingle);
+        var addedPluralLabel = resolveLoadMoreLabel('addedPlural', fallbackAddedPlural);
+        var noAdditionalLabel = resolveLoadMoreLabel('noAdditional', fallbackNoAdditional);
+        var noneLabel = resolveLoadMoreLabel('none', fallbackNone);
+
+        var totalLabel = '';
+        if (totalCount > 0) {
+            if (totalCount === 1) {
+                totalLabel = formatLoadMoreTemplate(totalSingleLabel, totalCount) || formatLoadMoreTemplate(fallbackTotalSingle, totalCount);
+                if (!totalLabel) {
+                    totalLabel = fallbackTotalSingle.replace('%s', String(totalCount));
+                }
+            } else {
+                totalLabel = formatLoadMoreTemplate(totalPluralLabel, totalCount) || formatLoadMoreTemplate(fallbackTotalPlural, totalCount);
+                if (!totalLabel) {
+                    totalLabel = fallbackTotalPlural.replace('%s', String(totalCount));
+                }
+            }
+        }
 
         if (addedCount > 0) {
-            var addedLabel = addedCount === 1 ? '1 article ajouté.' : addedCount + ' articles ajoutés.';
+            var addedLabel = '';
+            if (addedCount === 1) {
+                addedLabel = formatLoadMoreTemplate(addedSingleLabel, addedCount) || formatLoadMoreTemplate(fallbackAddedSingle, addedCount);
+                if (!addedLabel) {
+                    addedLabel = fallbackAddedSingle.replace('%s', String(addedCount));
+                }
+            } else {
+                addedLabel = formatLoadMoreTemplate(addedPluralLabel, addedCount) || formatLoadMoreTemplate(fallbackAddedPlural, addedCount);
+                if (!addedLabel) {
+                    addedLabel = fallbackAddedPlural.replace('%s', String(addedCount));
+                }
+            }
 
-            if (totalCount > 0) {
+            if (totalLabel) {
                 return addedLabel + ' ' + totalLabel;
             }
 
@@ -88,10 +153,18 @@
         }
 
         if (totalCount > 0) {
-            return 'Aucun article supplémentaire. ' + totalLabel;
+            if (totalLabel) {
+                if (noAdditionalLabel.slice(-1) === ' ') {
+                    return noAdditionalLabel + totalLabel;
+                }
+
+                return noAdditionalLabel + ' ' + totalLabel;
+            }
+
+            return noAdditionalLabel;
         }
 
-        return 'Aucun article à afficher.';
+        return noneLabel || fallbackNone;
     }
 
     function focusElement($element) {

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -802,6 +802,9 @@ class My_Articles_Shortcode {
                     'ajax_url'  => admin_url('admin-ajax.php'),
                     'nonce'     => wp_create_nonce('my_articles_filter_nonce'),
                     'errorText' => __( 'Erreur AJAX.', 'mon-articles' ),
+                    'countSingle' => __( '%s article affiché.', 'mon-articles' ),
+                    'countPlural' => __( '%s articles affichés.', 'mon-articles' ),
+                    'countNone'   => __( 'Aucun article à afficher.', 'mon-articles' ),
                 ]
             );
         }
@@ -817,6 +820,12 @@ class My_Articles_Shortcode {
                     'loadingText'  => __( 'Chargement...', 'mon-articles' ),
                     'loadMoreText' => esc_html__( 'Charger plus', 'mon-articles' ),
                     'errorText'    => __( 'Erreur AJAX.', 'mon-articles' ),
+                    'totalSingle'  => __( '%s article affiché au total.', 'mon-articles' ),
+                    'totalPlural'  => __( '%s articles affichés au total.', 'mon-articles' ),
+                    'addedSingle'  => __( '%s article ajouté.', 'mon-articles' ),
+                    'addedPlural'  => __( '%s articles ajoutés.', 'mon-articles' ),
+                    'noAdditional' => __( 'Aucun article supplémentaire.', 'mon-articles' ),
+                    'none'         => __( 'Aucun article à afficher.', 'mon-articles' ),
                 ]
             );
         }

--- a/tests/ShortcodeLocalizationTest.php
+++ b/tests/ShortcodeLocalizationTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+
+if (!function_exists('wp_enqueue_script')) {
+    /**
+     * @param string $handle
+     * @param string $src
+     * @param array<int, string> $deps
+     * @param string|bool $ver
+     * @param bool $in_footer
+     */
+    function wp_enqueue_script($handle, $src = '', $deps = array(), $ver = false, $in_footer = false): void
+    {
+        global $mon_articles_test_enqueued_scripts;
+
+        if (!is_array($mon_articles_test_enqueued_scripts)) {
+            $mon_articles_test_enqueued_scripts = array();
+        }
+
+        $mon_articles_test_enqueued_scripts[] = array(
+            'handle'    => (string) $handle,
+            'src'       => (string) $src,
+            'deps'      => is_array($deps) ? array_values($deps) : array(),
+            'ver'       => is_string($ver) ? $ver : '',
+            'in_footer' => (bool) $in_footer,
+        );
+    }
+}
+
+if (!function_exists('wp_enqueue_style')) {
+    /**
+     * @param string $handle
+     * @param string $src
+     * @param array<int, string> $deps
+     * @param string|bool $ver
+     * @param string $media
+     */
+    function wp_enqueue_style($handle, $src = '', $deps = array(), $ver = false, $media = 'all'): void
+    {
+        global $mon_articles_test_enqueued_styles;
+
+        if (!is_array($mon_articles_test_enqueued_styles)) {
+            $mon_articles_test_enqueued_styles = array();
+        }
+
+        $mon_articles_test_enqueued_styles[] = array(
+            'handle' => (string) $handle,
+            'src'    => (string) $src,
+            'deps'   => is_array($deps) ? array_values($deps) : array(),
+            'ver'    => is_string($ver) ? $ver : '',
+            'media'  => (string) $media,
+        );
+    }
+}
+
+if (!function_exists('wp_localize_script')) {
+    /**
+     * @param string $handle
+     * @param string $object_name
+     * @param array<string, mixed> $l10n
+     */
+    function wp_localize_script($handle, $object_name, $l10n): bool
+    {
+        global $mon_articles_test_localized_scripts;
+
+        if (!is_array($mon_articles_test_localized_scripts)) {
+            $mon_articles_test_localized_scripts = array();
+        }
+
+        $mon_articles_test_localized_scripts[] = array(
+            'handle'      => (string) $handle,
+            'object_name' => (string) $object_name,
+            'data'        => is_array($l10n) ? $l10n : array(),
+        );
+
+        return true;
+    }
+}
+
+if (!function_exists('admin_url')) {
+    function admin_url($path = ''): string
+    {
+        $path = is_string($path) ? $path : '';
+
+        return 'http://example.com/wp-admin/' . ltrim($path, '/');
+    }
+}
+
+if (!function_exists('wp_create_nonce')) {
+    function wp_create_nonce($action): string
+    {
+        return 'nonce-' . (string) $action;
+    }
+}
+
+if (!function_exists('wp_strip_all_tags')) {
+    function wp_strip_all_tags($string)
+    {
+        return is_string($string) ? strip_tags($string) : '';
+    }
+}
+
+if (!function_exists('taxonomy_exists')) {
+    function taxonomy_exists($taxonomy): bool
+    {
+        return in_array($taxonomy, array('category'), true);
+    }
+}
+
+if (!function_exists('is_object_in_taxonomy')) {
+    function is_object_in_taxonomy($object_type, $taxonomy): bool
+    {
+        if ('post' === $object_type && 'category' === $taxonomy) {
+            return true;
+        }
+
+        return false;
+    }
+}
+
+}
+
+namespace MonAffichageArticles\Tests {
+
+use My_Articles_Shortcode;
+use PHPUnit\Framework\TestCase;
+
+final class ShortcodeLocalizationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!defined('MY_ARTICLES_VERSION')) {
+            define('MY_ARTICLES_VERSION', 'tests');
+        }
+
+        if (!defined('MY_ARTICLES_PLUGIN_URL')) {
+            define('MY_ARTICLES_PLUGIN_URL', 'http://example.com/wp-content/plugins/mon-affichage-articles/');
+        }
+
+        global $mon_articles_test_post_type_map,
+            $mon_articles_test_post_status_map,
+            $mon_articles_test_post_meta_map,
+            $mon_articles_test_localized_scripts,
+            $mon_articles_test_enqueued_scripts,
+            $mon_articles_test_enqueued_styles;
+
+        $mon_articles_test_post_type_map   = array();
+        $mon_articles_test_post_status_map = array();
+        $mon_articles_test_post_meta_map   = array();
+        $mon_articles_test_localized_scripts = array();
+        $mon_articles_test_enqueued_scripts  = array();
+        $mon_articles_test_enqueued_styles   = array();
+    }
+
+    public function test_localized_scripts_include_feedback_labels(): void
+    {
+        $instanceId = 9001;
+
+        global $mon_articles_test_post_type_map,
+            $mon_articles_test_post_status_map,
+            $mon_articles_test_post_meta_map,
+            $mon_articles_test_localized_scripts;
+
+        $mon_articles_test_post_type_map[$instanceId]   = 'mon_affichage';
+        $mon_articles_test_post_status_map[$instanceId] = 'publish';
+        $mon_articles_test_post_meta_map[$instanceId]   = array(
+            '_my_articles_settings' => array(
+                'show_category_filter' => 1,
+                'pagination_mode'      => 'load_more',
+                'display_mode'         => 'grid',
+                'posts_per_page'       => 3,
+            ),
+        );
+
+        $shortcode = My_Articles_Shortcode::get_instance();
+
+        $shortcode->render_shortcode(array('id' => (string) $instanceId));
+
+        $filterData = null;
+        $loadMoreData = null;
+
+        foreach ($mon_articles_test_localized_scripts as $entry) {
+            if ($entry['handle'] === 'my-articles-filter') {
+                $filterData = $entry['data'];
+            }
+
+            if ($entry['handle'] === 'my-articles-load-more') {
+                $loadMoreData = $entry['data'];
+            }
+        }
+
+        $this->assertIsArray($filterData);
+        $this->assertArrayHasKey('countSingle', $filterData);
+        $this->assertArrayHasKey('countPlural', $filterData);
+        $this->assertArrayHasKey('countNone', $filterData);
+        $this->assertArrayHasKey('errorText', $filterData);
+
+        $this->assertIsArray($loadMoreData);
+        $this->assertArrayHasKey('totalSingle', $loadMoreData);
+        $this->assertArrayHasKey('totalPlural', $loadMoreData);
+        $this->assertArrayHasKey('addedSingle', $loadMoreData);
+        $this->assertArrayHasKey('addedPlural', $loadMoreData);
+        $this->assertArrayHasKey('noAdditional', $loadMoreData);
+        $this->assertArrayHasKey('none', $loadMoreData);
+        $this->assertArrayHasKey('errorText', $loadMoreData);
+    }
+}
+}
+


### PR DESCRIPTION
## Summary
- expose localized success, error, and counter strings for the filter and load more scripts
- update the JavaScript handlers to consume localized labels with sensible fallbacks
- add PHPUnit coverage to ensure the new localization keys remain available

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dd695ff6b8832e8781846fbc90c6d3