### PR TITLE
Add skeleton loading state for article listings

### DIFF
--- a/mon-affichage-article/assets/css/styles.css
+++ b/mon-affichage-article/assets/css/styles.css
@@ -3,53 +3,172 @@
 .my-articles-wrapper {
     position: relative;
     box-sizing: border-box;
+    --my-articles-skeleton-base: rgba(31, 41, 51, 0.08);
+    --my-articles-skeleton-highlight: rgba(31, 41, 51, 0.16);
+    --my-articles-skeleton-radius: var(--my-articles-border-radius, 12px);
 }
 
-.my-articles-wrapper--loading {
+.my-articles-wrapper--loading,
+.my-articles-wrapper.is-loading {
     pointer-events: none;
 }
 
 .my-articles-wrapper--loading::before,
 .my-articles-wrapper--loading::after {
-    content: '';
+    display: none !important;
+}
+
+.my-articles-grid-content,
+.my-articles-list-content {
+    position: relative;
+}
+
+.my-articles-skeleton {
     position: absolute;
+    inset: 0;
+    display: none;
+    pointer-events: none;
     z-index: 5;
+}
+
+.my-articles-wrapper.is-loading .my-articles-skeleton {
+    display: block;
+}
+
+.my-articles-wrapper.is-loading .my-articles-skeleton--grid {
+    display: grid;
+}
+
+.my-articles-wrapper.is-loading .my-articles-skeleton--list {
+    display: flex;
+}
+
+.my-articles-wrapper.is-loading .my-articles-grid-content,
+.my-articles-wrapper.is-loading .my-articles-list-content {
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.my-articles-wrapper.is-loading .my-articles-grid-content .my-article-item,
+.my-articles-wrapper.is-loading .my-articles-list-content .my-article-item {
     pointer-events: none;
 }
 
-.my-articles-wrapper--loading::before {
-    inset: 0;
-    background: rgba(255, 255, 255, 0.8);
-    backdrop-filter: blur(2px);
+.my-articles-skeleton--grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(var(--my-articles-min-card-width), 1fr));
+    gap: var(--my-articles-gap);
 }
 
-.my-articles-wrapper--loading::after {
-    width: 48px;
-    height: 48px;
-    top: 50%;
-    left: 50%;
-    margin: 0;
-    border-radius: 50%;
-    border: 4px solid rgba(0, 0, 0, 0.15);
-    border-top-color: rgba(0, 0, 0, 0.55);
-    transform: translate(-50%, -50%);
-    animation: my-articles-spinner 0.9s linear infinite;
-    z-index: 6;
+.my-articles-skeleton--list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--my-articles-list-gap);
+    padding: 0;
 }
 
