### PR TITLE
Normalize slideshow option overrides and Swiper autoplay handling

### DIFF
--- a/mon-affichage-article/assets/js/swiper-init.js
+++ b/mon-affichage-article/assets/js/swiper-init.js
@@ -157,11 +157,35 @@
             wrapper.classList.add('swiper-is-loading');
         }
 
-        const autoplayConfig = settings.autoplay
+        var autoplaySettings = settings.autoplay;
+
+        if (!autoplaySettings || typeof autoplaySettings !== 'object' || Array.isArray(autoplaySettings)) {
+            var fallbackEnabled = !!settings.autoplay;
+            autoplaySettings = {
+                enabled: fallbackEnabled,
+                delay: typeof settings.autoplay_delay === 'number' ? settings.autoplay_delay : 5000,
+                pause_on_interaction:
+                    settings.pause_on_interaction === undefined
+                        ? true
+                        : !!settings.pause_on_interaction,
+                pause_on_mouse_enter:
+                    settings.pause_on_mouse_enter === undefined
+                        ? true
+                        : !!settings.pause_on_mouse_enter,
+            };
+        }
+
+        const autoplayConfig = autoplaySettings.enabled
             ? {
-                  delay: typeof settings.autoplay_delay === 'number' ? settings.autoplay_delay : 5000,
-                  disableOnInteraction: !!settings.pause_on_interaction,
-                  pauseOnMouseEnter: !!settings.pause_on_mouse_enter,
+                  delay: typeof autoplaySettings.delay === 'number' ? autoplaySettings.delay : 5000,
+                  disableOnInteraction:
+                      autoplaySettings.pause_on_interaction === undefined
+                          ? true
+                          : !!autoplaySettings.pause_on_interaction,
+                  pauseOnMouseEnter:
+                      autoplaySettings.pause_on_mouse_enter === undefined
+                          ? true
+                          : !!autoplaySettings.pause_on_mouse_enter,
               }
             : false;
 

--- a/mon-affichage-article/includes/class-my-articles-block.php
+++ b/mon-affichage-article/includes/class-my-articles-block.php
@@ -63,10 +63,47 @@ class My_Articles_Block {
         $overrides = array();
         $filtered  = array_intersect_key( $attributes, $defaults );
 
+        $boolean_override_keys = array(
+            'slideshow_loop',
+            'slideshow_autoplay',
+            'slideshow_pause_on_interaction',
+            'slideshow_pause_on_mouse_enter',
+            'slideshow_show_navigation',
+            'slideshow_show_pagination',
+        );
+
         foreach ( $filtered as $key => $raw_value ) {
             $default_value = $defaults[ $key ];
 
             if ( null === $raw_value ) {
+                continue;
+            }
+
+            if ( in_array( $key, $boolean_override_keys, true ) ) {
+                $overrides[ $key ] = ! empty( $raw_value ) ? 1 : 0;
+                continue;
+            }
+
+            if ( 'slideshow_delay' === $key ) {
+                $value = (int) $raw_value;
+
+                if ( $value < 0 ) {
+                    $value = 0;
+                }
+
+                if ( $value > 0 && $value < 1000 ) {
+                    $value = 1000;
+                }
+
+                if ( $value > 20000 ) {
+                    $value = 20000;
+                }
+
+                if ( 0 === $value ) {
+                    $value = (int) $default_value;
+                }
+
+                $overrides[ $key ] = $value;
                 continue;
             }
 

--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -624,6 +624,9 @@ class My_Articles_Metaboxes {
         if ( $delay > 0 && $delay < 1000 ) {
             $delay = 1000;
         }
+        if ( $delay > 20000 ) {
+            $delay = 20000;
+        }
         if ( 0 === $delay ) {
             $delay = 5000;
         }

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -820,6 +820,9 @@ class My_Articles_Shortcode {
         if ( $slideshow_delay > 0 && $slideshow_delay < 1000 ) {
             $slideshow_delay = 1000;
         }
+        if ( $slideshow_delay > 20000 ) {
+            $slideshow_delay = 20000;
+        }
         if ( 0 === $slideshow_delay ) {
             $slideshow_delay = (int) $defaults['slideshow_delay'];
         }
@@ -1668,6 +1671,13 @@ class My_Articles_Shortcode {
         wp_enqueue_style('swiper-css');
         wp_enqueue_script('swiper-js');
         wp_enqueue_script('my-articles-swiper-init', MY_ARTICLES_PLUGIN_URL . 'assets/js/swiper-init.js', ['swiper-js', 'my-articles-responsive-layout'], MY_ARTICLES_VERSION, true);
+        $autoplay_settings = array(
+            'enabled'              => ! empty( $options['slideshow_autoplay'] ),
+            'delay'                => (int) $options['slideshow_delay'],
+            'pause_on_interaction' => ! empty( $options['slideshow_pause_on_interaction'] ),
+            'pause_on_mouse_enter' => ! empty( $options['slideshow_pause_on_mouse_enter'] ),
+        );
+
         $localized_settings = array(
             'columns_mobile'                    => $options['columns_mobile'],
             'columns_tablet'                    => $options['columns_tablet'],
@@ -1675,10 +1685,7 @@ class My_Articles_Shortcode {
             'columns_ultrawide'                 => $options['columns_ultrawide'],
             'gap_size'                          => $options['gap_size'],
             'loop'                              => ! empty( $options['slideshow_loop'] ),
-            'autoplay'                          => ! empty( $options['slideshow_autoplay'] ),
-            'autoplay_delay'                    => (int) $options['slideshow_delay'],
-            'pause_on_interaction'              => ! empty( $options['slideshow_pause_on_interaction'] ),
-            'pause_on_mouse_enter'              => ! empty( $options['slideshow_pause_on_mouse_enter'] ),
+            'autoplay'                          => $autoplay_settings,
             'show_navigation'                   => ! empty( $options['slideshow_show_navigation'] ),
             'show_pagination'                   => ! empty( $options['slideshow_show_pagination'] ),
             'container_selector'                => '#my-articles-wrapper-' . $instance_id . ' .swiper-container',


### PR DESCRIPTION
## Summary
- clamp slideshow overrides from the block to keep slideshow toggles boolean and delays within supported bounds
- enforce the same slideshow delay limits when saving metabox data and normalizing shortcode options
- expose structured autoplay settings to the Swiper initializer so autoplay, loop and pause behaviour follow the chosen options

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df96472960832e81d6fb56a59ec160