### PR TITLE
Add hover styling for article metadata

### DIFF
--- a/mon-affichage-article/assets/css/styles.css
+++ b/mon-affichage-article/assets/css/styles.css
@@ -370,6 +370,11 @@
     margin-top: 8px;
 }
 
+.my-article-item:hover .article-meta,
+.my-article-item:focus-within .article-meta {
+    color: var(--my-articles-meta-hover-color);
+}
+
 .my-article-item .my-article-excerpt {
     font-size: var(--my-articles-excerpt-font-size);
     color: var(--my-articles-excerpt-color);


### PR DESCRIPTION
## Summary
- update the article metadata color to use the hover variable when an item is hovered or focused

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd9166fb1c832e9992845563479d14