### PR TITLE
Add configurable ARIA label for category filter navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Options principales :
 - **Articles épinglés** : possibilité d'épingler certains articles, avec option d'ignorer les filtres.
 - **Lazy load** : chargement différé des images pour optimiser les performances.
 - **Étiquette ARIA** : personnalisez le libellé utilisé par les lecteurs d'écran (par défaut, le titre du module est utilisé).
+- **Étiquette ARIA du filtre** : définissez un texte explicite pour la navigation des catégories ou laissez le module générer automatiquement un intitulé (« Filtre des catégories pour … »).
 
 > ℹ️ **Diaporama et mode illimité** : lorsque `display_mode` vaut `slideshow`, la récupération des contenus respecte toujours le plafond défini par l'option `unlimited_query_cap` (50 par défaut via le filtre `my_articles_unlimited_batch_size`). Cela évite de charger un nombre excessif d'articles d'un coup tout en conservant un mode quasi illimité.
 
@@ -115,6 +116,7 @@ Le script affecte automatiquement le modèle « Personnalisé » (`custom`) au
 - Le mode diaporama expose désormais un carrousel conforme aux recommandations ARIA (région labellisée, boutons de navigation et pagination explicitement décrits).
 - La navigation clavier est activée par défaut dans Swiper et les messages d’assistance sont personnalisés pour les lecteurs d’écran.
 - Chaque module est annoncé comme région dynamique (`role="region"`, `aria-live="polite"`, `aria-busy`) et peut utiliser une étiquette ARIA personnalisée pour faciliter l’identification par les lecteurs d’écran. Les modules existants héritent automatiquement de leur titre tant que le champ dédié reste vide.
+- Le filtre de catégories (lorsqu’il est actif) dispose désormais d’un libellé ARIA explicite basé sur le titre du module. Ce texte peut être ajusté ou vidé dans la metabox et dans le panneau **Module** du bloc pour répondre aux besoins éditoriaux.
 
 ## Hooks AJAX
 

--- a/mon-affichage-article/blocks/mon-affichage-articles/block.json
+++ b/mon-affichage-article/blocks/mon-affichage-articles/block.json
@@ -47,6 +47,11 @@
             "type": "boolean",
             "default": false
         },
+        "category_filter_aria_label": {
+            "type": "string",
+            "default": "",
+            "description": "Libellé ARIA appliqué à la navigation du filtre de catégories."
+        },
         "filter_alignment": {
             "type": "string",
             "default": "right"

--- a/mon-affichage-article/blocks/mon-affichage-articles/edit.js
+++ b/mon-affichage-article/blocks/mon-affichage-articles/edit.js
@@ -926,6 +926,15 @@
                         }),
                         disabled: !attributes.show_category_filter || isAttributeLocked('filter_alignment'),
                     }),
