### PR TITLE
Add debounced search updates for article block

### DIFF
--- a/mon-affichage-article/blocks/mon-affichage-articles/edit.asset.php
+++ b/mon-affichage-article/blocks/mon-affichage-articles/edit.asset.php
@@ -8,6 +8,7 @@ return array(
         'wp-data',
         'wp-i18n',
         'wp-server-side-render',
+        'wp-compose',
     ),
     'version'      => defined( 'MY_ARTICLES_VERSION' ) ? MY_ARTICLES_VERSION : '1.0.0',
 );


### PR DESCRIPTION
## Summary
- add a debounced handler for module search filtering to limit network requests
- ensure pending debounced updates are cancelled on unmount and expose a fallback when compose utilities are unavailable
- declare the wp-compose dependency for the block script bundle

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1a3ed6768832eb790bf93d0a01a16