### PR TITLE
Add configurable mobile filter behavior for article module

### DIFF
--- a/mon-affichage-article/assets/css/styles.css
+++ b/mon-affichage-article/assets/css/styles.css
@@ -192,6 +192,40 @@
     margin-bottom: 20px;
 }
 
+.my-articles-filter-select {
+    display: none;
+    margin-bottom: 20px;
+}
+
+.my-articles-filter-select__label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.my-articles-filter-select__control {
+    width: 100%;
+    padding: 12px 16px;
+    border-radius: 8px;
+    border: 1px solid rgba(0, 0, 0, 0.18);
+    font-size: 15px;
+    line-height: 1.4;
+    background: #ffffff;
+    color: #1f2933;
+    box-shadow: 0 2px 6px rgba(15, 23, 42, 0.04);
+}
+
+.my-articles-filter-select__control:focus {
+    outline: 2px solid #1f2933;
+    outline-offset: 2px;
+}
+
 .my-articles-feedback {
     margin: 16px 0;
     padding: 14px 18px;
@@ -232,6 +266,10 @@
     padding: 0;
     display: flex;
     flex-wrap: wrap;
+}
+
+.my-articles-filter-nav--carousel ul {
+    gap: 8px;
 }
 
 .my-articles-filter-nav.filter-align-left ul { justify-content: flex-start; }
@@ -275,6 +313,36 @@
         padding: 10px 18px;
         font-size: 15px;
         margin: 5px 5px 0 0;
+    }
+
+    .my-articles-wrapper[data-filter-mobile="select"] .my-articles-filter-nav {
+        display: none;
+    }
+
+    .my-articles-wrapper[data-filter-mobile="select"] .my-articles-filter-select {
+        display: block;
+    }
+
+    .my-articles-wrapper[data-filter-mobile="carousel"] .my-articles-filter-nav ul {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        gap: 12px;
+        padding-bottom: 6px;
+        margin: 0 -6px;
+        padding-left: 6px;
+    }
+
+    .my-articles-wrapper[data-filter-mobile="carousel"] .my-articles-filter-nav ul::-webkit-scrollbar {
+        display: none;
+    }
+
+    .my-articles-wrapper[data-filter-mobile="carousel"] .my-articles-filter-nav ul {
+        scrollbar-width: none;
+    }
+
+    .my-articles-wrapper[data-filter-mobile="carousel"] .my-articles-filter-nav li {
+        flex: 0 0 auto;
     }
 
     .my-articles-load-more-btn {

--- a/mon-affichage-article/blocks/mon-affichage-articles/block.json
+++ b/mon-affichage-article/blocks/mon-affichage-articles/block.json
@@ -51,6 +51,10 @@
             "type": "string",
             "default": "right"
         },
+        "filter_mobile_behavior": {
+            "type": "string",
+            "default": "buttons"
+        },
         "pagination_mode": {
             "type": "string",
             "default": "none"

--- a/mon-affichage-article/blocks/mon-affichage-articles/edit.js
+++ b/mon-affichage-article/blocks/mon-affichage-articles/edit.js
@@ -926,6 +926,20 @@
                         }),
                         disabled: !attributes.show_category_filter || isAttributeLocked('filter_alignment'),
                     }),
+                    el(SelectControl, {
+                        label: __('Comportement mobile du filtre', 'mon-articles'),
+                        value: attributes.filter_mobile_behavior || 'buttons',
+                        options: [
+                            { label: __('Boutons (par défaut)', 'mon-articles'), value: 'buttons' },
+                            { label: __('Liste déroulante', 'mon-articles'), value: 'select' },
+                            { label: __('Carrousel horizontal', 'mon-articles'), value: 'carousel' },
+                        ],
+                        onChange: withLockedGuard('filter_mobile_behavior', function (value) {
+                            setAttributes({ filter_mobile_behavior: value });
+                        }),
+                        help: __('Contrôle affiché sous 768px.', 'mon-articles'),
+                        disabled: !attributes.show_category_filter || isAttributeLocked('filter_mobile_behavior'),
+                    }),
                     el(ToggleControl, {
                         label: __('Afficher la catégorie', 'mon-articles'),
                         checked: !!attributes.show_category,

--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -201,6 +201,15 @@ class My_Articles_Metaboxes {
                 'right'  => __('Droite', 'mon-articles'),
             ],
         ]);
+        $this->render_field('filter_mobile_behavior', esc_html__('Comportement mobile du filtre', 'mon-articles'), 'select', $opts, [
+            'default'     => 'buttons',
+            'options'     => [
+                'buttons'  => __('Boutons (par défaut)', 'mon-articles'),
+                'select'   => __('Liste déroulante', 'mon-articles'),
+                'carousel' => __('Carrousel horizontal', 'mon-articles'),
+            ],
+            'description' => __('Choisissez la présentation appliquée sous 768px.', 'mon-articles'),
+        ]);
         $this->render_field(
             'filter_categories',
             esc_html__('Catégories à inclure dans le filtre', 'mon-articles'),
@@ -553,6 +562,9 @@ class My_Articles_Metaboxes {
         $sanitized['meta_key'] = $meta_key;
         $sanitized['show_category_filter'] = isset( $input['show_category_filter'] ) ? 1 : 0;
         $sanitized['filter_alignment'] = isset($input['filter_alignment']) && in_array($input['filter_alignment'], ['left', 'center', 'right']) ? $input['filter_alignment'] : 'right';
+        $allowed_mobile_behaviors = array( 'buttons', 'select', 'carousel' );
+        $mobile_behavior_input = isset( $input['filter_mobile_behavior'] ) ? (string) $input['filter_mobile_behavior'] : 'buttons';
+        $sanitized['filter_mobile_behavior'] = in_array( $mobile_behavior_input, $allowed_mobile_behaviors, true ) ? $mobile_behavior_input : 'buttons';
         
         $sanitized['filter_categories'] = array();
         if ( isset($input['filter_categories']) && is_array($input['filter_categories']) ) {


### PR DESCRIPTION
## Summary
- add a persisted `filter_mobile_behavior` option with select/carousel rendering on the front end
- expose the new behavior selector in the metabox and Gutenberg block controls
- update filter assets to handle dropdown changes and provide responsive select/carousel styling

## Testing
- php -l mon-affichage-article/includes/class-my-articles-shortcode.php
- php -l mon-affichage-article/includes/class-my-articles-metaboxes.php

------
https://chatgpt.com/codex/tasks/task_e_68df9645c070832eb79e81f7074ce7cc