-@media (prefers-reduced-motion: reduce) {
-    .my-articles-wrapper--loading::after {
-        animation: none;
-    }
+.my-articles-skeleton__item {
+    border-radius: var(--my-articles-skeleton-radius);
+    overflow: hidden;
+    background-color: rgba(255, 255, 255, 0.85);
+    box-shadow: 0 2px 8px var(--my-articles-shadow-color, rgba(15, 23, 42, 0.1));
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    isolation: isolate;
+    min-height: 260px;
 }
 
-@keyframes my-articles-spinner {
+.my-articles-skeleton--list .my-articles-skeleton__item {
+    flex-direction: row;
+    align-items: stretch;
+    gap: 20px;
+    padding: 0;
+    min-height: 160px;
+}
+
+.my-articles-skeleton__thumbnail,
+.my-articles-skeleton__line {
+    position: relative;
+    overflow: hidden;
+    border-radius: calc(var(--my-articles-skeleton-radius) / 1.5);
+    background: linear-gradient(
+        90deg,
+        var(--my-articles-skeleton-base) 0%,
+        var(--my-articles-skeleton-highlight) 50%,
+        var(--my-articles-skeleton-base) 100%
+    );
+    background-size: 200% 100%;
+    animation: my-articles-skeleton-shimmer 1.2s linear infinite;
+    display: block;
+}
+
+.my-articles-skeleton__thumbnail {
+    aspect-ratio: 16 / 9;
+    width: 100%;
+}
+
+.my-articles-skeleton--list .my-articles-skeleton__thumbnail {
+    flex: 0 0 200px;
+    height: 140px;
+    border-radius: var(--my-articles-skeleton-radius);
+}
+
+.my-articles-skeleton__body {
+    padding: 16px 20px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.my-articles-skeleton--list .my-articles-skeleton__body {
+    flex: 1;
+    padding: var(--my-articles-list-padding-top) var(--my-articles-list-padding-right) var(--my-articles-list-padding-bottom) var(--my-articles-list-padding-left);
+    gap: 10px;
+}
+
+.my-articles-skeleton__line {
+    height: 14px;
+}
+
+.my-articles-skeleton__line--title {
+    height: 20px;
+    border-radius: calc(var(--my-articles-skeleton-radius) / 2);
+}
+
+.my-articles-skeleton__line--meta {
+    width: 60%;
+    height: 12px;
+}
+
+.my-articles-skeleton__line--short {
+    width: 70%;
+}
+
+.my-articles-skeleton__body .my-articles-skeleton__line:last-child {
+    width: 40%;
+}
+
+@keyframes my-articles-skeleton-shimmer {
     0% {
-        transform: translate(-50%, -50%) rotate(0deg);
+        background-position: 200% 0;
     }
 
     100% {
-        transform: translate(-50%, -50%) rotate(360deg);
+        background-position: -200% 0;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .my-articles-wrapper.is-loading .my-articles-grid-content,
+    .my-articles-wrapper.is-loading .my-articles-list-content {
+        transition: none;
+    }
+
+    .my-articles-skeleton__thumbnail,
+    .my-articles-skeleton__line {
+        animation: none;
+        background: var(--my-articles-skeleton-base);
     }
 }
 

--- a/mon-affichage-article/assets/js/filter.js
+++ b/mon-affichage-article/assets/js/filter.js
@@ -234,10 +234,9 @@
                 current_url: window.location && window.location.href ? window.location.href : ''
             },
             beforeSend: function () {
-                contentArea.css('opacity', 0.5);
                 if (wrapper && wrapper.length) {
                     wrapper.attr('aria-busy', 'true');
-                    wrapper.addClass('my-articles-wrapper--loading');
+                    wrapper.addClass('is-loading');
                 }
                 clearFeedback(wrapper);
             },
@@ -245,7 +244,6 @@
                 if (response.success) {
                     var wrapperElement = (wrapper && wrapper.length) ? wrapper.get(0) : null;
                     contentArea.html(response.data.html);
-                    contentArea.css('opacity', 1);
 
                     var totalPages = (response.data && typeof response.data.total_pages !== 'undefined') ? parseInt(response.data.total_pages, 10) : 0;
                     totalPages = isNaN(totalPages) ? 0 : totalPages;
@@ -365,7 +363,6 @@
                         previousActiveItem.find('button, a').first().attr('aria-pressed', 'true');
                     }
 
-                    contentArea.css('opacity', 1);
 
                     var fallbackMessage = (filterSettings && filterSettings.errorText) ? filterSettings.errorText : 'Une erreur est survenue. Veuillez réessayer plus tard.';
                     var responseMessage = (response.data && response.data.message) ? response.data.message : '';
@@ -381,7 +378,6 @@
                     previousActiveItem.find('button, a').first().attr('aria-pressed', 'true');
                 }
 
-                contentArea.css('opacity', 1);
                 var errorMessage = '';
 
                 if (jqXHR && jqXHR.responseJSON && jqXHR.responseJSON.data && jqXHR.responseJSON.data.message) {
@@ -395,10 +391,9 @@
                 showError(wrapper, errorMessage);
             },
             complete: function () {
-                contentArea.css('opacity', 1);
                 if (wrapper && wrapper.length) {
                     wrapper.attr('aria-busy', 'false');
-                    wrapper.removeClass('my-articles-wrapper--loading');
+                    wrapper.removeClass('is-loading');
                 }
             }
         });

--- a/mon-affichage-article/assets/js/load-more.js
+++ b/mon-affichage-article/assets/js/load-more.js
@@ -288,7 +288,7 @@
                 button.prop('disabled', true);
                 if (wrapper && wrapper.length) {
                     wrapper.attr('aria-busy', 'true');
-                    wrapper.addClass('my-articles-wrapper--loading');
+                    wrapper.addClass('is-loading');
                 }
                 clearFeedback(wrapper);
             },
