### PR TITLE
Document block layout controls and clarify override handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Utiliser le shortcode :
 - **border_radius** (arrondi des cartes), **title_font_size**, **meta_font_size**, **excerpt_font_size** (typographie)
 - Couleurs principales : **module_bg_color**, **vignette_bg_color**, **title_wrapper_bg_color**, **title_color**, **meta_color**, **meta_color_hover**, **excerpt_color**, **pagination_color**, **shadow_color**, **shadow_color_hover**, **pinned_border_color**, **pinned_badge_bg_color**, **pinned_badge_text_color**
 
+Les panneaux **Disposition**, **Espacements & typographie** et **Couleurs** regroupent l'ensemble de ces curseurs (RangeControl) et sélecteurs de couleurs. Chaque ajustement met immédiatement à jour l'aperçu (rendu serveur) du bloc pour faciliter la mise au point.
+
 ### Préréglages de design
 
 Les modèles intégrés permettent de démarrer rapidement avec des combinaisons cohérentes :

--- a/mon-affichage-article/blocks/mon-affichage-articles/block.json
+++ b/mon-affichage-article/blocks/mon-affichage-articles/block.json
@@ -57,139 +57,173 @@
         },
         "module_padding_left": {
             "type": "integer",
-            "default": 0
+            "default": 0,
+            "description": "Marge interne gauche du module (px)."
         },
         "module_padding_right": {
             "type": "integer",
-            "default": 0
+            "default": 0,
+            "description": "Marge interne droite du module (px)."
         },
         "list_content_padding_top": {
             "type": "integer",
-            "default": 0
+            "default": 0,
+            "description": "Marge interne supérieure des éléments en mode liste (px)."
         },
         "list_content_padding_right": {
             "type": "integer",
-            "default": 0
+            "default": 0,
+            "description": "Marge interne droite des éléments en mode liste (px)."
         },
         "list_content_padding_bottom": {
             "type": "integer",
-            "default": 0
+            "default": 0,
+            "description": "Marge interne inférieure des éléments en mode liste (px)."
         },
         "list_content_padding_left": {
             "type": "integer",
-            "default": 0
+            "default": 0,
+            "description": "Marge interne gauche des éléments en mode liste (px)."
         },
         "columns_mobile": {
             "type": "integer",
-            "default": 1
+            "default": 1,
+            "description": "Nombre de colonnes en affichage grille/diaporama sur mobile (<= 767px)."
         },
         "columns_tablet": {
             "type": "integer",
-            "default": 2
+            "default": 2,
+            "description": "Nombre de colonnes en affichage grille/diaporama sur tablette (768-1023px)."
         },
         "columns_desktop": {
             "type": "integer",
-            "default": 3
+            "default": 3,
+            "description": "Nombre de colonnes en affichage grille/diaporama sur desktop (>= 1024px)."
         },
         "columns_ultrawide": {
             "type": "integer",
-            "default": 4
+            "default": 4,
+            "description": "Nombre de colonnes en affichage grille/diaporama sur écran très large (>= 1536px)."
         },
         "gap_size": {
             "type": "integer",
-            "default": 25
+            "default": 25,
+            "description": "Espacement horizontal entre les cartes en mode grille/diaporama (px)."
         },
         "list_item_gap": {
             "type": "integer",
-            "default": 25
+            "default": 25,
+            "description": "Espacement vertical entre les éléments en mode liste (px)."
         },
         "border_radius": {
             "type": "integer",
-            "default": 12
+            "default": 12,
+            "description": "Rayon d'arrondi appliqué aux cartes (px)."
         },
         "title_font_size": {
             "type": "integer",
-            "default": 16
+            "default": 16,
+            "description": "Taille de police du titre (px)."
         },
         "meta_font_size": {
             "type": "integer",
-            "default": 14
+            "default": 14,
+            "description": "Taille de police des métadonnées (px)."
         },
         "excerpt_font_size": {
             "type": "integer",
-            "default": 14
+            "default": 14,
+            "description": "Taille de police de l'extrait (px)."
         },
         "module_bg_color": {
             "type": "string",
-            "default": "rgba(255,255,255,0)"
+            "default": "rgba(255,255,255,0)",
+            "description": "Couleur de fond principale du module."
         },
         "vignette_bg_color": {
             "type": "string",
-            "default": "#ffffff"
+            "default": "#ffffff",
+            "description": "Couleur de fond derrière l'image ou la vignette."
         },
         "title_wrapper_bg_color": {
             "type": "string",
-            "default": "#ffffff"
+            "default": "#ffffff",
+            "description": "Couleur de fond du bloc contenant le titre."
         },
         "title_color": {
             "type": "string",
-            "default": "#333333"
+            "default": "#333333",
+            "description": "Couleur du titre."
         },
         "meta_color": {
             "type": "string",
-            "default": "#6b7280"
+            "default": "#6b7280",
+            "description": "Couleur du texte des métadonnées."
         },
         "meta_color_hover": {
             "type": "string",
-            "default": "#000000"
+            "default": "#000000",
+            "description": "Couleur des métadonnées au survol."
         },
         "pagination_color": {
             "type": "string",
-            "default": "#333333"
+            "default": "#333333",
+            "description": "Couleur utilisée pour les liens de pagination."
         },
         "excerpt_color": {
             "type": "string",
-            "default": "#4b5563"
+            "default": "#4b5563",
+            "description": "Couleur du texte de l'extrait."
         },
         "shadow_color": {
             "type": "string",
-            "default": "rgba(0,0,0,0.07)"
+            "default": "rgba(0,0,0,0.07)",
+            "description": "Couleur de l'ombre principale."
         },
         "shadow_color_hover": {
             "type": "string",
-            "default": "rgba(0,0,0,0.12)"
+            "default": "rgba(0,0,0,0.12)",
+            "description": "Couleur de l'ombre au survol."
         },
         "pinned_border_color": {
             "type": "string",
-            "default": "#eab308"
+            "default": "#eab308",
+            "description": "Couleur de la bordure pour les articles épinglés."
         },
         "pinned_badge_bg_color": {
             "type": "string",
-            "default": "#eab308"
+            "default": "#eab308",
+            "description": "Couleur de fond du badge d'article épinglé."
         },
         "pinned_badge_text_color": {
             "type": "string",
-            "default": "#ffffff"
+            "default": "#ffffff",
+            "description": "Couleur du texte du badge d'article épinglé."
         },
         "show_excerpt": {
             "type": "boolean",
-            "default": false
+            "default": false,
+            "description": "Affiche ou masque l'extrait dans la liste des articles."
         },
         "excerpt_length": {
             "type": "integer",
-            "default": 25
+            "default": 25,
+            "description": "Longueur de l'extrait lorsqu'il est affiché (nombre de mots)."
         },
         "show_author": {
             "type": "boolean",
-            "default": true
+            "default": true,
+            "description": "Affiche ou masque l'auteur de l'article."
         },
         "show_date": {
             "type": "boolean",
-            "default": true
+            "default": true,
+            "description": "Affiche ou masque la date de publication."
         },
         "show_category": {
             "type": "boolean",
-            "default": true
+            "default": true,
+            "description": "Affiche ou masque la catégorie associée."
         }
     },
     "editorScript": "file:./edit.js",

