### PR TITLE
Add customizable slideshow behaviour settings

### DIFF
--- a/mon-affichage-article/assets/js/admin-options.js
+++ b/mon-affichage-article/assets/js/admin-options.js
@@ -41,6 +41,21 @@
         }
     }
 
+    function toggleSlideshowOptions() {
+        var $displayMode = $('#display_mode');
+        var $slideshowOptions = $('.my-articles-slideshow-settings');
+
+        if (!$slideshowOptions.length) {
+            return;
+        }
+
+        if ($displayMode.length && $displayMode.val() === 'slideshow') {
+            $slideshowOptions.show();
+        } else {
+            $slideshowOptions.hide();
+        }
+    }
+
     var columnSelectors = '#columns_mobile, #columns_tablet, #columns_desktop, #columns_ultrawide';
     var columnsConfigDefaults = {
         minColumnWidth: 240,
@@ -136,12 +151,14 @@
     $(document).on('change', '#pinned_show_badge', toggleBadgeOptions);
     $(document).on('change', '#show_excerpt', toggleExcerptOptions);
     $(document).on('change', '#orderby', toggleMetaKeyOption);
+    $(document).on('change', '#display_mode', toggleSlideshowOptions);
 
     // Exécution au chargement de la page pour définir l'état initial
     $(document).ready(function() {
         toggleBadgeOptions();
         toggleExcerptOptions();
         toggleMetaKeyOption();
+        toggleSlideshowOptions();
         initColumnsWarnings();
     });
 

--- a/mon-affichage-article/assets/js/swiper-init.js
+++ b/mon-affichage-article/assets/js/swiper-init.js
@@ -157,23 +157,40 @@
             wrapper.classList.add('swiper-is-loading');
         }
 
