### PR TITLE
Disable motion effects on article cards for reduced motion

### DIFF
--- a/mon-affichage-article/assets/css/styles.css
+++ b/mon-affichage-article/assets/css/styles.css
@@ -298,6 +298,17 @@
     box-shadow: 0 8px 20px var(--my-articles-shadow-color-hover);
 }
 
+@media (prefers-reduced-motion: reduce) {
+    .my-article-item {
+        transition: none;
+    }
+
+    .my-article-item:hover,
+    .my-article-item:focus-within {
+        transform: none;
+    }
+}
+
 .my-article-item:focus-within {
     box-shadow: 0 0 0 3px var(--my-articles-focus-ring-color, #1a73e8), 0 8px 20px var(--my-articles-shadow-color-hover);
 }


### PR DESCRIPTION
## Summary
- add a prefers-reduced-motion media query for article cards
- remove transform and transition effects when motion reduction is requested while preserving hover feedback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd916b09b0832e9414f18ad6db0b17