### PR TITLE
feat: improve category filter mobile experience

### DIFF
--- a/mon-affichage-article/assets/css/styles.css
+++ b/mon-affichage-article/assets/css/styles.css
@@ -190,6 +190,117 @@
 
 .my-articles-filter-nav {
     margin-bottom: 20px;
+    position: relative;
+}
+
+.my-articles-screen-reader-text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.my-articles-filter-nav__scroller {
+    overflow: visible;
+}
+
+.my-articles-filter-nav__mobile {
+    display: none;
+    margin-top: 12px;
+}
+
+.my-articles-filter-nav__select {
+    width: 100%;
+    min-height: 44px;
+    border-radius: 6px;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    padding: 10px 12px;
+    font: inherit;
+    background: #ffffff;
+    color: inherit;
+}
+
+.my-articles-filter-nav.mobile-select-active .my-articles-filter-nav__scroller {
+    display: none;
+}
+
+.my-articles-filter-nav.mobile-select-active .my-articles-filter-nav__mobile {
+    display: block;
+}
+
+.my-articles-filter-nav.mobile-scroll-active .my-articles-filter-nav__scroller {
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    mask-image: linear-gradient(
+        to right,
+        transparent,
+        #000 40px,
+        #000 calc(100% - 40px),
+        transparent
+    );
+    -webkit-mask-image: linear-gradient(
+        to right,
+        transparent,
+        #000 40px,
+        #000 calc(100% - 40px),
+        transparent
+    );
+}
+
+.my-articles-filter-nav.mobile-scroll-active .my-articles-filter-nav__scroller::-webkit-scrollbar {
+    display: none;
+}
+
+.my-articles-filter-nav.mobile-scroll-active ul {
+    flex-wrap: nowrap;
+    gap: 6px;
+}
+
+.my-articles-filter-nav.mobile-scroll-active li {
+    flex: 0 0 auto;
+}
+
+.my-articles-filter-nav.mobile-scroll-active li a,
+.my-articles-filter-nav.mobile-scroll-active li button {
+    margin: 0;
+}
+
+.my-articles-filter-nav.mobile-scroll-active::before,
+.my-articles-filter-nav.mobile-scroll-active::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 36px;
+    pointer-events: none;
+    z-index: 2;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+}
+
+.my-articles-filter-nav.mobile-scroll-active::before {
+    left: 0;
+    background: linear-gradient(to right, var(--my-articles-filter-mask-color, rgba(255, 255, 255, 0.98)), rgba(255, 255, 255, 0));
+}
+
+.my-articles-filter-nav.mobile-scroll-active::after {
+    right: 0;
+    background: linear-gradient(to left, var(--my-articles-filter-mask-color, rgba(255, 255, 255, 0.98)), rgba(255, 255, 255, 0));
+}
+
+.my-articles-filter-nav.mobile-scroll-active.has-left-shadow::before {
+    opacity: 1;
+}
+
+.my-articles-filter-nav.mobile-scroll-active.has-right-shadow::after {
+    opacity: 1;
 }
 
 .my-articles-feedback {

--- a/mon-affichage-article/assets/js/__tests__/filter.test.js
+++ b/mon-affichage-article/assets/js/__tests__/filter.test.js
@@ -5,10 +5,21 @@ describe('filter endpoint interactions', () => {
     const setupDom = () => {
         document.body.innerHTML = `
             <div class="my-articles-wrapper" data-instance-id="42">
-                <ul class="my-articles-filter-nav">
-                    <li class="active"><button data-category="all" aria-pressed="true">Tous</button></li>
-                    <li><button data-category="news">Actualités</button></li>
-                </ul>
+                <nav class="my-articles-filter-nav filter-align-right" data-mobile-behavior="list" data-filter-count="2">
+                    <div class="my-articles-filter-nav__scroller" role="group" aria-label="Filtrer par catégorie">
+                        <ul>
+                            <li class="active"><button data-category="all" aria-pressed="true">Tout</button></li>
+                            <li><button data-category="news">Actualités</button></li>
+                        </ul>
+                    </div>
+                    <div class="my-articles-filter-nav__mobile" hidden data-behavior="select">
+                        <label class="my-articles-screen-reader-text" for="my-articles-filter-select-42">Filtrer par catégorie</label>
+                        <select id="my-articles-filter-select-42" class="my-articles-filter-nav__select" data-instance-id="42">
+                            <option value="all" selected>Tout</option>
+                            <option value="news">Actualités</option>
+                        </select>
+                    </div>
+                </nav>
                 <div class="my-articles-grid-content">
                     <article class="my-article-item">Initial</article>
                 </div>
@@ -21,10 +32,25 @@ describe('filter endpoint interactions', () => {
             restRoot: 'http://example.com/wp-json',
             restNonce: 'nonce-123',
             errorText: 'Une erreur est survenue.',
+            countSingle: '%s article affiché.',
+            countPlural: '%s articles affichés.',
+            countNone: 'Aucun article à afficher.',
+            activeFilter: 'Filtre actif : %s.',
         };
         window.myArticlesLoadMore = { loadMoreText: 'Charger plus' };
         window.myArticlesInitWrappers = jest.fn();
         window.myArticlesInitSwipers = jest.fn();
+        window.matchMedia = jest.fn().mockReturnValue({
+            matches: false,
+            addListener: jest.fn(),
+            addEventListener: jest.fn(),
+            removeListener: jest.fn(),
+            removeEventListener: jest.fn(),
+        });
+        window.requestAnimationFrame = function (callback) {
+            callback();
+            return 0;
+        };
     };
 
     beforeEach(() => {
@@ -46,6 +72,9 @@ describe('filter endpoint interactions', () => {
         delete window.myArticlesLoadMore;
         delete window.myArticlesInitWrappers;
         delete window.myArticlesInitSwipers;
+        delete window.myArticlesInitFilters;
+        delete window.matchMedia;
+        delete window.requestAnimationFrame;
         delete window.fetch;
         jest.resetModules();
     });

--- a/mon-affichage-article/assets/js/load-more.js
+++ b/mon-affichage-article/assets/js/load-more.js
@@ -317,6 +317,10 @@
                         window.myArticlesInitSwipers(wrapperElement);
                     }
 
+                    if (typeof window.myArticlesInitFilters === 'function') {
+                        window.myArticlesInitFilters(wrapperElement);
+                    }
+
                     var totalArticles = contentArea.find('.my-article-item').length;
                     var addedCount = totalArticles - previousArticleCount;
                     if (addedCount < 0) {

--- a/mon-affichage-article/blocks/mon-affichage-articles/block.json
+++ b/mon-affichage-article/blocks/mon-affichage-articles/block.json
@@ -51,6 +51,10 @@
             "type": "string",
             "default": "right"
         },
+        "mobile_filter_behavior": {
+            "type": "string",
+            "default": "list"
+        },
         "pagination_mode": {
             "type": "string",
             "default": "none"

--- a/mon-affichage-article/blocks/mon-affichage-articles/edit.js
+++ b/mon-affichage-article/blocks/mon-affichage-articles/edit.js
@@ -926,6 +926,20 @@
                         }),
                         disabled: !attributes.show_category_filter || isAttributeLocked('filter_alignment'),
                     }),
+                    el(SelectControl, {
+                        label: __('Comportement mobile du filtre', 'mon-articles'),
+                        value: attributes.mobile_filter_behavior || 'list',
+                        options: [
+                            { label: __('Liste empilée (par défaut)', 'mon-articles'), value: 'list' },
+                            { label: __('Sélecteur déroulant', 'mon-articles'), value: 'select' },
+                            { label: __('Défilement horizontal', 'mon-articles'), value: 'scroll' },
+                        ],
+                        onChange: withLockedGuard('mobile_filter_behavior', function (value) {
+                            setAttributes({ mobile_filter_behavior: value });
+                        }),
+                        help: __('Apparence du filtre sur les écrans étroits.', 'mon-articles'),
+                        disabled: !attributes.show_category_filter || isAttributeLocked('mobile_filter_behavior'),
+                    }),
                     el(ToggleControl, {
                         label: __('Afficher la catégorie', 'mon-articles'),
                         checked: !!attributes.show_category,

--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -201,6 +201,15 @@ class My_Articles_Metaboxes {
                 'right'  => __('Droite', 'mon-articles'),
             ],
         ]);
+        $this->render_field('mobile_filter_behavior', esc_html__('Comportement mobile du filtre', 'mon-articles'), 'select', $opts, [
+            'default'     => 'list',
+            'options'     => [
+                'list'   => esc_html__('Liste empilée (par défaut)', 'mon-articles'),
+                'select' => esc_html__('Sélecteur déroulant', 'mon-articles'),
+                'scroll' => esc_html__('Défilement horizontal', 'mon-articles'),
+            ],
+            'description' => esc_html__('Définit l’apparence du filtre sur les petits écrans.', 'mon-articles'),
+        ]);
         $this->render_field(
             'filter_categories',
             esc_html__('Catégories à inclure dans le filtre', 'mon-articles'),
@@ -553,7 +562,12 @@ class My_Articles_Metaboxes {
         $sanitized['meta_key'] = $meta_key;
         $sanitized['show_category_filter'] = isset( $input['show_category_filter'] ) ? 1 : 0;
         $sanitized['filter_alignment'] = isset($input['filter_alignment']) && in_array($input['filter_alignment'], ['left', 'center', 'right']) ? $input['filter_alignment'] : 'right';
-        
+        $mobile_behavior = isset( $input['mobile_filter_behavior'] ) ? sanitize_key( $input['mobile_filter_behavior'] ) : 'list';
+        if ( ! in_array( $mobile_behavior, array( 'list', 'select', 'scroll' ), true ) ) {
+            $mobile_behavior = 'list';
+        }
+        $sanitized['mobile_filter_behavior'] = $mobile_behavior;
+
         $sanitized['filter_categories'] = array();
         if ( isset($input['filter_categories']) && is_array($input['filter_categories']) ) {
             $sanitized['filter_categories'] = array_map('absint', $input['filter_categories']);


### PR DESCRIPTION
## Summary
- add a mobile filter behaviour option to blocks/metaboxes and render both select and scroller markup
- enhance filter JavaScript to manage select/scroll modes, sync feedback messaging, and refresh load-more instances
- introduce supporting styles and update automated tests for the new behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df964d05b8832e9199ca6785c3e694