### PR TITLE
Clean up cache artifacts during uninstall

### DIFF
--- a/mon-affichage-article/uninstall.php
+++ b/mon-affichage-article/uninstall.php
@@ -4,6 +4,13 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 }
 
 delete_option( 'my_articles_options' );
+delete_option( 'my_articles_cache_namespace' );
+
+if ( function_exists( 'wp_cache_delete' ) ) {
+    my_articles_uninstall_purge_response_cache_group();
+}
+
+my_articles_uninstall_delete_response_transients();
 
 $query_args = array(
     'post_type'      => 'mon_affichage',
@@ -27,4 +34,90 @@ while ( true ) {
     }
 
     wp_reset_postdata();
+}
+
+/**
+ * Purge all entries stored in the my_articles_response object cache group.
+ */
+if ( ! function_exists( 'my_articles_uninstall_purge_response_cache_group' ) ) {
+function my_articles_uninstall_purge_response_cache_group() {
+    if ( ! isset( $GLOBALS['wp_object_cache'] ) ) {
+        return;
+    }
+
+    $cache_object = $GLOBALS['wp_object_cache'];
+
+    if ( is_object( $cache_object ) && method_exists( $cache_object, 'delete_group' ) ) {
+        $cache_object->delete_group( 'my_articles_response' );
+
+        return;
+    }
+
+    if ( ! is_object( $cache_object ) || ! property_exists( $cache_object, 'cache' ) ) {
+        return;
+    }
+
+    $groups = $cache_object->cache;
+
+    if ( ! is_array( $groups ) || empty( $groups['my_articles_response'] ) ) {
+        return;
+    }
+
+    $group_entries = $groups['my_articles_response'];
+
+    if ( ! is_array( $group_entries ) ) {
+        return;
+    }
+
+    foreach ( array_keys( $group_entries ) as $cache_key ) {
+        wp_cache_delete( $cache_key, 'my_articles_response' );
+    }
+}
+}
+
+/**
+ * Delete all transients created for the cached responses.
+ */
+if ( ! function_exists( 'my_articles_uninstall_delete_response_transients' ) ) {
+function my_articles_uninstall_delete_response_transients() {
+    global $wpdb;
+
+    if ( isset( $wpdb ) && is_object( $wpdb ) ) {
+        $like_fragment = method_exists( $wpdb, 'esc_like' ) ? $wpdb->esc_like( 'my_articles_' ) : addcslashes( 'my_articles_', '_%\\' );
+        $like_fragment .= '%';
+
+        if ( method_exists( $wpdb, 'prepare' ) ) {
+            $options_table = isset( $wpdb->options ) ? $wpdb->options : $wpdb->prefix . 'options';
+            $wpdb->query(
+                $wpdb->prepare(
+                    "DELETE FROM {$options_table} WHERE option_name LIKE %s OR option_name LIKE %s",
+                    '_transient_' . $like_fragment,
+                    '_transient_timeout_' . $like_fragment
+                )
+            );
+
+            if ( function_exists( 'is_multisite' ) && is_multisite() && isset( $wpdb->sitemeta ) ) {
+                $wpdb->query(
+                    $wpdb->prepare(
+                        "DELETE FROM {$wpdb->sitemeta} WHERE meta_key LIKE %s OR meta_key LIKE %s",
+                        '_site_transient_' . $like_fragment,
+                        '_site_transient_timeout_' . $like_fragment
+                    )
+                );
+            }
+        }
+
+        return;
+    }
+
+    if ( function_exists( 'delete_option' ) && function_exists( 'wp_load_alloptions' ) ) {
+        $all_options = wp_load_alloptions();
+
+        foreach ( array_keys( $all_options ) as $option_name ) {
+            if ( strpos( $option_name, '_transient_my_articles_' ) === 0 || strpos( $option_name, '_transient_timeout_my_articles_' ) === 0 ) {
+                delete_option( $option_name );
+            }
+        }
+    }
+}
 }