--- a/mon-affichage-article/blocks/mon-affichage-articles/edit.js
+++ b/mon-affichage-article/blocks/mon-affichage-articles/edit.js
@@ -308,6 +308,7 @@
             );
 
             var displayMode = attributes.display_mode || 'grid';
+            var isListMode = displayMode === 'list';
 
             var ensureNumber = function (value, fallback) {
                 return typeof value === 'number' ? value : fallback;
@@ -481,8 +482,8 @@
                             }
                             setAttributes({ columns_mobile: value });
                         }),
-                        disabled: 'list' === displayMode || isAttributeLocked('columns_mobile'),
-                        help: 'list' === displayMode ? __('Disponible pour Grille et Diaporama.', 'mon-articles') : null,
+                        disabled: isListMode || isAttributeLocked('columns_mobile'),
+                        help: isListMode ? __('Disponible pour Grille et Diaporama.', 'mon-articles') : null,
                     }),
                     el(RangeControl, {
                         label: __('Colonnes (tablette)', 'mon-articles'),
@@ -496,8 +497,8 @@
                             }
                             setAttributes({ columns_tablet: value });
                         }),
-                        disabled: 'list' === displayMode || isAttributeLocked('columns_tablet'),
-                        help: 'list' === displayMode ? __('Disponible pour Grille et Diaporama.', 'mon-articles') : null,
+                        disabled: isListMode || isAttributeLocked('columns_tablet'),
+                        help: isListMode ? __('Disponible pour Grille et Diaporama.', 'mon-articles') : null,
                     }),
                     el(RangeControl, {
                         label: __('Colonnes (desktop)', 'mon-articles'),
@@ -511,8 +512,8 @@
                             }
                             setAttributes({ columns_desktop: value });
                         }),
