### PR TITLE
Add sorting options to article displays

### DIFF
--- a/mon-affichage-article/assets/js/admin-options.js
+++ b/mon-affichage-article/assets/js/admin-options.js
@@ -26,6 +26,21 @@
         }
     }
 
+    function toggleMetaKeyOption() {
+        var $orderbySelect = $('#orderby');
+        var $metaKeyOption = $('.meta-key-option');
+
+        if (!$metaKeyOption.length) {
+            return;
+        }
+
+        if ($orderbySelect.length && $orderbySelect.val() === 'meta_value') {
+            $metaKeyOption.show();
+        } else {
+            $metaKeyOption.hide();
+        }
+    }
+
     var columnSelectors = '#columns_mobile, #columns_tablet, #columns_desktop, #columns_ultrawide';
     var columnsConfigDefaults = {
         minColumnWidth: 240,
@@ -120,11 +135,13 @@
     // Écouteurs d'événements
     $(document).on('change', '#pinned_show_badge', toggleBadgeOptions);
     $(document).on('change', '#show_excerpt', toggleExcerptOptions);
+    $(document).on('change', '#orderby', toggleMetaKeyOption);
 
     // Exécution au chargement de la page pour définir l'état initial
     $(document).ready(function() {
         toggleBadgeOptions();
         toggleExcerptOptions();
+        toggleMetaKeyOption();
         initColumnsWarnings();
     });
 

--- a/mon-affichage-article/blocks/mon-affichage-articles/block.json
+++ b/mon-affichage-article/blocks/mon-affichage-articles/block.json
@@ -27,6 +27,18 @@
             "type": "integer",
             "default": 10
         },
+        "orderby": {
+            "type": "string",
+            "default": "date"
+        },
+        "order": {
+            "type": "string",
+            "default": "DESC"
+        },
+        "meta_key": {
+            "type": "string",
+            "default": ""
+        },
         "show_category_filter": {
             "type": "boolean",
             "default": false

--- a/mon-affichage-article/blocks/mon-affichage-articles/edit.js
+++ b/mon-affichage-article/blocks/mon-affichage-articles/edit.js
@@ -11,6 +11,7 @@
     var SelectControl = wp.components.SelectControl;
     var ToggleControl = wp.components.ToggleControl;
     var RangeControl = wp.components.RangeControl;
+    var TextControl = wp.components.TextControl;
     var Placeholder = wp.components.Placeholder;
     var Spinner = wp.components.Spinner;
     var Notice = wp.components.Notice;
@@ -232,6 +233,44 @@
                             setAttributes({ pagination_mode: value });
                         },
                     })
+                ),
+                el(
+                    PanelBody,
+                    { title: __('Tri & ordre', 'mon-articles'), initialOpen: false },
+                    el(SelectControl, {
+                        label: __('Ordre de tri', 'mon-articles'),
+                        value: attributes.orderby || 'date',
+                        options: [
+                            { label: __('Date de publication', 'mon-articles'), value: 'date' },
+                            { label: __('Titre', 'mon-articles'), value: 'title' },
+                            { label: __('Ordre du menu', 'mon-articles'), value: 'menu_order' },
+                            { label: __('Méta personnalisée', 'mon-articles'), value: 'meta_value' },
+                        ],
+                        onChange: function (value) {
+                            setAttributes({ orderby: value });
+                        },
+                    }),
+                    el(SelectControl, {
+                        label: __('Sens du tri', 'mon-articles'),
+                        value: attributes.order || 'DESC',
+                        options: [
+                            { label: __('Décroissant (Z → A)', 'mon-articles'), value: 'DESC' },
+                            { label: __('Croissant (A → Z)', 'mon-articles'), value: 'ASC' },
+                        ],
+                        onChange: function (value) {
+                            setAttributes({ order: value });
+                        },
+                    }),
+                    'meta_value' === (attributes.orderby || 'date')
+                        ? el(TextControl, {
+                              label: __('Clé de méta personnalisée', 'mon-articles'),
+                              value: attributes.meta_key || '',
+                              onChange: function (value) {
+                                  setAttributes({ meta_key: value || '' });
+                              },
+                              help: __('Renseignez la clé utilisée pour le tri par méta.', 'mon-articles'),
+                          })
+                        : null
                 ),
                 el(
                     PanelBody,

--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -143,6 +143,46 @@ class My_Articles_Metaboxes {
                 'description' => esc_html__( 'Le nombre exact ou approximatif selon le comportement choisi. Utilisez 0 pour un affichage illimité.', 'mon-articles' ),
             ]
         );
