### PR TITLE
Switch front-end article scripts to REST endpoints

### DIFF
--- a/mon-affichage-article/assets/js/filter.js
+++ b/mon-affichage-article/assets/js/filter.js
@@ -223,12 +223,19 @@
         filterItem.addClass('active');
         filterLink.attr('aria-pressed', 'true');
 
+        var requestUrl = (filterSettings && typeof filterSettings.ajax_url === 'string') ? filterSettings.ajax_url : '';
+
+        if (!requestUrl && filterSettings && typeof filterSettings.rest_root === 'string') {
+            requestUrl = filterSettings.rest_root.replace(/\/+$/, '') + '/my-articles/v1/filter';
+        }
+
         $.ajax({
-            url: filterSettings.ajax_url,
+            url: requestUrl,
             type: 'POST',
+            headers: {
+                'X-WP-Nonce': filterSettings && filterSettings.nonce ? filterSettings.nonce : ''
+            },
             data: {
-                action: 'filter_articles',
-                security: filterSettings.nonce || '',
                 instance_id: instanceId,
                 category: categorySlug,
                 current_url: window.location && window.location.href ? window.location.href : ''

--- a/mon-affichage-article/assets/js/load-more.js
+++ b/mon-affichage-article/assets/js/load-more.js
@@ -271,12 +271,19 @@
             return;
         }
 
+        var requestUrl = (loadMoreSettings && typeof loadMoreSettings.ajax_url === 'string') ? loadMoreSettings.ajax_url : '';
+
+        if (!requestUrl && loadMoreSettings && typeof loadMoreSettings.rest_root === 'string') {
+            requestUrl = loadMoreSettings.rest_root.replace(/\/+$/, '') + '/my-articles/v1/load-more';
+        }
+
         $.ajax({
-            url: loadMoreSettings.ajax_url,
+            url: requestUrl,
             type: 'POST',
+            headers: {
+                'X-WP-Nonce': loadMoreSettings && loadMoreSettings.nonce ? loadMoreSettings.nonce : ''
+            },
             data: {
-                action: 'load_more_articles',
-                security: loadMoreSettings.nonce || '',
                 instance_id: instanceId,
                 paged: paged,
                 pinned_ids: pinnedIds,

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -841,14 +841,18 @@ class My_Articles_Shortcode {
         $resolved_taxonomy = $options['resolved_taxonomy'];
         $available_categories = $options['available_categories'];
 
+        $rest_nonce = wp_create_nonce( 'wp_rest' );
+        $rest_root  = esc_url_raw( rest_url() );
+
         if ( !empty($options['show_category_filter']) ) {
             wp_enqueue_script('my-articles-filter', MY_ARTICLES_PLUGIN_URL . 'assets/js/filter.js', ['jquery'], MY_ARTICLES_VERSION, true);
             wp_localize_script(
                 'my-articles-filter',
                 'myArticlesFilter',
                 [
-                    'ajax_url'  => admin_url('admin-ajax.php'),
-                    'nonce'     => wp_create_nonce('my_articles_filter_nonce'),
+                    'ajax_url'  => esc_url_raw( rest_url( 'my-articles/v1/filter' ) ),
+                    'rest_root' => $rest_root,
+                    'nonce'     => $rest_nonce,
                     'errorText' => __( 'Erreur AJAX.', 'mon-articles' ),
                     'countSingle' => __( '%s article affiché.', 'mon-articles' ),
                     'countPlural' => __( '%s articles affichés.', 'mon-articles' ),
@@ -863,8 +867,9 @@ class My_Articles_Shortcode {
                 'my-articles-load-more',
                 'myArticlesLoadMore',
                 [
-                    'ajax_url'     => admin_url('admin-ajax.php'),
-                    'nonce'        => wp_create_nonce('my_articles_load_more_nonce'),
+                    'ajax_url'     => esc_url_raw( rest_url( 'my-articles/v1/load-more' ) ),
+                    'rest_root'    => $rest_root,
+                    'nonce'        => $rest_nonce,
                     'loadingText'  => __( 'Chargement...', 'mon-articles' ),
                     'loadMoreText' => esc_html__( 'Charger plus', 'mon-articles' ),
                     'errorText'    => __( 'Erreur AJAX.', 'mon-articles' ),

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -122,7 +122,9 @@ final class Mon_Affichage_Articles {
 
             if ( in_array( $display_mode, array( 'grid', 'list' ), true ) ) {
                 $container_class = ( 'list' === $display_mode ) ? 'my-articles-list-content' : 'my-articles-grid-content';
-                echo $shortcode_instance->get_skeleton_placeholder_markup( $container_class, $options, $render_limit );
+                if ( method_exists( $shortcode_instance, 'get_skeleton_placeholder_markup' ) ) {
+                    echo $shortcode_instance->get_skeleton_placeholder_markup( $container_class, $options, $render_limit );
+                }
             }
         }
 
@@ -212,8 +214,6 @@ final class Mon_Affichage_Articles {
     }
 
     public function filter_articles_callback() {
-        check_ajax_referer( 'my_articles_filter_nonce', 'security' );
-
         $instance_id   = isset( $_POST['instance_id'] ) ? absint( wp_unslash( $_POST['instance_id'] ) ) : 0;
         $category_slug = isset( $_POST['category'] ) ? sanitize_title( wp_unslash( $_POST['category'] ) ) : '';
         $raw_current_url = isset( $_POST['current_url'] ) ? wp_unslash( $_POST['current_url'] ) : '';
@@ -425,8 +425,6 @@ final class Mon_Affichage_Articles {
     }
 
     public function load_more_articles_callback() {
-        check_ajax_referer( 'my_articles_load_more_nonce', 'security' );
-
         $instance_id = isset( $_POST['instance_id'] ) ? absint( wp_unslash( $_POST['instance_id'] ) ) : 0;
         $paged = isset( $_POST['paged'] ) ? absint( wp_unslash( $_POST['paged'] ) ) : 1;
         $pinned_ids_str = isset( $_POST['pinned_ids'] ) ? sanitize_text_field( wp_unslash( $_POST['pinned_ids'] ) ) : '';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,6 +9,10 @@ if (!defined('WPINC')) {
     define('WPINC', 'wp-includes');
 }
 
+if (!defined('HOUR_IN_SECONDS')) {
+    define('HOUR_IN_SECONDS', 3600);
+}
+
 if (!class_exists('WP_Error')) {
     class WP_Error
     {
@@ -231,7 +235,28 @@ if (!function_exists('add_action')) {
 if (!function_exists('get_option')) {
     function get_option(string $option, $default = false)
     {
-        return $default;
+        global $mon_articles_test_options_store;
+
+        if (!is_array($mon_articles_test_options_store)) {
+            $mon_articles_test_options_store = array();
+        }
+
+        return $mon_articles_test_options_store[$option] ?? $default;
+    }
+}
+
+if (!function_exists('update_option')) {
+    function update_option(string $option, $value)
+    {
+        global $mon_articles_test_options_store;
+
+        if (!is_array($mon_articles_test_options_store)) {
+            $mon_articles_test_options_store = array();
+        }
+
+        $mon_articles_test_options_store[$option] = $value;
+
+        return true;
     }
 }
 
@@ -387,6 +412,176 @@ if (!function_exists('esc_url')) {
     function esc_url($url)
     {
         return (string) $url;
+    }
+}
+
+if (!function_exists('esc_url_raw')) {
+    function esc_url_raw($url)
+    {
+        return (string) $url;
+    }
+}
+
+if (!function_exists('rest_url')) {
+    function rest_url($path = '', $scheme = 'rest')
+    {
+        $path = is_string($path) ? ltrim($path, '/') : '';
+
+        return 'http://example.com/wp-json/' . $path;
+    }
+}
+
+if (!function_exists('wp_create_nonce')) {
+    function wp_create_nonce($action)
+    {
+        return 'nonce-' . (string) $action;
+    }
+}
+
+if (!function_exists('wp_generate_password')) {
+    function wp_generate_password($length = 12)
+    {
+        $length = (int) $length;
+        if ($length <= 0) {
+            $length = 12;
+        }
+
+        return str_repeat('a', $length);
+    }
+}
+
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($data, $options = 0, $depth = 512)
+    {
+        return json_encode($data, $options, $depth);
+    }
+}
+
+if (!function_exists('wp_cache_get')) {
+    function wp_cache_get($key, $group = '')
+    {
+        global $mon_articles_test_cache_store;
+
+        if (!is_array($mon_articles_test_cache_store)) {
+            $mon_articles_test_cache_store = array();
+        }
+
+        $group = (string) $group;
+        if (!isset($mon_articles_test_cache_store[$group])) {
+            return false;
+        }
+
+        return $mon_articles_test_cache_store[$group][$key] ?? false;
+    }
+}
+
+if (!function_exists('wp_cache_set')) {
+    function wp_cache_set($key, $value, $group = '', $expire = 0)
+    {
+        global $mon_articles_test_cache_store;
+
+        if (!is_array($mon_articles_test_cache_store)) {
+            $mon_articles_test_cache_store = array();
+        }
+
+        $group = (string) $group;
+        if (!isset($mon_articles_test_cache_store[$group])) {
+            $mon_articles_test_cache_store[$group] = array();
+        }
+
+        $mon_articles_test_cache_store[$group][$key] = $value;
+
+        return true;
+    }
+}
+
+if (!function_exists('wp_cache_delete')) {
+    function wp_cache_delete($key, $group = '')
+    {
+        global $mon_articles_test_cache_store;
+
+        if (!is_array($mon_articles_test_cache_store)) {
+            return false;
+        }
+
+        $group = (string) $group;
+        if (!isset($mon_articles_test_cache_store[$group])) {
+            return false;
+        }
+
+        if (!array_key_exists($key, $mon_articles_test_cache_store[$group])) {
+            return false;
+        }
+
+        unset($mon_articles_test_cache_store[$group][$key]);
+
+        return true;
+    }
+}
+
+if (!function_exists('get_transient')) {
+    function get_transient($transient)
+    {
+        global $mon_articles_test_transients_store;
+
+        if (!is_array($mon_articles_test_transients_store)) {
+            $mon_articles_test_transients_store = array();
+        }
+
+        $key = (string) $transient;
+
+        if (!isset($mon_articles_test_transients_store[$key])) {
+            return false;
+        }
+
+        $entry = $mon_articles_test_transients_store[$key];
+
+        if (isset($entry['expires']) && $entry['expires'] > 0 && $entry['expires'] < time()) {
+            unset($mon_articles_test_transients_store[$key]);
+
+            return false;
+        }
+
+        return $entry['value'];
+    }
+}
+
+if (!function_exists('set_transient')) {
+    function set_transient($transient, $value, $expiration = 0)
+    {
+        global $mon_articles_test_transients_store;
+
+        if (!is_array($mon_articles_test_transients_store)) {
+            $mon_articles_test_transients_store = array();
+        }
+
+        $mon_articles_test_transients_store[(string) $transient] = array(
+            'value'   => $value,
+            'expires' => $expiration > 0 ? time() + (int) $expiration : 0,
+        );
+
+        return true;
+    }
+}
+
+if (!function_exists('delete_transient')) {
+    function delete_transient($transient)
+    {
+        global $mon_articles_test_transients_store;
+
+        if (!is_array($mon_articles_test_transients_store)) {
+            return false;
+        }
+
+        $key = (string) $transient;
+
+        if (!isset($mon_articles_test_transients_store[$key])) {
+            return false;
+        }
+
+        unset($mon_articles_test_transients_store[$key]);
+
+        return true;
     }
 }
 


### PR DESCRIPTION
## Summary
- localize REST URLs and a wp_rest nonce for the front-end filter and load-more scripts
- update the JavaScript clients to call the REST endpoints with the X-WP-Nonce header
- remove legacy admin-ajax nonce checks and extend the test bootstrap with REST-aware stubs

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68de4562e1a0832e9bb0b47958cda18a