+                    el(TextControl, {
+                        label: __('Libellé ARIA du filtre de catégories', 'mon-articles'),
+                        value: attributes.category_filter_aria_label || '',
+                        onChange: function (value) {
+                            setAttributes({ category_filter_aria_label: value || '' });
+                        },
+                        help: __('Laissez vide pour générer automatiquement une étiquette basée sur le titre du module.', 'mon-articles'),
+                        disabled: !attributes.show_category_filter,
+                    }),
                     el(ToggleControl, {
                         label: __('Afficher la catégorie', 'mon-articles'),
                         checked: !!attributes.show_category,

--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -332,6 +332,20 @@ class My_Articles_Metaboxes {
             ]
         );
 
+        /* translators: %s: module accessible label. */
+        $default_filter_aria_label = sprintf( __( 'Filtre des catégories pour %s', 'mon-articles' ), $default_aria_label );
+
+        $this->render_field(
+            'category_filter_aria_label',
+            esc_html__( 'Étiquette du filtre de catégories (ARIA)', 'mon-articles' ),
+            'text',
+            $opts,
+            [
+                'placeholder' => $default_filter_aria_label,
+                'description' => esc_html__( 'Texte lu par les lecteurs d’écran pour annoncer la navigation du filtre. Laissez vide pour utiliser l’étiquette générée automatiquement.', 'mon-articles' ),
+            ]
+        );
+
         echo '<hr><h3>' . esc_html__('Apparence & Performances', 'mon-articles') . '</h3>';
         $design_presets = My_Articles_Shortcode::get_design_presets();
         $design_preset_options = array();
@@ -587,6 +601,13 @@ class My_Articles_Metaboxes {
             $aria_label = trim( $aria_label );
         }
         $sanitized['aria_label'] = $aria_label;
+
+        $category_filter_aria_label = '';
+        if ( isset( $input['category_filter_aria_label'] ) && is_string( $input['category_filter_aria_label'] ) ) {
+            $category_filter_aria_label = sanitize_text_field( $input['category_filter_aria_label'] );
+            $category_filter_aria_label = trim( $category_filter_aria_label );
+        }
+        $sanitized['category_filter_aria_label'] = $category_filter_aria_label;
 
         $design_preset = 'custom';
         if ( isset( $input['design_preset'] ) && is_string( $input['design_preset'] ) ) {

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -548,6 +548,7 @@ class My_Articles_Shortcode {
             'filter_alignment' => 'right',
             'filter_categories' => array(),
             'aria_label' => '',
+            'category_filter_aria_label' => '',
             'pinned_posts' => array(),
             'pinned_border_color' => '#eab308',
             'pinned_posts_ignore_filter' => 0,
@@ -693,6 +694,16 @@ class My_Articles_Shortcode {
             $aria_label = trim( sanitize_text_field( $options['aria_label'] ) );
         }
         $options['aria_label'] = $aria_label;
+
+        $category_filter_aria_label = '';
+        if ( isset( $options['category_filter_aria_label'] ) && is_string( $options['category_filter_aria_label'] ) ) {
+            $category_filter_aria_label = trim( sanitize_text_field( $options['category_filter_aria_label'] ) );
+        }
+        if ( '' === $category_filter_aria_label && '' !== $aria_label ) {
+            /* translators: %s: module accessible label. */
+            $category_filter_aria_label = sprintf( __( 'Filtre des catégories pour %s', 'mon-articles' ), $aria_label );
+        }
+        $options['category_filter_aria_label'] = $category_filter_aria_label;
 
         $allowed_display_modes = array( 'grid', 'list', 'slideshow' );
         $display_mode          = $options['display_mode'] ?? $defaults['display_mode'];
@@ -999,6 +1010,20 @@ class My_Articles_Shortcode {
 
         $options_meta['aria_label'] = $resolved_aria_label;
 
+        /* translators: %s: module accessible label. */
+        $default_filter_aria_label = sprintf( __( 'Filtre des catégories pour %s', 'mon-articles' ), $resolved_aria_label );
+
+        $resolved_filter_aria_label = '';
+        if ( isset( $options_meta['category_filter_aria_label'] ) && is_string( $options_meta['category_filter_aria_label'] ) ) {
+            $resolved_filter_aria_label = trim( sanitize_text_field( $options_meta['category_filter_aria_label'] ) );
+        }
+
+        if ( '' === $resolved_filter_aria_label ) {
+            $resolved_filter_aria_label = $default_filter_aria_label;
+        }
+
+        $options_meta['category_filter_aria_label'] = $resolved_filter_aria_label;
+
         $has_filter_categories = false;
         if ( isset( $options_meta['filter_categories'] ) ) {
             $raw_filter_categories = $options_meta['filter_categories'];
@@ -1176,7 +1201,21 @@ class My_Articles_Shortcode {
 
         if ( ! empty( $options['show_category_filter'] ) && ! empty( $resolved_taxonomy ) && ! empty( $available_categories ) ) {
             $alignment_class = 'filter-align-' . esc_attr( $options['filter_alignment'] );
-            echo '<nav class="my-articles-filter-nav ' . $alignment_class . '"><ul>';
+            $nav_attributes = array(
+                'class'      => 'my-articles-filter-nav ' . $alignment_class,
+                'aria-label' => $options['category_filter_aria_label'],
+            );
+
+            $nav_attribute_strings = array();
+            foreach ( $nav_attributes as $attribute => $value ) {
+                if ( '' === $value ) {
+                    continue;
+                }
+
+                $nav_attribute_strings[] = sprintf( '%s="%s"', esc_attr( $attribute ), esc_attr( (string) $value ) );
+            }
+
+            echo '<nav ' . implode( ' ', $nav_attribute_strings ) . '><ul>';
             $default_cat   = $options['term'] ?? '';
             $is_all_active = '' === $default_cat || 'all' === $default_cat;
             echo '<li class="' . ( $is_all_active ? 'active' : '' ) . '"><button type="button" data-category="all" aria-pressed="' . ( $is_all_active ? 'true' : 'false' ) . '">' . esc_html__( 'Tout', 'mon-articles' ) . '</button></li>';


### PR DESCRIPTION
## Summary
- compute a default ARIA label for the category filter based on the module title and inject it on the navigation markup
- expose a new optional field in the metabox and block attributes so editors can override or clear the generated label
- document the new accessibility option in the README to guide authors

## Testing
- composer test *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68df964e5cdc832ea974e466d8620e96