+        $this->render_field(
+            'orderby',
+            esc_html__( 'Ordre de tri', 'mon-articles' ),
+            'select',
+            $opts,
+            [
+                'default'     => 'date',
+                'options'     => [
+                    'date'       => __( 'Date de publication', 'mon-articles' ),
+                    'title'      => __( 'Titre', 'mon-articles' ),
+                    'menu_order' => __( 'Ordre du menu', 'mon-articles' ),
+                    'meta_value' => __( 'Méta personnalisée', 'mon-articles' ),
+                ],
+                'description' => __( 'Choisissez le champ principal utilisé pour trier les contenus.', 'mon-articles' ),
+            ]
+        );
+        $this->render_field(
+            'order',
+            esc_html__( 'Sens du tri', 'mon-articles' ),
+            'select',
+            $opts,
+            [
+                'default' => 'DESC',
+                'options' => [
+                    'DESC' => __( 'Décroissant (Z → A)', 'mon-articles' ),
+                    'ASC'  => __( 'Croissant (A → Z)', 'mon-articles' ),
+                ],
+            ]
+        );
+        $this->render_field(
+            'meta_key',
+            esc_html__( 'Clé de méta personnalisée', 'mon-articles' ),
+            'text',
+            $opts,
+            [
+                'default'       => '',
+                'wrapper_class' => 'meta-key-option',
+                'description'   => __( 'Renseignez la clé utilisée lors d\'un tri par méta personnalisée.', 'mon-articles' ),
+            ]
+        );
         $this->render_field('pagination_mode', esc_html__('Type de pagination', 'mon-articles'), 'select', $opts, [
             'default'     => 'none',
             'options'     => [
@@ -436,6 +476,16 @@ class My_Articles_Metaboxes {
             ? min( 50, max( 0, absint( $input['posts_per_page'] ) ) )
             : 10;
         $sanitized['pagination_mode'] = isset($input['pagination_mode']) && in_array($input['pagination_mode'], ['none', 'load_more', 'numbered']) ? $input['pagination_mode'] : 'none';
+        $allowed_orderby = array( 'date', 'title', 'menu_order', 'meta_value' );
+        $sanitized['orderby'] = isset( $input['orderby'] ) && in_array( $input['orderby'], $allowed_orderby, true ) ? $input['orderby'] : 'date';
+        $order = isset( $input['order'] ) ? strtoupper( (string) $input['order'] ) : 'DESC';
+        $sanitized['order'] = in_array( $order, array( 'ASC', 'DESC' ), true ) ? $order : 'DESC';
+        $meta_key = '';
+        if ( isset( $input['meta_key'] ) ) {
+            $meta_key = sanitize_text_field( (string) $input['meta_key'] );
+            $meta_key = trim( $meta_key );
+        }
+        $sanitized['meta_key'] = $meta_key;
         $sanitized['show_category_filter'] = isset( $input['show_category_filter'] ) ? 1 : 0;
         $sanitized['filter_alignment'] = isset($input['filter_alignment']) && in_array($input['filter_alignment'], ['left', 'center', 'right']) ? $input['filter_alignment'] : 'right';
         

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -63,6 +63,23 @@ class My_Articles_Shortcode {
 
         $query_args = array_merge( $base_args, $overrides );
 
+        if ( ! isset( $query_args['orderby'] ) && ! empty( $options['orderby'] ) ) {
+            $query_args['orderby'] = $options['orderby'];
+        }
+
+        if ( ! isset( $query_args['order'] ) && ! empty( $options['order'] ) ) {
+            $query_args['order'] = $options['order'];
+        }
+
+        if (
+            ! isset( $query_args['meta_key'] )
+            && isset( $query_args['orderby'] )
+            && 'meta_value' === $query_args['orderby']
+            && ! empty( $options['meta_key'] )
+        ) {
+            $query_args['meta_key'] = $options['meta_key'];
+        }
+
         $resolved_taxonomy = $options['resolved_taxonomy'] ?? '';
         $active_category   = null === $active_category ? ( $options['term'] ?? '' ) : $active_category;
 
@@ -383,6 +400,9 @@ class My_Articles_Shortcode {
             'term' => '',
             'counting_behavior' => 'exact',
             'posts_per_page' => 10,
+            'orderby' => 'date',
+            'order' => 'DESC',
+            'meta_key' => '',
             'pagination_mode' => 'none',
             'show_category_filter' => 0,
             'filter_alignment' => 'right',
@@ -501,6 +521,34 @@ class My_Articles_Shortcode {
         $options['taxonomy'] = $taxonomy;
 
         $options['term'] = sanitize_title( $options['term'] ?? '' );
+
+        $allowed_orderby = array( 'date', 'title', 'menu_order', 'meta_value' );
+        $requested_orderby = isset( $options['orderby'] ) ? (string) $options['orderby'] : $defaults['orderby'];
+        if ( ! in_array( $requested_orderby, $allowed_orderby, true ) ) {
+            $requested_orderby = $defaults['orderby'];
+        }
+
+        $meta_key = '';
+        if ( isset( $options['meta_key'] ) && is_scalar( $options['meta_key'] ) ) {
+            $meta_key = trim( sanitize_text_field( (string) $options['meta_key'] ) );
+        }
+
+        if ( 'meta_value' === $requested_orderby ) {
+            if ( '' === $meta_key ) {
+                $requested_orderby = $defaults['orderby'];
+            }
+        } else {
+            $meta_key = '';
+        }
+
+        $options['orderby']  = $requested_orderby;
+        $options['meta_key'] = $meta_key;
+
+        $order = isset( $options['order'] ) ? strtoupper( (string) $options['order'] ) : $defaults['order'];
+        if ( ! in_array( $order, array( 'ASC', 'DESC' ), true ) ) {
+            $order = $defaults['order'];
+        }
+        $options['order'] = $order;
 
         $options['resolved_taxonomy'] = self::resolve_taxonomy( $options );
 


### PR DESCRIPTION
## Summary
- add order field controls to the instance metabox and persist the values safely
- normalize and forward the new sorting options when rendering shortcode queries
- expose matching sorting controls in the block editor and toggle the meta key field dynamically

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dda1b2107c832e9faf0f3fe8a1f306