-                        disabled: 'list' === displayMode || isAttributeLocked('columns_desktop'),
-                        help: 'list' === displayMode ? __('Disponible pour Grille et Diaporama.', 'mon-articles') : null,
+                        disabled: isListMode || isAttributeLocked('columns_desktop'),
+                        help: isListMode ? __('Disponible pour Grille et Diaporama.', 'mon-articles') : null,
                     }),
                     el(RangeControl, {
                         label: __('Colonnes (ultra-large)', 'mon-articles'),
@@ -526,8 +527,8 @@
                             }
                             setAttributes({ columns_ultrawide: value });
                         }),
-                        disabled: 'list' === displayMode || isAttributeLocked('columns_ultrawide'),
-                        help: 'list' === displayMode ? __('Disponible pour Grille et Diaporama.', 'mon-articles') : null,
+                        disabled: isListMode || isAttributeLocked('columns_ultrawide'),
+                        help: isListMode ? __('Disponible pour Grille et Diaporama.', 'mon-articles') : null,
                     }),
                     el(RangeControl, {
                         label: __('Espacement des vignettes (px)', 'mon-articles'),
@@ -541,7 +542,7 @@
                             }
                             setAttributes({ gap_size: value });
                         }),
-                        disabled: 'list' === displayMode || isAttributeLocked('gap_size'),
+                        disabled: isListMode || isAttributeLocked('gap_size'),
                     }),
                     el(RangeControl, {
                         label: __('Espacement vertical (liste)', 'mon-articles'),
@@ -555,7 +556,7 @@
                             }
                             setAttributes({ list_item_gap: value });
                         }),
-                        disabled: 'list' !== displayMode || isAttributeLocked('list_item_gap'),
+                        disabled: !isListMode || isAttributeLocked('list_item_gap'),
                     })
                 ),
                 el(
@@ -657,7 +658,7 @@
                             }
                             setAttributes({ list_content_padding_top: value });
                         }),
-                        disabled: 'list' !== displayMode || isAttributeLocked('list_content_padding_top'),
+                        disabled: !isListMode || isAttributeLocked('list_content_padding_top'),
                     }),
                     el(RangeControl, {
                         label: __('Padding contenu liste – droite (px)', 'mon-articles'),
@@ -671,7 +672,7 @@
                             }
                             setAttributes({ list_content_padding_right: value });
                         }),
-                        disabled: 'list' !== displayMode || isAttributeLocked('list_content_padding_right'),
+                        disabled: !isListMode || isAttributeLocked('list_content_padding_right'),
                     }),
                     el(RangeControl, {
                         label: __('Padding contenu liste – bas (px)', 'mon-articles'),
@@ -685,7 +686,7 @@
                             }
                             setAttributes({ list_content_padding_bottom: value });
                         }),
-                        disabled: 'list' !== displayMode || isAttributeLocked('list_content_padding_bottom'),
+                        disabled: !isListMode || isAttributeLocked('list_content_padding_bottom'),
                     }),
                     el(RangeControl, {
                         label: __('Padding contenu liste – gauche (px)', 'mon-articles'),
@@ -699,7 +700,7 @@
                             }
                             setAttributes({ list_content_padding_left: value });
                         }),
-                        disabled: 'list' !== displayMode || isAttributeLocked('list_content_padding_left'),
+                        disabled: !isListMode || isAttributeLocked('list_content_padding_left'),
                     })
                 ),
                 el(
@@ -851,7 +852,7 @@
                     }),
                     el(RangeControl, {
                         label: __('Longueur de l’extrait', 'mon-articles'),
-                        value: attributes.excerpt_length,
+                        value: ensureNumber(attributes.excerpt_length, 25),
                         min: 0,
                         max: 100,
                         onChange: withLockedGuard('excerpt_length', function (value) {

--- a/mon-affichage-article/includes/class-my-articles-block.php
+++ b/mon-affichage-article/includes/class-my-articles-block.php
@@ -66,6 +66,10 @@ class My_Articles_Block {
         foreach ( $filtered as $key => $raw_value ) {
             $default_value = $defaults[ $key ];
 
+            if ( null === $raw_value ) {
+                continue;
+            }
+
             if ( is_array( $default_value ) ) {
                 if ( is_array( $raw_value ) ) {
                     $overrides[ $key ] = $raw_value;


### PR DESCRIPTION
## Summary
- document the layout and color controls exposed by the block to ease discovery in the editor
- add human-readable descriptions for layout, spacing, and color attributes in `block.json`
- reuse a shared list-mode flag in the editor UI and harden override preparation when values are null

## Testing
- not run (WordPress environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de9f6a8ef8832e8842be5b2132307f