### PR TITLE
Use PanelColorSettings for block color controls

### DIFF
--- a/mon-affichage-article/blocks/mon-affichage-articles/edit.js
+++ b/mon-affichage-article/blocks/mon-affichage-articles/edit.js
@@ -445,6 +445,13 @@
                 var key = control.key;
                 var value = getAttributeValue(key, control.defaultValue || '');
                 var isLocked = isAttributeLocked(key);
+                var changeHandler = withLockedGuard(key, function (nextValue) {
+                    var colorValue = typeof nextValue === 'string' ? nextValue : '';
+
+                    var update = {};
+                    update[key] = colorValue;
+                    setAttributes(update);
+                });
 
                 if (isLocked) {
                     lockedColorNotices.push(
@@ -472,35 +479,36 @@
                             )
                         )
                     );
-                    return;
                 }
-
-                var changeHandler = withLockedGuard(key, function (nextValue) {
-                    var colorValue = typeof nextValue === 'string' ? nextValue : '';
-
-                    var update = {};
-                    update[key] = colorValue;
-                    setAttributes(update);
-                });
 
                 colorPanelSettings.push({
                     label: control.label,
                     value: value,
-                    onChange: changeHandler,
-                    className: 'my-articles-color-control',
-                    clearable: true,
+                    onChange: isLocked
+                        ? function () {}
+                        : changeHandler,
+                    className: isLocked
+                        ? 'my-articles-color-control is-locked'
+                        : 'my-articles-color-control',
+                    clearable: !isLocked,
                     enableAlpha: !(control.disableAlpha || false),
                     key: key,
+                    help: isLocked ? __('Réglage verrouillé par le modèle.', 'mon-articles') : undefined,
                 });
 
                 gradientPanelSettings.push({
                     label: control.label,
                     colorValue: value,
-                    onColorChange: changeHandler,
-                    className: 'my-articles-color-control',
-                    clearable: true,
+                    onColorChange: isLocked
+                        ? function () {}
+                        : changeHandler,
+                    className: isLocked
+                        ? 'my-articles-color-control is-locked'
+                        : 'my-articles-color-control',
+                    clearable: !isLocked,
                     enableAlpha: !(control.disableAlpha || false),
                     key: key,
+                    help: isLocked ? __('Réglage verrouillé par le modèle.', 'mon-articles') : undefined,
                 });
             });
 
@@ -517,8 +525,7 @@
                         disableCustomColors: false,
                         disableCustomGradients: true,
                         __experimentalIsRenderedInSidebar: true,
-                    },
-                    lockedColorNotices.length > 0 ? el(Fragment, {}, lockedColorNotices) : null
+                    }
                 );
             } else if (colorSettingsComponent === __experimentalColorGradientSettings && __experimentalColorGradientSettings) {
                 colorSettingsPanel = el(
@@ -532,8 +539,7 @@
                         disableCustomColors: false,
                         disableCustomGradients: true,
                         __experimentalIsRenderedInSidebar: true,
-                    },
-                    lockedColorNotices.length > 0 ? el(Fragment, {}, lockedColorNotices) : null
+                    }
                 );
             } else {
                 colorSettingsPanel = el(


### PR DESCRIPTION
## Summary
- switch the block color controls to PanelColorSettings/`__experimentalColorGradientSettings` using the palette from `useSetting( 'color.palette' )`
- disable locked preset color settings while still surfacing a lock notice fallback
- keep color attribute updates wired directly through `setAttributes`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e034c9eae4832e87d6193156a09034