### PR TITLE
Add design presets for tiles module

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Utiliser le shortcode :
 
 ### Attributs disponibles dans l'éditeur
 
+- **design_preset** (`custom`, `lcv-classique`, `dark-spotlight`, `editorial-focus`)
+  - Contrôle l’application d’un préréglage complet (couleurs, ombres, espacements). Le modèle « Focus éditorial » est verrouillé et fige les réglages associés.
 - **display_mode** (`grid`, `list`, `slideshow`)
 - **posts_per_page** (nombre d'articles, `0` pour illimité)
 - **pagination_mode** (`none`, `load_more`, `numbered`)
@@ -36,6 +38,17 @@ Utiliser le shortcode :
 - **list_content_padding_top/right/bottom/left** (marges internes des éléments en mode liste)
 - **border_radius** (arrondi des cartes), **title_font_size**, **meta_font_size**, **excerpt_font_size** (typographie)
 - Couleurs principales : **module_bg_color**, **vignette_bg_color**, **title_wrapper_bg_color**, **title_color**, **meta_color**, **meta_color_hover**, **excerpt_color**, **pagination_color**, **shadow_color**, **shadow_color_hover**, **pinned_border_color**, **pinned_badge_bg_color**, **pinned_badge_text_color**
+
+### Préréglages de design
+
+Les modèles intégrés permettent de démarrer rapidement avec des combinaisons cohérentes :
+
+- **Personnalisé** (`custom`) : aucun ajustement automatique, vos réglages manuels sont conservés.
+- **Classique LCV** (`lcv-classique`) : fond clair, ombres légères et cartes arrondies.
+- **Projecteur sombre** (`dark-spotlight`) : palette foncée à fort contraste pour des mises en avant immersives.
+- **Focus éditorial** (`editorial-focus`) : présentation magazine verrouillée (mode liste, extraits activés) pour homogénéiser les modules éditoriaux.
+
+Le panneau « Module » de l’éditeur propose un sélecteur de modèle ; les préréglages verrouillés grisent automatiquement les contrôles concernés.
 
 Options principales :
 
@@ -79,6 +92,16 @@ base64 --decode mon-affichage-article/languages/mon-articles-fr_FR.mo.base64 \
    ```
 
 Veiller à ne pas ajouter le fichier `.mo` généré au dépôt (il est ignoré par Git) et à ne commiter que la version encodée.
+
+## Migration des modules existants
+
+Les modules créés avant l’introduction des préréglages conservent leurs réglages manuels. Pour normaliser la nouvelle valeur `design_preset`, vous pouvez exécuter :
+
+```bash
+wp eval-file scripts/migrations/assign-design-preset.php
+```
+
+Le script affecte automatiquement le modèle « Personnalisé » (`custom`) aux contenus `mon_affichage` dépourvus de préréglage.
 
 ## Tests
 

--- a/mon-affichage-article/blocks/mon-affichage-articles/block.json
+++ b/mon-affichage-article/blocks/mon-affichage-articles/block.json
@@ -39,6 +39,10 @@
             "type": "string",
             "default": ""
         },
+        "design_preset": {
+            "type": "string",
+            "default": "custom"
+        },
         "show_category_filter": {
             "type": "boolean",
             "default": false

--- a/mon-affichage-article/includes/class-my-articles-enqueue.php
+++ b/mon-affichage-article/includes/class-my-articles-enqueue.php
@@ -51,5 +51,59 @@ class My_Articles_Enqueue {
         wp_enqueue_script( 'lazysizes' );
         wp_enqueue_script( 'my-articles-responsive-layout' );
         wp_enqueue_script( 'my-articles-debug-helper' );
+
+        $editor_handle = 'mon-affichage-articles-editor-script';
+
+        if ( class_exists( 'My_Articles_Shortcode' ) && function_exists( 'wp_add_inline_script' ) && wp_script_is( $editor_handle, 'registered' ) ) {
+            $presets = My_Articles_Shortcode::get_design_presets();
+            $export  = array();
+
+            if ( is_array( $presets ) ) {
+                foreach ( $presets as $preset_id => $preset ) {
+                    if ( ! is_string( $preset_id ) || '' === $preset_id ) {
+                        continue;
+                    }
+
+                    $label = '';
+
+                    if ( is_array( $preset ) && isset( $preset['label'] ) && is_string( $preset['label'] ) ) {
+                        $label = $preset['label'];
+                    }
+
+                    if ( '' === $label ) {
+                        $label = $preset_id;
+                    }
+
+                    $description = '';
+
+                    if ( is_array( $preset ) && isset( $preset['description'] ) && is_string( $preset['description'] ) ) {
+                        $description = $preset['description'];
+                    }
+
+                    $values = array();
+
+                    if ( is_array( $preset ) && isset( $preset['values'] ) && is_array( $preset['values'] ) ) {
+                        foreach ( $preset['values'] as $key => $value ) {
+                            if ( is_string( $key ) && ( is_scalar( $value ) || is_null( $value ) ) ) {
+                                $values[ $key ] = $value;
+                            }
+                        }
+                    }
+
+                    $export[ $preset_id ] = array(
+                        'label'       => $label,
+                        'description' => $description,
+                        'locked'      => ! empty( $preset['locked'] ),
+                        'values'      => $values,
+                    );
+                }
+            }
+
+            wp_add_inline_script(
+                $editor_handle,
+                'window.myArticlesDesignPresets = ' . wp_json_encode( $export ) . ';',
+                'before'
+            );
+        }
     }
 }

--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -302,6 +302,40 @@ class My_Articles_Metaboxes {
         );
 
         echo '<hr><h3>' . esc_html__('Apparence & Performances', 'mon-articles') . '</h3>';
+        $design_presets = My_Articles_Shortcode::get_design_presets();
+        $design_preset_options = array();
+
+        if ( is_array( $design_presets ) ) {
+            foreach ( $design_presets as $preset_id => $preset ) {
+                $label = $preset['label'] ?? $preset_id;
+
+                if ( is_array( $label ) ) {
+                    $label = $preset_id;
+                }
+
+                $design_preset_options[ $preset_id ] = (string) $label;
+            }
+        }
+
+        if ( empty( $design_preset_options ) || ! isset( $design_preset_options['custom'] ) ) {
+            $design_preset_options = array_merge(
+                array( 'custom' => __( 'Personnalisé', 'mon-articles' ) ),
+                $design_preset_options
+            );
+        }
+
+        $this->render_field(
+            'design_preset',
+            esc_html__( 'Modèle', 'mon-articles' ),
+            'select',
+            $opts,
+            [
+                'default'     => 'custom',
+                'options'     => $design_preset_options,
+                'description' => __( 'Applique un préréglage de couleurs, d’ombres et d’espacements.', 'mon-articles' ),
+            ]
+        );
+
         $this->render_field('module_padding_left', esc_html__('Marge intérieure gauche (px)', 'mon-articles'), 'number', $opts, ['default' => 0, 'min' => 0, 'max' => 200]);
         $this->render_field('module_padding_right', esc_html__('Marge intérieure droite (px)', 'mon-articles'), 'number', $opts, ['default' => 0, 'min' => 0, 'max' => 200]);
         $this->render_field('gap_size', esc_html__('Espacement des vignettes (Grille)', 'mon-articles'), 'number', $opts, ['default' => 25, 'min' => 0, 'max' => 50]);
@@ -522,6 +556,16 @@ class My_Articles_Metaboxes {
             $aria_label = trim( $aria_label );
         }
         $sanitized['aria_label'] = $aria_label;
+
+        $design_preset = 'custom';
+        if ( isset( $input['design_preset'] ) && is_string( $input['design_preset'] ) ) {
+            $candidate = sanitize_key( $input['design_preset'] );
+            $available_presets = My_Articles_Shortcode::get_design_presets();
+            if ( is_array( $available_presets ) && isset( $available_presets[ $candidate ] ) ) {
+                $design_preset = $candidate;
+            }
+        }
+        $sanitized['design_preset'] = $design_preset;
 
         $sanitized['display_mode'] = in_array($input['display_mode'] ?? 'grid', ['grid', 'slideshow', 'list']) ? $input['display_mode'] : 'grid';
         $sanitized['columns_mobile'] = isset( $input['columns_mobile'] ) ? max( 1, absint( $input['columns_mobile'] ) ) : 1;

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -11,6 +11,130 @@ class My_Articles_Shortcode {
     private static $lazysizes_enqueued = false;
     private static $normalized_options_cache = array();
     private static $matching_pinned_ids_cache = array();
+    private static $design_presets = null;
+
+    public static function get_design_presets() {
+        if ( null !== self::$design_presets ) {
+            return self::$design_presets;
+        }
+
+        $presets = array(
+            'custom' => array(
+                'label'   => __( 'Personnalisé', 'mon-articles' ),
+                'locked'  => false,
+                'values'  => array(),
+                'description' => __( 'Conservez vos propres réglages de couleurs et d’espacements.', 'mon-articles' ),
+            ),
+            'lcv-classique' => array(
+                'label'       => __( 'Classique LCV', 'mon-articles' ),
+                'locked'      => false,
+                'description' => __( 'Fond clair légèrement bleuté, cartes arrondies et typographie lisible.', 'mon-articles' ),
+                'values'      => array(
+                    'module_bg_color'             => '#f3f4f6',
+                    'vignette_bg_color'           => '#ffffff',
+                    'title_wrapper_bg_color'      => '#ffffff',
+                    'title_color'                 => '#1f2937',
+                    'meta_color'                  => '#6b7280',
+                    'meta_color_hover'            => '#111827',
+                    'excerpt_color'               => '#374151',
+                    'pagination_color'            => '#2563eb',
+                    'shadow_color'                => 'rgba(15,23,42,0.08)',
+                    'shadow_color_hover'          => 'rgba(37,99,235,0.16)',
+                    'module_padding_left'         => 24,
+                    'module_padding_right'        => 24,
+                    'gap_size'                    => 24,
+                    'list_item_gap'               => 28,
+                    'border_radius'               => 18,
+                    'title_font_size'             => 18,
+                    'meta_font_size'              => 13,
+                    'excerpt_font_size'           => 15,
+                    'list_content_padding_top'    => 16,
+                    'list_content_padding_right'  => 16,
+                    'list_content_padding_bottom' => 16,
+                    'list_content_padding_left'   => 16,
+                ),
+            ),
+            'dark-spotlight' => array(
+                'label'       => __( 'Projecteur sombre', 'mon-articles' ),
+                'locked'      => false,
+                'description' => __( 'Contraste élevé, idéal pour des pages sombres ou des encarts immersifs.', 'mon-articles' ),
+                'values'      => array(
+                    'module_bg_color'             => '#111827',
+                    'vignette_bg_color'           => '#1f2937',
+                    'title_wrapper_bg_color'      => '#111827',
+                    'title_color'                 => '#f9fafb',
+                    'meta_color'                  => '#cbd5f5',
+                    'meta_color_hover'            => '#ffffff',
+                    'excerpt_color'               => '#e5e7eb',
+                    'pagination_color'            => '#93c5fd',
+                    'shadow_color'                => 'rgba(0,0,0,0.4)',
+                    'shadow_color_hover'          => 'rgba(30,64,175,0.6)',
+                    'module_padding_left'         => 32,
+                    'module_padding_right'        => 32,
+                    'gap_size'                    => 20,
+                    'list_item_gap'               => 32,
+                    'border_radius'               => 20,
+                    'title_font_size'             => 20,
+                    'meta_font_size'              => 14,
+                    'excerpt_font_size'           => 16,
+                    'list_content_padding_top'    => 20,
+                    'list_content_padding_right'  => 20,
+                    'list_content_padding_bottom' => 20,
+                    'list_content_padding_left'   => 20,
+                ),
+            ),
+            'editorial-focus' => array(
+                'label'       => __( 'Focus éditorial', 'mon-articles' ),
+                'locked'      => true,
+                'description' => __( 'Présentation magazine sobre, optimisée pour les listes avec extraits courts.', 'mon-articles' ),
+                'values'      => array(
+                    'display_mode'                => 'list',
+                    'module_bg_color'             => '#ffffff',
+                    'vignette_bg_color'           => '#ffffff',
+                    'title_wrapper_bg_color'      => '#ffffff',
+                    'title_color'                 => '#111827',
+                    'meta_color'                  => '#6b7280',
+                    'meta_color_hover'            => '#111827',
+                    'excerpt_color'               => '#374151',
+                    'pagination_color'            => '#1d4ed8',
+                    'shadow_color'                => 'rgba(0,0,0,0.04)',
+                    'shadow_color_hover'          => 'rgba(0,0,0,0.08)',
+                    'module_padding_left'         => 16,
+                    'module_padding_right'        => 16,
+                    'gap_size'                    => 20,
+                    'list_item_gap'               => 24,
+                    'border_radius'               => 8,
+                    'title_font_size'             => 18,
+                    'meta_font_size'              => 12,
+                    'excerpt_font_size'           => 14,
+                    'list_content_padding_top'    => 12,
+                    'list_content_padding_right'  => 12,
+                    'list_content_padding_bottom' => 12,
+                    'list_content_padding_left'   => 12,
+                    'show_excerpt'                => 1,
+                    'excerpt_length'              => 22,
+                ),
+            ),
+        );
+
+        self::$design_presets = apply_filters( 'my_articles_design_presets', $presets );
+
+        if ( ! is_array( self::$design_presets ) ) {
+            self::$design_presets = $presets;
+        }
+
+        return self::$design_presets;
+    }
+
+    public static function get_design_preset( $preset_id ) {
+        $presets = self::get_design_presets();
+
+        if ( isset( $presets[ $preset_id ] ) ) {
+            return $presets[ $preset_id ];
+        }
+
+        return null;
+    }
 
     private static function build_normalized_options_cache_key( $raw_options, $context ) {
         return md5( maybe_serialize( array( 'options' => $raw_options, 'context' => $context ) ) );
@@ -404,6 +528,8 @@ class My_Articles_Shortcode {
             'order' => 'DESC',
             'meta_key' => '',
             'pagination_mode' => 'none',
+            'design_preset' => 'custom',
+            'design_preset_locked' => 0,
             'show_category_filter' => 0,
             'filter_alignment' => 'right',
             'filter_categories' => array(),
@@ -474,6 +600,8 @@ class My_Articles_Shortcode {
             $context = array();
         }
 
+        $raw_options = is_array( $raw_options ) ? $raw_options : array();
+
         $external_requested_category = '';
 
         if ( array_key_exists( 'requested_category', $context ) ) {
@@ -497,7 +625,51 @@ class My_Articles_Shortcode {
         }
 
         $defaults = self::get_default_options();
-        $options  = wp_parse_args( (array) $raw_options, $defaults );
+
+        $requested_design_preset = $defaults['design_preset'];
+
+        if ( isset( $raw_options['design_preset'] ) && is_scalar( $raw_options['design_preset'] ) ) {
+            $requested_design_preset = sanitize_key( (string) $raw_options['design_preset'] );
+        }
+
+        $design_presets = self::get_design_presets();
+
+        if ( ! isset( $design_presets[ $requested_design_preset ] ) ) {
+            $requested_design_preset = 'custom';
+        }
+
+        $raw_options['design_preset'] = $requested_design_preset;
+
+        $preset_definition = self::get_design_preset( $requested_design_preset );
+        $preset_values     = array();
+        $is_preset_locked  = false;
+
+        if ( is_array( $preset_definition ) ) {
+            if ( isset( $preset_definition['values'] ) && is_array( $preset_definition['values'] ) ) {
+                $preset_values = $preset_definition['values'];
+            }
+
+            $is_preset_locked = ! empty( $preset_definition['locked'] );
+        }
+
+        $options = wp_parse_args( $raw_options, $defaults );
+
+        if ( ! empty( $preset_values ) ) {
+            if ( $is_preset_locked ) {
+                $options = array_merge( $options, $preset_values );
+            } else {
+                foreach ( $preset_values as $preset_key => $preset_value ) {
+                    if ( array_key_exists( $preset_key, $raw_options ) ) {
+                        continue;
+                    }
+
+                    $options[ $preset_key ] = $preset_value;
+                }
+            }
+        }
+
+        $options['design_preset'] = $requested_design_preset;
+        $options['design_preset_locked'] = $is_preset_locked ? 1 : 0;
 
         $aria_label = '';
         if ( isset( $options['aria_label'] ) && is_string( $options['aria_label'] ) ) {

--- a/scripts/migrations/assign-design-preset.php
+++ b/scripts/migrations/assign-design-preset.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Migration script to ensure existing modules use the “Personnalisé” design preset.
+ *
+ * Usage: wp eval-file scripts/migrations/assign-design-preset.php
+ */
+
+if ( ! defined( 'WPINC' ) ) {
+    exit;
+}
+
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+    fwrite( STDERR, "This script must be executed from WP-CLI using `wp eval-file`\n" );
+    return;
+}
+
+$modules = get_posts(
+    array(
+        'post_type'      => 'mon_affichage',
+        'post_status'    => 'any',
+        'numberposts'    => -1,
+        'fields'         => 'ids',
+        'no_found_rows'  => true,
+        'update_post_meta_cache' => false,
+        'update_post_term_cache' => false,
+    )
+);
+
+if ( empty( $modules ) ) {
+    WP_CLI::log( 'No mon_affichage posts found.' );
+    return;
+}
+
+$updated = 0;
+
+foreach ( $modules as $post_id ) {
+    $settings = get_post_meta( $post_id, '_my_articles_settings', true );
+
+    if ( ! is_array( $settings ) ) {
+        continue;
+    }
+
+    if ( isset( $settings['design_preset'] ) && '' !== $settings['design_preset'] ) {
+        continue;
+    }
+
+    $settings['design_preset'] = 'custom';
+    update_post_meta( $post_id, '_my_articles_settings', $settings );
+    $updated++;
+}
+
+WP_CLI::success( sprintf( 'Design preset set to "custom" for %d module(s).', $updated ) );


### PR DESCRIPTION
## Summary
- define reusable design presets in the shortcode layer and merge them during option normalization
- surface the preset selector in the metabox and block inspector, including locked-preset handling in the editor
- expose preset data to the editor script, extend the documentation, and ship a helper migration script

## Testing
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php
- php -l mon-affichage-article/includes/class-my-articles-metaboxes.php
- php -l mon-affichage-article/includes/class-my-articles-enqueue.php
- php -l scripts/migrations/assign-design-preset.php

------
https://chatgpt.com/codex/tasks/task_e_68de8aceccac832eb9f6b6f6ac1252b8