### PR TITLE
Improve feedback styles and accessibility

### DIFF
--- a/mon-affichage-article/assets/css/styles.css
+++ b/mon-affichage-article/assets/css/styles.css
@@ -75,29 +75,32 @@
 
 .my-articles-feedback {
     margin: 16px 0;
-    padding: 12px 16px;
-    border-radius: 6px;
-    border: 1px solid rgba(34, 34, 34, 0.15);
-    background: rgba(34, 34, 34, 0.04);
+    padding: 14px 18px;
+    border-radius: 8px;
+    border: 1px solid rgba(31, 41, 51, 0.18);
+    background: rgba(31, 41, 51, 0.05);
     color: #1f2933;
-    line-height: 1.5;
-    display: none;
+    line-height: 1.6;
     position: relative;
+    font-size: 0.95rem;
+    display: none;
+    box-shadow: 0 6px 18px rgba(15, 23, 42, 0.05);
 }
 
 .my-articles-feedback::before {
     content: '\2139';
     font-size: 18px;
-    margin-right: 8px;
+    margin-right: 10px;
     display: inline-block;
     vertical-align: middle;
     color: inherit;
 }
 
 .my-articles-feedback.is-error {
-    background: #fef2f2;
+    background: #fee2e2;
     border-color: #dc2626;
-    color: #b91c1c;
+    color: #7f1d1d;
+    box-shadow: 0 10px 24px rgba(220, 38, 38, 0.12);
 }
 
 .my-articles-feedback.is-error::before {
@@ -134,12 +137,14 @@
 
 @media (max-width: 767px) {
     .my-articles-feedback {
-        font-size: 16px;
-        padding: 14px 18px;
+        font-size: 1.05rem;
+        line-height: 1.7;
+        padding: 16px 22px;
     }
 
     .my-articles-feedback::before {
-        font-size: 20px;
+        font-size: 22px;
+        margin-right: 12px;
     }
 
     .my-articles-filter-nav li a,

--- a/mon-affichage-article/assets/js/filter.js
+++ b/mon-affichage-article/assets/js/filter.js
@@ -24,13 +24,21 @@
     function clearFeedback(wrapper) {
         var feedback = wrapper.find('.my-articles-feedback');
         if (feedback.length) {
-            feedback.removeClass('is-error').text('').hide();
+            feedback.removeClass('is-error')
+                .removeAttr('role')
+                .attr('aria-live', 'polite')
+                .text('')
+                .hide();
         }
     }
 
     function showError(wrapper, message) {
         var feedback = getFeedbackElement(wrapper);
-        feedback.text(message).addClass('is-error').show();
+        feedback.text(message)
+            .addClass('is-error')
+            .attr('role', 'alert')
+            .attr('aria-live', 'assertive')
+            .show();
     }
 
     function updateInstanceQueryParams(instanceId, params) {
@@ -341,7 +349,11 @@
                     var totalArticles = contentArea.find('.my-article-item').length;
                     var feedbackMessage = buildFilterFeedbackMessage(totalArticles);
                     var feedbackElement = getFeedbackElement(wrapper);
-                    feedbackElement.removeClass('is-error').text(feedbackMessage).show();
+                    feedbackElement.removeClass('is-error')
+                        .removeAttr('role')
+                        .attr('aria-live', 'polite')
+                        .text(feedbackMessage)
+                        .show();
 
                     var firstArticle = contentArea.find('.my-article-item').first();
                     focusOnFirstArticleOrTitle(wrapper, contentArea, firstArticle);

--- a/mon-affichage-article/assets/js/load-more.js
+++ b/mon-affichage-article/assets/js/load-more.js
@@ -24,13 +24,21 @@
     function clearFeedback(wrapper) {
         var feedback = wrapper.find('.my-articles-feedback');
         if (feedback.length) {
-            feedback.removeClass('is-error').text('').hide();
+            feedback.removeClass('is-error')
+                .removeAttr('role')
+                .attr('aria-live', 'polite')
+                .text('')
+                .hide();
         }
     }
 
     function showError(wrapper, message) {
         var feedback = getFeedbackElement(wrapper);
-        feedback.text(message).addClass('is-error').show();
+        feedback.text(message)
+            .addClass('is-error')
+            .attr('role', 'alert')
+            .attr('aria-live', 'assertive')
+            .show();
     }
 
     function updateInstanceQueryParams(instanceId, params) {
@@ -317,7 +325,11 @@
 
                     var feedbackMessage = buildLoadMoreFeedbackMessage(totalArticles, addedCount);
                     var feedbackElement = getFeedbackElement(wrapper);
-                    feedbackElement.removeClass('is-error').text(feedbackMessage).show();
+                    feedbackElement.removeClass('is-error')
+                        .removeAttr('role')
+                        .attr('aria-live', 'polite')
+                        .text(feedbackMessage)
+                        .show();
 
                     focusOnFirstArticleOrTitle(wrapper, contentArea, focusArticle);
 


### PR DESCRIPTION
## Summary
- refresh the .my-articles-feedback block with updated spacing, contrast, and subtle shadowing
- strengthen the responsive typography/icon sizing for feedback notices on narrow screens
- ensure filter/load-more feedback toggles reset aria attributes and apply the is-error class for error states

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd7edde1b0832eb60e4341b69198d5