### PR TITLE
Sync refreshed REST nonce across front-end scripts

### DIFF
--- a/mon-affichage-article/assets/js/__tests__/filter.test.js
+++ b/mon-affichage-article/assets/js/__tests__/filter.test.js
@@ -207,6 +207,7 @@ describe('filter endpoint interactions', () => {
         expect(postCallCount).toBe(2);
         expect(nonceCallCount).toBe(1);
         expect(window.myArticlesFilter.restNonce).toBe('nonce-refreshed');
+        expect(window.myArticlesLoadMore.restNonce).toBe('nonce-refreshed');
 
         expect(postCalls[0].headers['X-WP-Nonce']).toBe('nonce-123');
         expect(postCalls[1].headers['X-WP-Nonce']).toBe('nonce-refreshed');

--- a/mon-affichage-article/assets/js/__tests__/load-more.test.js
+++ b/mon-affichage-article/assets/js/__tests__/load-more.test.js
@@ -213,6 +213,7 @@ describe('load-more endpoint interactions', () => {
         expect(postCallCount).toBe(2);
         expect(nonceCallCount).toBe(1);
         expect(window.myArticlesLoadMore.restNonce).toBe('nonce-updated');
+        expect(window.myArticlesFilter.restNonce).toBe('nonce-updated');
 
         expect(postCalls[0].headers['X-WP-Nonce']).toBe('nonce-456');
         expect(postCalls[1].headers['X-WP-Nonce']).toBe('nonce-updated');

--- a/mon-affichage-article/assets/js/filter.js
+++ b/mon-affichage-article/assets/js/filter.js
@@ -33,6 +33,28 @@
         return '';
     }
 
+    function applyRefreshedNonce(settings, nonce) {
+        if (!nonce) {
+            return;
+        }
+
+        if (settings && typeof settings === 'object') {
+            settings.restNonce = nonce;
+        }
+
+        if (typeof window !== 'undefined') {
+            var filterSettingsGlobal = window.myArticlesFilter;
+            if (filterSettingsGlobal && typeof filterSettingsGlobal === 'object') {
+                filterSettingsGlobal.restNonce = nonce;
+            }
+
+            var loadMoreSettingsGlobal = window.myArticlesLoadMore;
+            if (loadMoreSettingsGlobal && typeof loadMoreSettingsGlobal === 'object') {
+                loadMoreSettingsGlobal.restNonce = nonce;
+            }
+        }
+    }
+
     function refreshRestNonce(settings) {
         if (pendingNonceDeferred) {
             return pendingNonceDeferred.promise();
@@ -57,10 +79,7 @@
                 var nonce = extractNonceFromResponse(response);
 
                 if (nonce) {
-                    if (settings) {
-                        settings.restNonce = nonce;
-                    }
-
+                    applyRefreshedNonce(settings, nonce);
                     deferred.resolve(nonce);
 
                     return;

--- a/mon-affichage-article/assets/js/load-more.js
+++ b/mon-affichage-article/assets/js/load-more.js
@@ -33,6 +33,28 @@
         return '';
     }
 
+    function applyRefreshedNonce(settings, nonce) {
+        if (!nonce) {
+            return;
+        }
+
+        if (settings && typeof settings === 'object') {
+            settings.restNonce = nonce;
+        }
+
+        if (typeof window !== 'undefined') {
+            var loadMoreSettingsGlobal = window.myArticlesLoadMore;
+            if (loadMoreSettingsGlobal && typeof loadMoreSettingsGlobal === 'object') {
+                loadMoreSettingsGlobal.restNonce = nonce;
+            }
+
+            var filterSettingsGlobal = window.myArticlesFilter;
+            if (filterSettingsGlobal && typeof filterSettingsGlobal === 'object') {
+                filterSettingsGlobal.restNonce = nonce;
+            }
+        }
+    }
+
     function refreshRestNonce(settings) {
         if (pendingNonceDeferred) {
             return pendingNonceDeferred.promise();
@@ -57,10 +79,7 @@
                 var nonce = extractNonceFromResponse(response);
 
                 if (nonce) {
-                    if (settings) {
-                        settings.restNonce = nonce;
-                    }
-
+                    applyRefreshedNonce(settings, nonce);
                     deferred.resolve(nonce);
 
                     return;

--- a/tests/Rest/ControllerRoutesTest.php
+++ b/tests/Rest/ControllerRoutesTest.php
@@ -292,6 +292,25 @@ final class ControllerRoutesTest extends TestCase
         $this->assertSame('nonce-wp_rest', $payload['data']['nonce']);
     }
 
+    public function test_nonce_route_accepts_internal_referer_when_origin_missing(): void
+    {
+        $controller = $this->createControllerWithHandlers(array());
+
+        $request = new WP_REST_Request('GET', '/my-articles/v1/nonce');
+        $request->set_header('referer', '/subdir/page?foo=bar');
+
+        $response = $controller->get_rest_nonce($request);
+
+        $this->assertInstanceOf(WP_REST_Response::class, $response);
+
+        $payload = $response->get_data();
+        $this->assertIsArray($payload);
+        $this->assertArrayHasKey('success', $payload);
+        $this->assertTrue($payload['success']);
+        $this->assertArrayHasKey('data', $payload);
+        $this->assertSame('nonce-wp_rest', $payload['data']['nonce']);
+    }
+
     public function test_nonce_route_rejects_external_origin(): void
     {
         $controller = $this->createControllerWithHandlers(array());


### PR DESCRIPTION
## Summary
- propagate refreshed REST nonce across both filter and load-more script contexts after a retry succeeds
- extend Jest retry scenarios to confirm the shared nonce update and cover REST nonce refresh with referer-only requests

## Testing
- composer test
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e148ea4c00832ebb870632b1987d90