### PR TITLE
Expose REST controller accessor and sync test option stubs

### DIFF
--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -25,6 +25,12 @@ if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
 final class Mon_Affichage_Articles {
     private static $instance;
     private $cache_namespace = null;
+
+    /**
+     * REST controller instance.
+     *
+     * @var My_Articles_Controller
+     */
     private $rest_controller;
 
     public static function get_instance() {
@@ -46,6 +52,15 @@ final class Mon_Affichage_Articles {
         require_once MY_ARTICLES_PLUGIN_DIR . 'includes/rest/class-my-articles-controller.php';
 
         $this->rest_controller = new My_Articles_Controller( $this );
+    }
+
+    /**
+     * Retrieves the REST controller instance.
+     *
+     * @return My_Articles_Controller
+     */
+    public function get_rest_controller() {
+        return $this->rest_controller;
     }
 
     private function add_hooks() {
@@ -235,7 +250,7 @@ final class Mon_Affichage_Articles {
         );
     }
 
-public function prepare_filter_articles_response( array $args ) {
+    public function prepare_filter_articles_response( array $args ) {
         $instance_id   = isset( $args['instance_id'] ) ? absint( $args['instance_id'] ) : 0;
         $category_slug = isset( $args['category'] ) ? sanitize_title( $args['category'] ) : '';
         $raw_current_url = isset( $args['current_url'] ) ? (string) $args['current_url'] : '';
@@ -486,7 +501,7 @@ public function prepare_filter_articles_response( array $args ) {
         wp_send_json_success( $response );
     }
 
-public function prepare_load_more_articles_response( array $args ) {
+    public function prepare_load_more_articles_response( array $args ) {
         $instance_id = isset( $args['instance_id'] ) ? absint( $args['instance_id'] ) : 0;
         $paged       = isset( $args['paged'] ) ? absint( $args['paged'] ) : 1;
         $category    = isset( $args['category'] ) ? sanitize_title( $args['category'] ) : '';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -424,10 +424,16 @@ if (!function_exists('add_action')) {
 if (!function_exists('get_option')) {
     function get_option(string $option, $default = false)
     {
-        global $mon_articles_test_options_store;
+        global $mon_articles_test_options_store, $mon_articles_test_options;
 
         if (!is_array($mon_articles_test_options_store)) {
-            $mon_articles_test_options_store = array();
+            if (isset($mon_articles_test_options) && is_array($mon_articles_test_options)) {
+                $mon_articles_test_options_store =& $mon_articles_test_options;
+            } else {
+                $mon_articles_test_options_store = array();
+            }
+        } elseif (isset($mon_articles_test_options) && is_array($mon_articles_test_options) && $mon_articles_test_options_store !== $mon_articles_test_options) {
+            $mon_articles_test_options_store =& $mon_articles_test_options;
         }
 
         return $mon_articles_test_options_store[$option] ?? $default;
@@ -437,13 +443,23 @@ if (!function_exists('get_option')) {
 if (!function_exists('update_option')) {
     function update_option(string $option, $value)
     {
-        global $mon_articles_test_options_store;
+        global $mon_articles_test_options_store, $mon_articles_test_options;
 
         if (!is_array($mon_articles_test_options_store)) {
-            $mon_articles_test_options_store = array();
+            if (isset($mon_articles_test_options) && is_array($mon_articles_test_options)) {
+                $mon_articles_test_options_store =& $mon_articles_test_options;
+            } else {
+                $mon_articles_test_options_store = array();
+            }
+        } elseif (isset($mon_articles_test_options) && is_array($mon_articles_test_options) && $mon_articles_test_options_store !== $mon_articles_test_options) {
+            $mon_articles_test_options_store =& $mon_articles_test_options;
         }
 
         $mon_articles_test_options_store[$option] = $value;
+
+        if (isset($mon_articles_test_options) && is_array($mon_articles_test_options) && $mon_articles_test_options !== $mon_articles_test_options_store) {
+            $mon_articles_test_options = $mon_articles_test_options_store;
+        }
 
         return true;
     }


### PR DESCRIPTION
## Summary
- document the REST controller property on the main plugin class and expose a getter while correcting method indentation
- keep the test option stubs in sync with the mutable options array to exercise cache namespace logic reliably

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68de566c1a80832e9fb0ad70b3145461