### PR TITLE
Add loading indicator for article interactions

### DIFF
--- a/mon-affichage-article/assets/css/styles.css
+++ b/mon-affichage-article/assets/css/styles.css
@@ -5,6 +5,54 @@
     box-sizing: border-box;
 }
 
+.my-articles-wrapper--loading {
+    pointer-events: none;
+}
+
+.my-articles-wrapper--loading::before,
+.my-articles-wrapper--loading::after {
+    content: '';
+    position: absolute;
+    z-index: 5;
+    pointer-events: none;
+}
+
+.my-articles-wrapper--loading::before {
+    inset: 0;
+    background: rgba(255, 255, 255, 0.8);
+    backdrop-filter: blur(2px);
+}
+
+.my-articles-wrapper--loading::after {
+    width: 48px;
+    height: 48px;
+    top: 50%;
+    left: 50%;
+    margin: 0;
+    border-radius: 50%;
+    border: 4px solid rgba(0, 0, 0, 0.15);
+    border-top-color: rgba(0, 0, 0, 0.55);
+    transform: translate(-50%, -50%);
+    animation: my-articles-spinner 0.9s linear infinite;
+    z-index: 6;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .my-articles-wrapper--loading::after {
+        animation: none;
+    }
+}
+
+@keyframes my-articles-spinner {
+    0% {
+        transform: translate(-50%, -50%) rotate(0deg);
+    }
+
+    100% {
+        transform: translate(-50%, -50%) rotate(360deg);
+    }
+}
+
 .my-articles-wrapper.my-articles-slideshow {
     visibility: visible;
     opacity: 1;

--- a/mon-affichage-article/assets/js/filter.js
+++ b/mon-affichage-article/assets/js/filter.js
@@ -184,6 +184,7 @@
                 contentArea.css('opacity', 0.5);
                 if (wrapper && wrapper.length) {
                     wrapper.attr('aria-busy', 'true');
+                    wrapper.addClass('my-articles-wrapper--loading');
                 }
                 clearFeedback(wrapper);
             },
@@ -340,6 +341,7 @@
                 contentArea.css('opacity', 1);
                 if (wrapper && wrapper.length) {
                     wrapper.attr('aria-busy', 'false');
+                    wrapper.removeClass('my-articles-wrapper--loading');
                 }
             }
         });

--- a/mon-affichage-article/assets/js/load-more.js
+++ b/mon-affichage-article/assets/js/load-more.js
@@ -207,6 +207,7 @@
                 button.prop('disabled', true);
                 if (wrapper && wrapper.length) {
                     wrapper.attr('aria-busy', 'true');
+                    wrapper.addClass('my-articles-wrapper--loading');
                 }
                 clearFeedback(wrapper);
             },
@@ -335,6 +336,7 @@
             complete: function () {
                 if (wrapper && wrapper.length) {
                     wrapper.attr('aria-busy', 'false');
+                    wrapper.removeClass('my-articles-wrapper--loading');
                 }
             }
         });


### PR DESCRIPTION
## Summary
- add a reusable loading overlay and spinner style for article wrappers
- toggle the loading state class alongside aria-busy during filter and load more AJAX calls

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd6966e0bc832e9864003486267f05