### PR TITLE
Namespace plugin classes and configure Composer autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,12 @@
     },
     "autoload": {
         "psr-4": {
+            "LCV\\MonAffichage\\": "mon-affichage-article/includes/",
             "MonAffichageArticles\\Tests\\": "tests/"
-        }
+        },
+        "files": [
+            "mon-affichage-article/includes/helpers.php"
+        ]
     },
     "scripts": {
         "test": "vendor/bin/phpunit"

--- a/mon-affichage-article/includes/My_Articles_Block.php
+++ b/mon-affichage-article/includes/My_Articles_Block.php
@@ -1,6 +1,8 @@
 <?php
 // Fichier: includes/class-my-articles-block.php
 
+namespace LCV\MonAffichage;
+
 if ( ! defined( 'WPINC' ) ) {
     die;
 }
@@ -35,7 +37,7 @@ class My_Articles_Block {
     }
 
     public function render_block( $attributes = array(), $content = '' ) {
-        if ( ! class_exists( 'My_Articles_Shortcode' ) ) {
+        if ( ! class_exists( My_Articles_Shortcode::class ) ) {
             return '';
         }
 

--- a/mon-affichage-article/includes/My_Articles_Enqueue.php
+++ b/mon-affichage-article/includes/My_Articles_Enqueue.php
@@ -1,6 +1,8 @@
 <?php
 // Fichier: includes/class-my-articles-enqueue.php
 
+namespace LCV\MonAffichage;
+
 if ( ! defined( 'WPINC' ) ) {
     die;
 }

--- a/mon-affichage-article/includes/My_Articles_Metaboxes.php
+++ b/mon-affichage-article/includes/My_Articles_Metaboxes.php
@@ -1,6 +1,8 @@
 <?php
 // Fichier: includes/class-my-articles-metaboxes.php
 
+namespace LCV\MonAffichage;
+
 if ( ! defined( 'WPINC' ) ) {
     die;
 }

--- a/mon-affichage-article/includes/My_Articles_Settings.php
+++ b/mon-affichage-article/includes/My_Articles_Settings.php
@@ -1,6 +1,8 @@
 <?php
 // Fichier: includes/class-my-articles-settings.php
 
+namespace LCV\MonAffichage;
+
 if ( ! defined( 'WPINC' ) ) {
     die;
 }

--- a/mon-affichage-article/includes/My_Articles_Shortcode.php
+++ b/mon-affichage-article/includes/My_Articles_Shortcode.php
@@ -1,6 +1,10 @@
 <?php
 // Fichier: includes/class-my-articles-shortcode.php
 
+namespace LCV\MonAffichage;
+
+use WP_Query;
+
 if ( ! defined( 'WPINC' ) ) {
     die;
 }

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -10,8 +10,20 @@
  * Domain Path:       /languages
  */
 
+use LCV\MonAffichage\My_Articles_Block;
+use LCV\MonAffichage\My_Articles_Enqueue;
+use LCV\MonAffichage\My_Articles_Metaboxes;
+use LCV\MonAffichage\My_Articles_Settings;
+use LCV\MonAffichage\My_Articles_Shortcode;
+
 if ( ! defined( 'WPINC' ) ) {
     die;
+}
+
+$autoload_path = dirname( __DIR__ ) . '/vendor/autoload.php';
+
+if ( is_readable( $autoload_path ) ) {
+    require_once $autoload_path;
 }
 
 define( 'MY_ARTICLES_VERSION', '2.4.0' );
@@ -25,19 +37,9 @@ final class Mon_Affichage_Articles {
     public static function get_instance() {
         if ( ! isset( self::$instance ) ) {
             self::$instance = new Mon_Affichage_Articles();
-            self::$instance->includes();
             self::$instance->add_hooks();
         }
         return self::$instance;
-    }
-
-    private function includes() {
-        require_once MY_ARTICLES_PLUGIN_DIR . 'includes/helpers.php';
-        require_once MY_ARTICLES_PLUGIN_DIR . 'includes/class-my-articles-settings.php';
-        require_once MY_ARTICLES_PLUGIN_DIR . 'includes/class-my-articles-metaboxes.php';
-        require_once MY_ARTICLES_PLUGIN_DIR . 'includes/class-my-articles-shortcode.php';
-        require_once MY_ARTICLES_PLUGIN_DIR . 'includes/class-my-articles-enqueue.php';
-        require_once MY_ARTICLES_PLUGIN_DIR . 'includes/class-my-articles-block.php';
     }
 
     private function add_hooks() {

--- a/tests/FilterArticlesPaginationTest.php
+++ b/tests/FilterArticlesPaginationTest.php
@@ -195,8 +195,8 @@ if (!function_exists('is_object_in_taxonomy')) {
 
 namespace MonAffichageArticles\Tests {
 
+use LCV\MonAffichage\My_Articles_Shortcode;
 use Mon_Affichage_Articles;
-use My_Articles_Shortcode;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use WP_Query;
@@ -383,6 +383,11 @@ final class FilterArticlesPaginationTest extends TestCase
             public function get_empty_state_slide_html(): string
             {
                 return '<div class="empty-slide">Aucun article</div>';
+            }
+
+            public function get_skeleton_placeholder_markup(string $containerClass, array $options, int $renderLimit): string
+            {
+                return '<div class="skeleton">Placeholder</div>';
             }
         };
 

--- a/tests/LoadMoreArticlesCallbackTest.php
+++ b/tests/LoadMoreArticlesCallbackTest.php
@@ -195,8 +195,8 @@ if (!function_exists('is_object_in_taxonomy')) {
 
 namespace MonAffichageArticles\Tests {
 
+use LCV\MonAffichage\My_Articles_Shortcode;
 use Mon_Affichage_Articles;
-use My_Articles_Shortcode;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use WP_Query;
@@ -427,6 +427,11 @@ final class LoadMoreArticlesCallbackTest extends TestCase
             {
                 return '<div class="empty-slide">Aucun article</div>';
             }
+
+            public function get_skeleton_placeholder_markup(string $containerClass, array $options, int $renderLimit): string
+            {
+                return '<div class="skeleton">Placeholder</div>';
+            }
         };
 
         $this->setShortcodeInstance($shortcodeStub);
@@ -561,6 +566,11 @@ final class LoadMoreArticlesCallbackTest extends TestCase
             public function get_empty_state_slide_html(): string
             {
                 return '<div class="empty-slide">Aucun article</div>';
+            }
+
+            public function get_skeleton_placeholder_markup(string $containerClass, array $options, int $renderLimit): string
+            {
+                return '<div class="skeleton">Placeholder</div>';
             }
         };
 

--- a/tests/MyArticlesEnqueueTest.php
+++ b/tests/MyArticlesEnqueueTest.php
@@ -60,7 +60,7 @@ if (!function_exists('wp_enqueue_script')) {
 
 namespace MonAffichageArticles\Tests {
 
-use My_Articles_Enqueue;
+use LCV\MonAffichage\My_Articles_Enqueue;
 use PHPUnit\Framework\TestCase;
 
 final class MyArticlesEnqueueTest extends TestCase
@@ -76,8 +76,6 @@ final class MyArticlesEnqueueTest extends TestCase
         if (!defined('MY_ARTICLES_PLUGIN_URL')) {
             define('MY_ARTICLES_PLUGIN_URL', 'http://example.com/wp-content/plugins/mon-affichage-articles/');
         }
-
-        require_once __DIR__ . '/../mon-affichage-article/includes/class-my-articles-enqueue.php';
 
         global $mon_articles_test_registered_styles,
             $mon_articles_test_registered_scripts,

--- a/tests/MyArticlesMetaboxesTest.php
+++ b/tests/MyArticlesMetaboxesTest.php
@@ -100,7 +100,7 @@ if (!function_exists('get_current_screen')) {
 
 namespace MonAffichageArticles\Tests {
 
-use My_Articles_Metaboxes;
+use LCV\MonAffichage\My_Articles_Metaboxes;
 use PHPUnit\Framework\TestCase;
 
 final class MyArticlesMetaboxesTest extends TestCase
@@ -121,10 +121,6 @@ final class MyArticlesMetaboxesTest extends TestCase
 
         if (!defined('MY_ARTICLES_PLUGIN_URL')) {
             define('MY_ARTICLES_PLUGIN_URL', 'http://example.com/wp-content/plugins/mon-affichage-articles/');
-        }
-
-        if (!class_exists(My_Articles_Metaboxes::class)) {
-            require_once dirname(__DIR__) . '/mon-affichage-article/includes/class-my-articles-metaboxes.php';
         }
 
         $mon_articles_test_enqueued_styles    = array();

--- a/tests/MyArticlesSettingsSanitizeTest.php
+++ b/tests/MyArticlesSettingsSanitizeTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace MonAffichageArticles\Tests;
 
-use My_Articles_Settings;
-use My_Articles_Shortcode;
+use LCV\MonAffichage\My_Articles_Settings;
+use LCV\MonAffichage\My_Articles_Shortcode;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -24,9 +24,6 @@ final class MyArticlesSettingsSanitizeTest extends TestCase
             define('MY_ARTICLES_PLUGIN_URL', 'http://example.com/wp-content/plugins/mon-affichage-articles/');
         }
 
-        if (!class_exists(My_Articles_Settings::class)) {
-            require_once dirname(__DIR__) . '/mon-affichage-article/includes/class-my-articles-settings.php';
-        }
     }
 
     protected function setUp(): void

--- a/tests/RenderArticleItemTest.php
+++ b/tests/RenderArticleItemTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MonAffichageArticles\Tests;
 
-use My_Articles_Shortcode;
+use LCV\MonAffichage\My_Articles_Shortcode;
 use PHPUnit\Framework\TestCase;
 
 final class RenderArticleItemTest extends TestCase

--- a/tests/RenderArticlesContainerTest.php
+++ b/tests/RenderArticlesContainerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MonAffichageArticles\Tests;
 
-use My_Articles_Shortcode;
+use LCV\MonAffichage\My_Articles_Shortcode;
 use PHPUnit\Framework\TestCase;
 
 final class RenderArticlesContainerTest extends TestCase

--- a/tests/RenderArticlesForResponseTest.php
+++ b/tests/RenderArticlesForResponseTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace MonAffichageArticles\Tests;
 
+use LCV\MonAffichage\My_Articles_Shortcode;
 use Mon_Affichage_Articles;
-use My_Articles_Shortcode;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use WP_Query;
@@ -33,6 +33,11 @@ class RenderArticlesForResponseTest extends TestCase
             public function get_empty_state_slide_html(): string
             {
                 return '<div class="empty-slide">Aucun article</div>';
+            }
+
+            public function get_skeleton_placeholder_markup(string $containerClass, array $options, int $renderLimit): string
+            {
+                return '<div class="skeleton">Placeholder</div>';
             }
         };
 

--- a/tests/RenderInlineStylesTest.php
+++ b/tests/RenderInlineStylesTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MonAffichageArticles\Tests;
 
-use My_Articles_Shortcode;
+use LCV\MonAffichage\My_Articles_Shortcode;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 

--- a/tests/ShortcodeLocalizationTest.php
+++ b/tests/ShortcodeLocalizationTest.php
@@ -125,7 +125,7 @@ if (!function_exists('is_object_in_taxonomy')) {
 
 namespace MonAffichageArticles\Tests {
 
-use My_Articles_Shortcode;
+use LCV\MonAffichage\My_Articles_Shortcode;
 use PHPUnit\Framework\TestCase;
 
 final class ShortcodeLocalizationTest extends TestCase

--- a/tests/ShortcodeVisibilityTest.php
+++ b/tests/ShortcodeVisibilityTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MonAffichageArticles\Tests;
 
-use My_Articles_Shortcode;
+use LCV\MonAffichage\My_Articles_Shortcode;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,12 +1,22 @@
 <?php
 declare(strict_types=1);
 
+$autoloadPath = dirname(__DIR__) . '/vendor/autoload.php';
+
+if (file_exists($autoloadPath)) {
+    require_once $autoloadPath;
+}
+
 if (!defined('MY_ARTICLES_DISABLE_AUTOBOOT')) {
     define('MY_ARTICLES_DISABLE_AUTOBOOT', true);
 }
 
 if (!defined('WPINC')) {
     define('WPINC', 'wp-includes');
+}
+
+if (!defined('HOUR_IN_SECONDS')) {
+    define('HOUR_IN_SECONDS', 3600);
 }
 
 if (!class_exists('WP_Error')) {
@@ -97,6 +107,15 @@ if (!function_exists('apply_filters')) {
     function apply_filters($hook, $value)
     {
         return $value;
+    }
+}
+
+if (!function_exists('wp_generate_password')) {
+    function wp_generate_password($length = 12, $special_chars = true, $extra_special_chars = false)
+    {
+        $length = max(1, (int) $length);
+
+        return str_repeat('a', $length);
     }
 }
 
@@ -231,7 +250,28 @@ if (!function_exists('add_action')) {
 if (!function_exists('get_option')) {
     function get_option(string $option, $default = false)
     {
-        return $default;
+        global $mon_articles_test_options;
+
+        if (!is_array($mon_articles_test_options)) {
+            $mon_articles_test_options = array();
+        }
+
+        return $mon_articles_test_options[$option] ?? $default;
+    }
+}
+
+if (!function_exists('update_option')) {
+    function update_option(string $option, $value)
+    {
+        global $mon_articles_test_options;
+
+        if (!is_array($mon_articles_test_options)) {
+            $mon_articles_test_options = array();
+        }
+
+        $mon_articles_test_options[$option] = $value;
+
+        return true;
     }
 }
 
@@ -275,6 +315,96 @@ if (!function_exists('wp_add_inline_style')) {
     function wp_add_inline_style(string $handle, string $data): bool
     {
         return wp_styles()->add_inline_style($handle, $data);
+    }
+}
+
+if (!function_exists('wp_cache_get')) {
+    function wp_cache_get($key, $group = '')
+    {
+        global $mon_articles_test_cache;
+
+        if (!is_array($mon_articles_test_cache)) {
+            $mon_articles_test_cache = array();
+        }
+
+        return $mon_articles_test_cache[$group][$key] ?? false;
+    }
+}
+
+if (!function_exists('wp_cache_set')) {
+    function wp_cache_set($key, $value, $group = '', $expire = 0)
+    {
+        global $mon_articles_test_cache;
+
+        if (!is_array($mon_articles_test_cache)) {
+            $mon_articles_test_cache = array();
+        }
+
+        if (!isset($mon_articles_test_cache[$group])) {
+            $mon_articles_test_cache[$group] = array();
+        }
+
+        $mon_articles_test_cache[$group][$key] = $value;
+
+        return true;
+    }
+}
+
+if (!function_exists('wp_cache_delete')) {
+    function wp_cache_delete($key, $group = '')
+    {
+        global $mon_articles_test_cache;
+
+        if (isset($mon_articles_test_cache[$group][$key])) {
+            unset($mon_articles_test_cache[$group][$key]);
+
+            return true;
+        }
+
+        return false;
+    }
+}
+
+if (!function_exists('get_transient')) {
+    function get_transient($transient)
+    {
+        global $mon_articles_test_transients;
+
+        if (!is_array($mon_articles_test_transients)) {
+            $mon_articles_test_transients = array();
+        }
+
+        return $mon_articles_test_transients[$transient] ?? false;
+    }
+}
+
+if (!function_exists('set_transient')) {
+    function set_transient($transient, $value, $expiration = 0)
+    {
+        global $mon_articles_test_transients;
+
+        if (!is_array($mon_articles_test_transients)) {
+            $mon_articles_test_transients = array();
+        }
+
+        $mon_articles_test_transients[$transient] = $value;
+
+        return true;
+    }
+}
+
+if (!function_exists('delete_transient')) {
+    function delete_transient($transient)
+    {
+        global $mon_articles_test_transients;
+
+        if (isset($mon_articles_test_transients[$transient])) {
+            unset($mon_articles_test_transients[$transient]);
+
+            return true;
+        }
+
+        return false;
     }
 }
 
@@ -366,6 +496,13 @@ if (!function_exists('wp_parse_args')) {
         }
 
         return array_merge($defaults, $args);
+    }
+}
+
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($data, $options = 0, $depth = 512)
+    {
+        return json_encode($data, $options, $depth);
     }
 }
 
@@ -669,5 +806,3 @@ if (!class_exists('WP_Query')) {
 }
 
 require_once __DIR__ . '/../mon-affichage-article/mon-affichage-articles.php';
-require_once __DIR__ . '/../mon-affichage-article/includes/helpers.php';
-require_once __DIR__ . '/../mon-affichage-article/includes/class-my-articles-shortcode.php';


### PR DESCRIPTION
## Summary
- namespace the plugin classes under `LCV\MonAffichage` and rename the include files to follow PSR-4 expectations
- update the plugin bootstrap to load Composer’s autoloader and rely on namespaced services instead of manual includes
- extend the PHPUnit bootstrap and test cases for the new autoloaded classes and WordPress stubs

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68de3e55bcb0832ebb602e074057058e