@@ -421,7 +421,7 @@
             complete: function () {
                 if (wrapper && wrapper.length) {
                     wrapper.attr('aria-busy', 'false');
-                    wrapper.removeClass('my-articles-wrapper--loading');
+                    wrapper.removeClass('is-loading');
                 }
             }
         });

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -1043,6 +1043,8 @@ class My_Articles_Shortcode {
 
         echo '<div class="' . esc_attr( $container_class ) . '">';
 
+        echo $this->get_skeleton_placeholder_markup( $container_class, $options, $render_limit );
+
         if ( $pinned_query instanceof WP_Query && $pinned_query->have_posts() ) {
             while ( $pinned_query->have_posts() && ( ! $should_limit || $rendered_count < $render_limit ) ) {
                 $pinned_query->the_post();
@@ -1076,6 +1078,41 @@ class My_Articles_Shortcode {
         }
 
         return $displayed_pinned_ids;
+    }
+
+    public function get_skeleton_placeholder_markup( $container_class, array $options, $render_limit ) {
+        $layout = false !== strpos( $container_class, 'list' ) ? 'list' : 'grid';
+        $placeholder_count = (int) $render_limit;
+
+        if ( $placeholder_count <= 0 ) {
+            $placeholder_count = isset( $options['posts_per_page'] ) ? (int) $options['posts_per_page'] : 0;
+        }
+
+        if ( $placeholder_count <= 0 ) {
+            $placeholder_count = 6;
+        }
+
+        $placeholder_count = min( max( $placeholder_count, 3 ), 12 );
+
+        ob_start();
+
+        echo '<div class="my-articles-skeleton my-articles-skeleton--' . esc_attr( $layout ) . '" aria-hidden="true" role="presentation">';
+
+        for ( $i = 0; $i < $placeholder_count; $i++ ) {
+            echo '<div class="my-articles-skeleton__item">';
+            echo '<div class="my-articles-skeleton__thumbnail"></div>';
+            echo '<div class="my-articles-skeleton__body">';
+            echo '<span class="my-articles-skeleton__line my-articles-skeleton__line--title"></span>';
+            echo '<span class="my-articles-skeleton__line my-articles-skeleton__line--meta"></span>';
+            echo '<span class="my-articles-skeleton__line"></span>';
+            echo '<span class="my-articles-skeleton__line my-articles-skeleton__line--short"></span>';
+            echo '</div>';
+            echo '</div>';
+        }
+
+        echo '</div>';
+
+        return ob_get_clean();
     }
 
     private function render_list($pinned_query, $regular_query, $options, $posts_per_page) {

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -96,6 +96,7 @@ final class Mon_Affichage_Articles {
             'track_pinned'  => false,
             'wrap_slides'   => ( isset( $options['display_mode'] ) && 'slideshow' === $options['display_mode'] ),
             'skip_empty_state_when_empty' => false,
+            'include_skeleton'            => false,
         );
 
         $args = wp_parse_args( $args, $defaults );
@@ -105,9 +106,19 @@ final class Mon_Affichage_Articles {
         $track_pinned  = ! empty( $args['track_pinned'] );
         $wrap_slides   = ! empty( $args['wrap_slides'] );
         $skip_empty_state = ! empty( $args['skip_empty_state_when_empty'] );
+        $include_skeleton = ! empty( $args['include_skeleton'] );
         $should_limit  = ( $render_limit > 0 && ! $wrap_slides );
 
         ob_start();
+
+        if ( $include_skeleton && ! $wrap_slides ) {
+            $display_mode = $options['display_mode'] ?? 'grid';
+
+            if ( in_array( $display_mode, array( 'grid', 'list' ), true ) ) {
+                $container_class = ( 'list' === $display_mode ) ? 'my-articles-list-content' : 'my-articles-grid-content';
+                echo $shortcode_instance->get_skeleton_placeholder_markup( $container_class, $options, $render_limit );
+            }
+        }
 
         $displayed_posts_count = 0;
         $displayed_pinned_ids  = array();
@@ -330,6 +341,7 @@ final class Mon_Affichage_Articles {
                 'regular_limit' => $state['regular_posts_needed'],
                 'track_pinned'  => true,
                 'wrap_slides'   => ( 'slideshow' === $display_mode ),
+                'include_skeleton' => true,
             )
         );
 


### PR DESCRIPTION
## Summary
- add reusable skeleton placeholder markup for list and grid renders
- style the skeleton overlay with shimmer (and reduced-motion fallback) while hiding the legacy spinner
- toggle a new `is-loading` flag from the filter and load more scripts so the skeleton appears during requests

## Testing
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php
- php -l mon-affichage-article/mon-affichage-articles.php

------
https://chatgpt.com/codex/tasks/task_e_68dda1b8b438832ea219d1c7ef1af438