--- a/tests/UninstallTest.php
+++ b/tests/UninstallTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class UninstallTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        global $mon_articles_test_options_store, $mon_articles_test_options, $mon_articles_test_cache_store, $mon_articles_test_transients_store, $wp_object_cache, $wpdb;
+
+        $mon_articles_test_options_store   = array();
+        $mon_articles_test_options         = array();
+        $mon_articles_test_cache_store     = array();
+        $mon_articles_test_transients_store = array();
+        $wp_object_cache                   = null;
+        $wpdb                              = null;
+    }
+
+    public function test_uninstall_removes_options_and_cache_and_transients(): void
+    {
+        global $mon_articles_test_cache_store, $mon_articles_test_options_store, $wp_object_cache, $wpdb;
+
+        update_option('my_articles_options', array('color' => 'blue'));
+        update_option('my_articles_cache_namespace', 'namespace123');
+        update_option('_transient_my_articles_namespace123_aabb', array('cached' => true));
+        update_option('_transient_timeout_my_articles_namespace123_aabb', time() + 60);
+
+        wp_cache_set('my_articles_namespace123_foo', array('cached' => true), 'my_articles_response');
+        wp_cache_set('my_articles_namespace123_bar', array('cached' => true), 'my_articles_response');
+
+        $wp_object_cache = new class
+        {
+            /** @var array<string, array<string, mixed>> */
+            public array $cache = array();
+
+            public function delete_group(string $group): void
+            {
+                if (isset($this->cache[$group]) && is_array($this->cache[$group])) {
+                    foreach (array_keys($this->cache[$group]) as $key) {
+                        unset($this->cache[$group][$key]);
+                    }
+                }
+            }
+        };
+
+        $wp_object_cache->cache =& $mon_articles_test_cache_store;
+
+        $wpdb = new class
+        {
+            public string $options = 'wp_options';
+            public string $sitemeta = 'wp_sitemeta';
+
+            /** @var array<int, string> */
+            public array $queries = array();
+
+            public function esc_like(string $text): string
+            {
+                return addcslashes($text, "_%\\");
+            }
+
+            public function prepare(string $query, string ...$args): string
+            {
+                $quoted = array();
+
+                foreach ($args as $arg) {
+                    $quoted[] = "'" . addslashes($arg) . "'";
+                }
+
+                return vsprintf($query, $quoted);
+            }
+
+            public function query(string $query): bool
+            {
+                global $mon_articles_test_options_store;
+
+                $this->queries[] = $query;
+
+                if (preg_match_all("/LIKE '([^']+)'/", $query, $matches)) {
+                    foreach ($matches[1] as $pattern) {
+                        $regex = $this->convert_like_to_regex($pattern);
+
+                        foreach (array_keys($mon_articles_test_options_store) as $option_name) {
+                            if (preg_match($regex, $option_name)) {
+                                unset($mon_articles_test_options_store[$option_name]);
+                            }
+                        }
+                    }
+                }
+
+                return true;
+            }
+
+            private function convert_like_to_regex(string $pattern): string
+            {
+                $pattern = str_replace(array('\\%', '\\_'), array('%', '_'), $pattern);
+
+                $regex = '';
+                $length = strlen($pattern);
+
+                for ($i = 0; $i < $length; $i++) {
+                    $character = $pattern[$i];
+
+                    if ('%' === $character) {
+                        $regex .= '.*';
+                        continue;
+                    }
+
+                    if ('_' === $character) {
+                        $regex .= '.';
+                        continue;
+                    }
+
+                    $regex .= preg_quote($character, '/');
+                }
+
+                return '/^' . $regex . '$/';
+            }
+        };
+
+        require __DIR__ . '/../mon-affichage-article/uninstall.php';
+
+        $this->assertArrayNotHasKey('my_articles_options', $mon_articles_test_options_store);
+        $this->assertArrayNotHasKey('my_articles_cache_namespace', $mon_articles_test_options_store);
+        $this->assertArrayNotHasKey('_transient_my_articles_namespace123_aabb', $mon_articles_test_options_store);
+        $this->assertArrayNotHasKey('_transient_timeout_my_articles_namespace123_aabb', $mon_articles_test_options_store);
+        $this->assertArrayNotHasKey('my_articles_response', $mon_articles_test_cache_store);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -674,6 +674,29 @@ if (!function_exists('update_option')) {
     }
 }
 
+if (!function_exists('delete_option')) {
+    function delete_option(string $option)
+    {
+        global $mon_articles_test_options_store, $mon_articles_test_options;
+
+        if (!is_array($mon_articles_test_options_store)) {
+            $mon_articles_test_options_store = array();
+        }
+
+        $option = (string) $option;
+
+        $existed = array_key_exists($option, $mon_articles_test_options_store);
+
+        unset($mon_articles_test_options_store[$option]);
+
+        if (is_array($mon_articles_test_options) && array_key_exists($option, $mon_articles_test_options)) {
+            unset($mon_articles_test_options[$option]);
+        }
+
+        return $existed;
+    }
+}
+
 if (!class_exists('WP_Styles')) {
     class WP_Styles
     {


### PR DESCRIPTION
## Summary
- delete the cache namespace option during uninstall and flush the my_articles_response object cache group when possible
- remove cached response transients associated with the plugin during uninstall
- add a PHPUnit integration test and supporting bootstrap helper to cover uninstall cleanup

## Testing
- `vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68e12d6fd388832e870f66e4794170e3