### PR TITLE
Enable REST API for mon_affichage post type

### DIFF
--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -1075,7 +1075,8 @@ public function prepare_load_more_articles_response( array $args ) {
             'exclude_from_search' => true,
             'publicly_queryable' => false,
             'capability_type' => 'post',
-            'show_in_rest' => false,
+            'show_in_rest' => true,
+            'rest_base' => 'mon_affichage',
         ];
         register_post_type( 'mon_affichage', $args );
     }


### PR DESCRIPTION
## Summary
- expose the `mon_affichage` custom post type in the REST API
- define a REST base so the block editor can access instances

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de667a8728832e9e191ceea758639b