### PR TITLE
Enable REST API editing for mon_affichage post type

### DIFF
--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -1101,6 +1101,7 @@ public function prepare_load_more_articles_response( array $args ) {
             'exclude_from_search' => true,
             'publicly_queryable' => false,
             'capability_type' => 'post',
+            'map_meta_cap' => true,
             'show_in_rest' => true,
             'rest_base' => 'mon_affichage',
         ];


### PR DESCRIPTION
## Summary
- ensure the mon_affichage custom post type is exposed to the REST API by enabling map_meta_cap

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de9f698684832eaf9cc547a6205712