+        const autoplayConfig = settings.autoplay
+            ? {
+                  delay: typeof settings.autoplay_delay === 'number' ? settings.autoplay_delay : 5000,
+                  disableOnInteraction: !!settings.pause_on_interaction,
+                  pauseOnMouseEnter: !!settings.pause_on_mouse_enter,
+              }
+            : false;
+
+        const paginationConfig = settings.show_pagination
+            ? {
+                  el: settings.container_selector + ' .swiper-pagination',
+                  clickable: true,
+              }
+            : false;
+
+        const navigationConfig = settings.show_navigation
+            ? {
+                  nextEl: settings.container_selector + ' .swiper-button-next',
+                  prevEl: settings.container_selector + ' .swiper-button-prev',
+              }
+            : false;
+
         const instance = new Swiper(settings.container_selector, {
             slidesPerView: settings.columns_mobile,
             spaceBetween: settings.gap_size,
-            loop: true,
+            loop: !!settings.loop,
             watchOverflow: true,
             keyboard: {
                 enabled: true,
                 onlyInViewport: true,
             },
-            pagination: {
-                el: settings.container_selector + ' .swiper-pagination',
-                clickable: true,
-            },
-            navigation: {
-                nextEl: settings.container_selector + ' .swiper-button-next',
-                prevEl: settings.container_selector + ' .swiper-button-prev',
-            },
+            pagination: paginationConfig,
+            navigation: navigationConfig,
+            autoplay: autoplayConfig,
             a11y: {
                 enabled: true,
                 prevSlideMessage: settings.a11y_prev_slide_message,

--- a/mon-affichage-article/blocks/mon-affichage-articles/block.json
+++ b/mon-affichage-article/blocks/mon-affichage-articles/block.json
@@ -55,6 +55,41 @@
             "type": "string",
             "default": "none"
         },
+        "slideshow_loop": {
+            "type": "boolean",
+            "default": true,
+            "description": "Active la boucle infinie du diaporama."
+        },
+        "slideshow_autoplay": {
+            "type": "boolean",
+            "default": false,
+            "description": "Active la lecture automatique du diaporama."
+        },
+        "slideshow_delay": {
+            "type": "integer",
+            "default": 5000,
+            "description": "Délai entre les diapositives en millisecondes lorsque l'autoplay est actif."
+        },
+        "slideshow_pause_on_interaction": {
+            "type": "boolean",
+            "default": true,
+            "description": "Met l'autoplay en pause lors d'une interaction utilisateur."
+        },
+        "slideshow_pause_on_mouse_enter": {
+            "type": "boolean",
+            "default": true,
+            "description": "Met l'autoplay en pause quand la souris survole le module."
+        },
+        "slideshow_show_navigation": {
+            "type": "boolean",
+            "default": true,
+            "description": "Affiche les flèches de navigation du diaporama."
+        },
+        "slideshow_show_pagination": {
+            "type": "boolean",
+            "default": true,
+            "description": "Affiche la pagination (puces) du diaporama."
+        },
         "module_padding_left": {
             "type": "integer",
             "default": 0,

--- a/mon-affichage-article/blocks/mon-affichage-articles/edit.js
+++ b/mon-affichage-article/blocks/mon-affichage-articles/edit.js
@@ -348,6 +348,7 @@
 
             var displayMode = attributes.display_mode || 'grid';
             var isListMode = displayMode === 'list';
+            var isSlideshowMode = displayMode === 'slideshow';
 
             var ensureNumber = function (value, fallback) {
                 return typeof value === 'number' ? value : fallback;
@@ -504,7 +505,75 @@
                             setAttributes({ pagination_mode: value });
                         }),
                         disabled: isAttributeLocked('pagination_mode'),
-                    })
+                    }),
+                    isSlideshowMode
+                        ? el(Fragment, {},
+                              el(ToggleControl, {
+                                  label: __('Boucle infinie', 'mon-articles'),
+                                  checked: !!attributes.slideshow_loop,
+                                  onChange: withLockedGuard('slideshow_loop', function (value) {
+                                      setAttributes({ slideshow_loop: !!value });
+                                  }),
+                                  disabled: isAttributeLocked('slideshow_loop'),
+                              }),
+                              el(ToggleControl, {
+                                  label: __('Lecture automatique', 'mon-articles'),
+                                  checked: !!attributes.slideshow_autoplay,
+                                  onChange: withLockedGuard('slideshow_autoplay', function (value) {
+                                      setAttributes({ slideshow_autoplay: !!value });
+                                  }),
+                                  disabled: isAttributeLocked('slideshow_autoplay'),
+                              }),
+                              el(RangeControl, {
+                                  label: __('Délai entre les diapositives (ms)', 'mon-articles'),
+                                  value: ensureNumber(attributes.slideshow_delay, 5000),
+                                  min: 1000,
+                                  max: 20000,
+                                  step: 100,
+                                  allowReset: true,
+                                  onChange: withLockedGuard('slideshow_delay', function (value) {
+                                      if (typeof value !== 'number') {
+                                          value = 5000;
+                                      }
+                                      setAttributes({ slideshow_delay: value });
+                                  }),
+                                  disabled: !attributes.slideshow_autoplay || isAttributeLocked('slideshow_delay'),
+                                  help: __('Actif uniquement si la lecture automatique est activée.', 'mon-articles'),
+                              }),
+                              el(ToggleControl, {
+                                  label: __('Mettre en pause lors des interactions', 'mon-articles'),
+                                  checked: !!attributes.slideshow_pause_on_interaction,
+                                  onChange: withLockedGuard('slideshow_pause_on_interaction', function (value) {
+                                      setAttributes({ slideshow_pause_on_interaction: !!value });
+                                  }),
+                                  disabled: !attributes.slideshow_autoplay || isAttributeLocked('slideshow_pause_on_interaction'),
+                              }),
+                              el(ToggleControl, {
+                                  label: __('Mettre en pause au survol', 'mon-articles'),
+                                  checked: !!attributes.slideshow_pause_on_mouse_enter,
+                                  onChange: withLockedGuard('slideshow_pause_on_mouse_enter', function (value) {
+                                      setAttributes({ slideshow_pause_on_mouse_enter: !!value });
+                                  }),
+                                  disabled: !attributes.slideshow_autoplay || isAttributeLocked('slideshow_pause_on_mouse_enter'),
+                              }),
+                              el(ToggleControl, {
+                                  label: __('Afficher les flèches de navigation', 'mon-articles'),
+                                  checked: !!attributes.slideshow_show_navigation,
+                                  onChange: withLockedGuard('slideshow_show_navigation', function (value) {
+                                      setAttributes({ slideshow_show_navigation: !!value });
+                                  }),
+                                  disabled: isAttributeLocked('slideshow_show_navigation'),
+                              }),
+                              el(ToggleControl, {
+                                  label: __('Afficher la pagination', 'mon-articles'),
+                                  checked: !!attributes.slideshow_show_pagination,
+                                  onChange: withLockedGuard('slideshow_show_pagination', function (value) {
+                                      setAttributes({ slideshow_show_pagination: !!value });
+                                  }),
+                                  disabled: isAttributeLocked('slideshow_show_pagination'),
+                              })
+                          )
+                        : null
                 ),
                 el(
                     PanelBody,

--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -233,6 +233,37 @@ class My_Articles_Metaboxes {
         echo '<hr><h3>' . esc_html__('Mise en Page', 'mon-articles') . '</h3>';
         $this->render_field('display_mode', esc_html__('Mode d\'affichage', 'mon-articles'), 'select', $opts, [ 'default' => 'grid', 'options' => [ 'grid' => 'Grille', 'slideshow' => 'Diaporama', 'list' => 'Liste' ] ]);
 
+        echo '<div class="my-articles-slideshow-settings" data-field="slideshow" style="display:none;">';
+        $this->render_field('slideshow_loop', esc_html__('Boucle infinie', 'mon-articles'), 'checkbox', $opts, [
+            'default'     => 1,
+            'description' => __('Autorise le carrousel à revenir automatiquement au début.', 'mon-articles'),
+        ]);
+        $this->render_field('slideshow_autoplay', esc_html__('Lecture automatique', 'mon-articles'), 'checkbox', $opts, [
+            'default'     => 0,
+            'description' => __('Fait défiler les diapositives sans interaction de l’utilisateur.', 'mon-articles'),
+        ]);
+        $this->render_field('slideshow_delay', esc_html__('Délai entre les diapositives (ms)', 'mon-articles'), 'number', $opts, [
+            'default'     => 5000,
+            'min'         => 1000,
+            'max'         => 20000,
+            'description' => __('Utilisé lorsque la lecture automatique est activée.', 'mon-articles'),
+        ]);
+        $this->render_field('slideshow_pause_on_interaction', esc_html__('Mettre en pause lors des interactions', 'mon-articles'), 'checkbox', $opts, [
+            'default'     => 1,
+            'description' => __('Suspend l’autoplay lorsqu’un lien ou un contrôle du carrousel est utilisé.', 'mon-articles'),
+        ]);
+        $this->render_field('slideshow_pause_on_mouse_enter', esc_html__('Mettre en pause au survol', 'mon-articles'), 'checkbox', $opts, [
+            'default'     => 1,
+            'description' => __('Gèle le carrousel quand la souris survole la zone.', 'mon-articles'),
+        ]);
+        $this->render_field('slideshow_show_navigation', esc_html__('Afficher les flèches de navigation', 'mon-articles'), 'checkbox', $opts, [
+            'default' => 1,
+        ]);
+        $this->render_field('slideshow_show_pagination', esc_html__('Afficher la pagination', 'mon-articles'), 'checkbox', $opts, [
+            'default' => 1,
+        ]);
+        echo '</div>';
+
         echo '<div class="my-articles-columns-warning" data-field="columns_mobile">';
         $this->render_field('columns_mobile', esc_html__('Colonnes (Mobile < 768px)', 'mon-articles'), 'number', $opts, [
             'default'     => 1,
@@ -586,6 +617,21 @@ class My_Articles_Metaboxes {
         $sanitized['show_category'] = isset( $input['show_category'] ) ? 1 : 0;
         $sanitized['show_author'] = isset( $input['show_author'] ) ? 1 : 0;
         $sanitized['show_date'] = isset( $input['show_date'] ) ? 1 : 0;
+
+        $sanitized['slideshow_loop'] = isset( $input['slideshow_loop'] ) ? 1 : 0;
+        $sanitized['slideshow_autoplay'] = isset( $input['slideshow_autoplay'] ) ? 1 : 0;
+        $delay = isset( $input['slideshow_delay'] ) ? absint( $input['slideshow_delay'] ) : 5000;
+        if ( $delay > 0 && $delay < 1000 ) {
+            $delay = 1000;
+        }
+        if ( 0 === $delay ) {
+            $delay = 5000;
+        }
+        $sanitized['slideshow_delay'] = $delay;
+        $sanitized['slideshow_pause_on_interaction'] = isset( $input['slideshow_pause_on_interaction'] ) ? 1 : 0;
+        $sanitized['slideshow_pause_on_mouse_enter'] = isset( $input['slideshow_pause_on_mouse_enter'] ) ? 1 : 0;
+        $sanitized['slideshow_show_navigation'] = isset( $input['slideshow_show_navigation'] ) ? 1 : 0;
+        $sanitized['slideshow_show_pagination'] = isset( $input['slideshow_show_pagination'] ) ? 1 : 0;
 
         $sanitized['show_excerpt'] = isset( $input['show_excerpt'] ) ? 1 : 0;
         $sanitized['excerpt_length'] = isset( $input['excerpt_length'] ) ? absint($input['excerpt_length']) : 25;

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -576,6 +576,13 @@ class My_Articles_Shortcode {
             'title_wrapper_bg_color' => '#ffffff', 'title_color' => '#333333',
             'meta_color' => '#6b7280', 'meta_color_hover' => '#000000', 'pagination_color' => '#333333',
             'shadow_color' => 'rgba(0,0,0,0.07)', 'shadow_color_hover' => 'rgba(0,0,0,0.12)',
+            'slideshow_loop' => 1,
+            'slideshow_autoplay' => 0,
+            'slideshow_delay' => 5000,
+            'slideshow_pause_on_interaction' => 1,
+            'slideshow_pause_on_mouse_enter' => 1,
+            'slideshow_show_navigation' => 1,
+            'slideshow_show_pagination' => 1,
         ];
 
         $saved_options = get_option( 'my_articles_options', array() );
@@ -798,6 +805,25 @@ class My_Articles_Shortcode {
         $options['exclude_post_ids'] = $exclude_post_ids;
 
         $options['all_excluded_ids'] = array_values( array_unique( array_merge( $pinned_ids, $exclude_post_ids ) ) );
+
+        $options['slideshow_loop'] = ! empty( $options['slideshow_loop'] ) ? 1 : 0;
+        $options['slideshow_autoplay'] = ! empty( $options['slideshow_autoplay'] ) ? 1 : 0;
+        $options['slideshow_pause_on_interaction'] = ! empty( $options['slideshow_pause_on_interaction'] ) ? 1 : 0;
+        $options['slideshow_pause_on_mouse_enter'] = ! empty( $options['slideshow_pause_on_mouse_enter'] ) ? 1 : 0;
+        $options['slideshow_show_navigation'] = ! empty( $options['slideshow_show_navigation'] ) ? 1 : 0;
+        $options['slideshow_show_pagination'] = ! empty( $options['slideshow_show_pagination'] ) ? 1 : 0;
+
+        $slideshow_delay = isset( $options['slideshow_delay'] ) ? (int) $options['slideshow_delay'] : (int) $defaults['slideshow_delay'];
+        if ( $slideshow_delay < 0 ) {
+            $slideshow_delay = 0;
+        }
+        if ( $slideshow_delay > 0 && $slideshow_delay < 1000 ) {
+            $slideshow_delay = 1000;
+        }
+        if ( 0 === $slideshow_delay ) {
+            $slideshow_delay = (int) $defaults['slideshow_delay'];
+        }
+        $options['slideshow_delay'] = $slideshow_delay;
 
         $default_term = $options['term'];
         $requested_category = '';
@@ -1370,6 +1396,9 @@ class My_Articles_Shortcode {
         $previous_slide_label  = esc_attr( __( 'Revenir à la diapositive précédente', 'mon-articles' ) );
 
         echo '<div class="swiper-accessibility-wrapper" role="region" aria-roledescription="carousel" aria-label="' . $carousel_label . '">';
+        $show_navigation  = ! empty( $options['slideshow_show_navigation'] );
+        $show_pagination  = ! empty( $options['slideshow_show_pagination'] );
+
         echo '<div class="swiper-container"><div class="swiper-wrapper">';
         $post_count = 0;
 
@@ -1398,9 +1427,15 @@ class My_Articles_Shortcode {
         }
 
         echo '</div>';
-        echo '<div class="swiper-pagination" aria-label="' . $pagination_label . '"></div>';
-        echo '<div class="swiper-button-next" aria-label="' . $next_slide_label . '"></div>';
-        echo '<div class="swiper-button-prev" aria-label="' . $previous_slide_label . '"></div>';
+
+        if ( $show_pagination ) {
+            echo '<div class="swiper-pagination" aria-label="' . $pagination_label . '"></div>';
+        }
+
+        if ( $show_navigation ) {
+            echo '<div class="swiper-button-next" aria-label="' . $next_slide_label . '"></div>';
+            echo '<div class="swiper-button-prev" aria-label="' . $previous_slide_label . '"></div>';
+        }
         echo '</div>';
         echo '</div>';
 
@@ -1639,6 +1674,13 @@ class My_Articles_Shortcode {
             'columns_desktop'                   => $options['columns_desktop'],
             'columns_ultrawide'                 => $options['columns_ultrawide'],
             'gap_size'                          => $options['gap_size'],
+            'loop'                              => ! empty( $options['slideshow_loop'] ),
+            'autoplay'                          => ! empty( $options['slideshow_autoplay'] ),
+            'autoplay_delay'                    => (int) $options['slideshow_delay'],
+            'pause_on_interaction'              => ! empty( $options['slideshow_pause_on_interaction'] ),
+            'pause_on_mouse_enter'              => ! empty( $options['slideshow_pause_on_mouse_enter'] ),
+            'show_navigation'                   => ! empty( $options['slideshow_show_navigation'] ),
+            'show_pagination'                   => ! empty( $options['slideshow_show_pagination'] ),
             'container_selector'                => '#my-articles-wrapper-' . $instance_id . ' .swiper-container',
             'a11y_prev_slide_message'           => __( 'Diapositive précédente', 'mon-articles' ),
             'a11y_next_slide_message'           => __( 'Diapositive suivante', 'mon-articles' ),


### PR DESCRIPTION
## Summary
- add slideshow behaviour defaults for autoplay, loop, navigation, and pagination to the shortcode and expose them in the metabox
- extend the block attributes and inspector controls to edit slideshow autoplay timing and visibility options
- pass the new settings to Swiper and update the initializer to honour autoplay, loop, and control visibility choices

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68def9d85ae4832e80fcbbdc344ef9ec