### PR TITLE
Clamp settings sanitization to UI ranges

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-settings.php
+++ b/mon-affichage-article/includes/class-my-articles-settings.php
@@ -96,23 +96,39 @@ class My_Articles_Settings {
         $sanitized_input['posts_per_page'] = isset( $input['posts_per_page'] )
             ? min( 50, max( 0, absint( $input['posts_per_page'] ) ) )
             : 10;
-        $sanitized_input['desktop_columns'] = isset( $input['desktop_columns'] ) ? max( 1, absint( $input['desktop_columns'] ) ) : 3;
-        $sanitized_input['mobile_columns'] = isset( $input['mobile_columns'] ) ? max( 1, absint( $input['mobile_columns'] ) ) : 1;
-        $sanitized_input['gap_size'] = isset( $input['gap_size'] ) ? absint( $input['gap_size'] ) : 25;
-        $sanitized_input['border_radius'] = isset( $input['border_radius'] ) ? absint( $input['border_radius'] ) : 12;
+        $sanitized_input['desktop_columns'] = isset( $input['desktop_columns'] )
+            ? min( 6, max( 1, absint( $input['desktop_columns'] ) ) )
+            : 3;
+        $sanitized_input['mobile_columns'] = isset( $input['mobile_columns'] )
+            ? min( 3, max( 1, absint( $input['mobile_columns'] ) ) )
+            : 1;
+        $sanitized_input['gap_size'] = isset( $input['gap_size'] )
+            ? min( 50, max( 0, absint( $input['gap_size'] ) ) )
+            : 25;
+        $sanitized_input['border_radius'] = isset( $input['border_radius'] )
+            ? min( 50, max( 0, absint( $input['border_radius'] ) ) )
+            : 12;
         $sanitized_input['title_color'] = my_articles_sanitize_color($input['title_color'] ?? '', '#333333');
-        $sanitized_input['title_font_size'] = isset( $input['title_font_size'] ) ? absint( $input['title_font_size'] ) : 16;
+        $sanitized_input['title_font_size'] = isset( $input['title_font_size'] )
+            ? min( 40, max( 10, absint( $input['title_font_size'] ) ) )
+            : 16;
         $sanitized_input['show_category'] = isset( $input['show_category'] ) ? 1 : 0;
         $sanitized_input['show_author'] = isset( $input['show_author'] ) ? 1 : 0;
         $sanitized_input['show_date'] = isset( $input['show_date'] ) ? 1 : 0;
-        $sanitized_input['meta_font_size'] = isset( $input['meta_font_size'] ) ? absint( $input['meta_font_size'] ) : 12;
+        $sanitized_input['meta_font_size'] = isset( $input['meta_font_size'] )
+            ? min( 20, max( 8, absint( $input['meta_font_size'] ) ) )
+            : 12;
         $sanitized_input['meta_color'] = my_articles_sanitize_color($input['meta_color'] ?? '', '#6b7280');
         $sanitized_input['meta_color_hover'] = my_articles_sanitize_color($input['meta_color_hover'] ?? '', '#000000');
         $sanitized_input['module_bg_color'] = my_articles_sanitize_color($input['module_bg_color'] ?? '', 'rgba(255,255,255,0)');
         $sanitized_input['vignette_bg_color'] = my_articles_sanitize_color($input['vignette_bg_color'] ?? '', '#ffffff');
         $sanitized_input['title_wrapper_bg_color'] = my_articles_sanitize_color($input['title_wrapper_bg_color'] ?? '', '#ffffff');
-        $sanitized_input['module_margin_left'] = isset( $input['module_margin_left'] ) ? absint( $input['module_margin_left'] ) : 0;
-        $sanitized_input['module_margin_right'] = isset( $input['module_margin_right'] ) ? absint( $input['module_margin_right'] ) : 0;
+        $sanitized_input['module_margin_left'] = isset( $input['module_margin_left'] )
+            ? min( 200, max( 0, absint( $input['module_margin_left'] ) ) )
+            : 0;
+        $sanitized_input['module_margin_right'] = isset( $input['module_margin_right'] )
+            ? min( 200, max( 0, absint( $input['module_margin_right'] ) ) )
+            : 0;
         $sanitized_input['pagination_color'] = my_articles_sanitize_color($input['pagination_color'] ?? '', '#333333');
 
         return $sanitized_input;

--- a/tests/MyArticlesSettingsSanitizeTest.php
+++ b/tests/MyArticlesSettingsSanitizeTest.php
@@ -82,6 +82,49 @@ final class MyArticlesSettingsSanitizeTest extends TestCase
         );
     }
 
+    /**
+     * @param non-empty-string $field
+     * @param int $input
+     * @param int $expected
+     *
+     * @dataProvider provide_clamped_integer_settings
+     */
+    public function test_sanitize_clamps_integer_settings(string $field, int $input, int $expected): void
+    {
+        $settings = My_Articles_Settings::get_instance();
+
+        $result = $settings->sanitize(array($field => $input));
+
+        self::assertSame(
+            $expected,
+            $result[$field] ?? null,
+            sprintf('The sanitize routine should clamp %s values to the UI boundaries.', $field)
+        );
+    }
+
+    /**
+     * @return iterable<string, array{0: non-empty-string, 1: int, 2: int}>
+     */
+    public function provide_clamped_integer_settings(): iterable
+    {
+        yield 'desktop columns minimum' => array('desktop_columns', -5, 1);
+        yield 'desktop columns maximum' => array('desktop_columns', 99, 6);
+        yield 'mobile columns minimum' => array('mobile_columns', 0, 1);
+        yield 'mobile columns maximum' => array('mobile_columns', 10, 3);
+        yield 'gap size minimum' => array('gap_size', -10, 0);
+        yield 'gap size maximum' => array('gap_size', 120, 50);
+        yield 'border radius minimum' => array('border_radius', -20, 0);
+        yield 'border radius maximum' => array('border_radius', 120, 50);
+        yield 'title font size minimum' => array('title_font_size', 1, 10);
+        yield 'title font size maximum' => array('title_font_size', 99, 40);
+        yield 'meta font size minimum' => array('meta_font_size', 1, 8);
+        yield 'meta font size maximum' => array('meta_font_size', 999, 20);
+        yield 'module margin left minimum' => array('module_margin_left', -50, 0);
+        yield 'module margin left maximum' => array('module_margin_left', 999, 200);
+        yield 'module margin right minimum' => array('module_margin_right', -50, 0);
+        yield 'module margin right maximum' => array('module_margin_right', 999, 200);
+    }
+
     public function test_normalize_instance_options_treats_zero_as_unlimited(): void
     {
         $options = My_Articles_Shortcode::normalize_instance_options(


### PR DESCRIPTION
## Summary
- clamp numeric settings during sanitization to match the UI-defined minimum and maximum values
- expand the sanitize test suite to cover clamping behaviour for each affected field

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e0e9ee5fec832eabfe384670add2aa