### PR TITLE
Improve focus styles for article controls

### DIFF
--- a/mon-affichage-article/assets/css/styles.css
+++ b/mon-affichage-article/assets/css/styles.css
@@ -433,6 +433,11 @@
     transition: background 0.3s ease;
 }
 
+.my-articles-load-more-btn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px #ffffff, 0 0 0 6px #1f75fe;
+}
+
 .my-articles-load-more-btn:hover {
     background: #555;
 }
@@ -457,6 +462,14 @@
     text-decoration: none;
     border-radius: 4px;
     transition: all 0.2s ease;
+}
+
+.my-articles-pagination .page-numbers:focus-visible {
+    outline: none;
+    border-color: #1f75fe;
+    box-shadow: 0 0 0 3px rgba(31, 117, 254, 0.35);
+    background: #f7fbff;
+    color: #1b2a4b;
 }
 
 .my-articles-pagination .page-numbers:hover {


### PR DESCRIPTION
## Summary
- add a layered focus-visible outline to the "load more" button to improve keyboard accessibility
- highlight pagination links on focus with a high-contrast border, shadow, and background change distinct from hover

## Testing
- not run (manual testing required)


------
https://chatgpt.com/codex/tasks/task_e_68dd91691aa4832e89a5a18ef3374a77