### PR TITLE
Add module padding top and bottom controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Utiliser le shortcode :
 - **show_excerpt** et **excerpt_length** (affichage et longueur de l'extrait)
 - **columns_mobile**, **columns_tablet**, **columns_desktop**, **columns_ultrawide** (colonnes disponibles selon la largeur d'écran)
 - **gap_size** (espacement horizontal en mode grille/diaporama) et **list_item_gap** (espacement vertical en mode liste)
-- **module_padding_left**, **module_padding_right** (marges internes du module)
+- **module_padding_top/right/bottom/left** (marges internes du module)
 - **list_content_padding_top/right/bottom/left** (marges internes des éléments en mode liste)
 - **border_radius** (arrondi des cartes), **title_font_size**, **meta_font_size**, **excerpt_font_size** (typographie)
 - Couleurs principales : **module_bg_color**, **vignette_bg_color**, **title_wrapper_bg_color**, **title_color**, **meta_color**, **meta_color_hover**, **excerpt_color**, **pagination_color**, **shadow_color**, **shadow_color_hover**, **pinned_border_color**, **pinned_badge_bg_color**, **pinned_badge_text_color**

--- a/mon-affichage-article/assets/css/styles.css
+++ b/mon-affichage-article/assets/css/styles.css
@@ -6,6 +6,14 @@
     --my-articles-skeleton-base: rgba(31, 41, 51, 0.08);
     --my-articles-skeleton-highlight: rgba(31, 41, 51, 0.16);
     --my-articles-skeleton-radius: var(--my-articles-border-radius, 12px);
+    --my-articles-module-padding-top: 0px;
+    --my-articles-module-padding-right: 0px;
+    --my-articles-module-padding-bottom: 0px;
+    --my-articles-module-padding-left: 0px;
+    padding-top: var(--my-articles-module-padding-top);
+    padding-right: var(--my-articles-module-padding-right);
+    padding-bottom: var(--my-articles-module-padding-bottom);
+    padding-left: var(--my-articles-module-padding-left);
 }
 
 .my-articles-wrapper--loading,

--- a/mon-affichage-article/blocks/mon-affichage-articles/block.json
+++ b/mon-affichage-article/blocks/mon-affichage-articles/block.json
@@ -110,6 +110,16 @@
             "default": 0,
             "description": "Marge interne droite du module (px)."
         },
+        "module_padding_top": {
+            "type": "integer",
+            "default": 0,
+            "description": "Marge interne supérieure du module (px)."
+        },
+        "module_padding_bottom": {
+            "type": "integer",
+            "default": 0,
+            "description": "Marge interne inférieure du module (px)."
+        },
         "list_content_padding_top": {
             "type": "integer",
             "default": 0,

--- a/mon-affichage-article/blocks/mon-affichage-articles/edit.js
+++ b/mon-affichage-article/blocks/mon-affichage-articles/edit.js
@@ -861,6 +861,34 @@
                     PanelBody,
                     { title: __('Espacements & typographie', 'mon-articles'), initialOpen: false },
                     el(RangeControl, {
+                        label: __('Marge intérieure haute (px)', 'mon-articles'),
+                        value: ensureNumber(attributes.module_padding_top, 0),
+                        min: 0,
+                        max: 200,
+                        allowReset: true,
+                        onChange: withLockedGuard('module_padding_top', function (value) {
+                            if (typeof value !== 'number') {
+                                value = 0;
+                            }
+                            setAttributes({ module_padding_top: value });
+                        }),
+                        disabled: isAttributeLocked('module_padding_top'),
+                    }),
+                    el(RangeControl, {
+                        label: __('Marge intérieure basse (px)', 'mon-articles'),
+                        value: ensureNumber(attributes.module_padding_bottom, 0),
+                        min: 0,
+                        max: 200,
+                        allowReset: true,
+                        onChange: withLockedGuard('module_padding_bottom', function (value) {
+                            if (typeof value !== 'number') {
+                                value = 0;
+                            }
+                            setAttributes({ module_padding_bottom: value });
+                        }),
+                        disabled: isAttributeLocked('module_padding_bottom'),
+                    }),
+                    el(RangeControl, {
                         label: __('Marge intérieure gauche (px)', 'mon-articles'),
                         value: ensureNumber(attributes.module_padding_left, 0),
                         min: 0,

--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -381,6 +381,8 @@ class My_Articles_Metaboxes {
             ]
         );
 
+        $this->render_field('module_padding_top', esc_html__('Marge intérieure haute (px)', 'mon-articles'), 'number', $opts, ['default' => 0, 'min' => 0, 'max' => 200]);
+        $this->render_field('module_padding_bottom', esc_html__('Marge intérieure basse (px)', 'mon-articles'), 'number', $opts, ['default' => 0, 'min' => 0, 'max' => 200]);
         $this->render_field('module_padding_left', esc_html__('Marge intérieure gauche (px)', 'mon-articles'), 'number', $opts, ['default' => 0, 'min' => 0, 'max' => 200]);
         $this->render_field('module_padding_right', esc_html__('Marge intérieure droite (px)', 'mon-articles'), 'number', $opts, ['default' => 0, 'min' => 0, 'max' => 200]);
         $this->render_field('gap_size', esc_html__('Espacement des vignettes (Grille)', 'mon-articles'), 'number', $opts, ['default' => 25, 'min' => 0, 'max' => 50]);
@@ -632,6 +634,12 @@ class My_Articles_Metaboxes {
         $sanitized['columns_ultrawide'] = isset( $input['columns_ultrawide'] )
             ? min( 8, max( 1, absint( $input['columns_ultrawide'] ) ) )
             : 4;
+        $sanitized['module_padding_top'] = isset( $input['module_padding_top'] )
+            ? min( 200, max( 0, absint( $input['module_padding_top'] ) ) )
+            : 0;
+        $sanitized['module_padding_bottom'] = isset( $input['module_padding_bottom'] )
+            ? min( 200, max( 0, absint( $input['module_padding_bottom'] ) ) )
+            : 0;
         $sanitized['module_padding_left'] = isset( $input['module_padding_left'] )
             ? min( 200, max( 0, absint( $input['module_padding_left'] ) ) )
             : 0;

--- a/mon-affichage-article/includes/class-my-articles-settings.php
+++ b/mon-affichage-article/includes/class-my-articles-settings.php
@@ -69,6 +69,8 @@ class My_Articles_Settings {
         add_settings_field( 'display_mode', __( 'Mode d\'affichage', 'mon-articles' ), array( $this, 'display_mode_callback' ), 'my-articles-admin', 'setting_section_layout' );
         add_settings_field( 'desktop_columns', __( 'Articles visibles (Desktop)', 'mon-articles' ), array( $this, 'desktop_columns_callback' ), 'my-articles-admin', 'setting_section_layout' );
         add_settings_field( 'mobile_columns', __( 'Articles visibles (Mobile)', 'mon-articles' ), array( $this, 'mobile_columns_callback' ), 'my-articles-admin', 'setting_section_layout' );
+        add_settings_field( 'module_padding_top', __( 'Marge intérieure haute (px)', 'mon-articles' ), array( $this, 'module_padding_top_callback' ), 'my-articles-admin', 'setting_section_layout' );
+        add_settings_field( 'module_padding_bottom', __( 'Marge intérieure basse (px)', 'mon-articles' ), array( $this, 'module_padding_bottom_callback' ), 'my-articles-admin', 'setting_section_layout' );
         add_settings_field( 'module_margin_left', __( 'Marge à gauche (px)', 'mon-articles' ), array( $this, 'module_margin_left_callback' ), 'my-articles-admin', 'setting_section_layout' );
         add_settings_field( 'module_margin_right', __( 'Marge à droite (px)', 'mon-articles' ), array( $this, 'module_margin_right_callback' ), 'my-articles-admin', 'setting_section_layout' );
         
@@ -123,6 +125,12 @@ class My_Articles_Settings {
         $sanitized_input['module_bg_color'] = my_articles_sanitize_color($input['module_bg_color'] ?? '', 'rgba(255,255,255,0)');
         $sanitized_input['vignette_bg_color'] = my_articles_sanitize_color($input['vignette_bg_color'] ?? '', '#ffffff');
         $sanitized_input['title_wrapper_bg_color'] = my_articles_sanitize_color($input['title_wrapper_bg_color'] ?? '', '#ffffff');
+        $sanitized_input['module_padding_top'] = isset( $input['module_padding_top'] )
+            ? min( 200, max( 0, intval( $input['module_padding_top'] ) ) )
+            : 0;
+        $sanitized_input['module_padding_bottom'] = isset( $input['module_padding_bottom'] )
+            ? min( 200, max( 0, intval( $input['module_padding_bottom'] ) ) )
+            : 0;
         $sanitized_input['module_margin_left'] = isset( $input['module_margin_left'] )
             ? min( 200, max( 0, intval( $input['module_margin_left'] ) ) )
             : 0;
@@ -185,6 +193,8 @@ class My_Articles_Settings {
     public function module_bg_color_callback() { $this->render_color_input('module_bg_color', 'rgba(255,255,255,0)', true); }
     public function vignette_bg_color_callback() { $this->render_color_input('vignette_bg_color', '#ffffff'); }
     public function title_wrapper_bg_color_callback() { $this->render_color_input('title_wrapper_bg_color', '#ffffff'); }
+    public function module_padding_top_callback() { $this->render_number_input('module_padding_top', 0, 0, 200); }
+    public function module_padding_bottom_callback() { $this->render_number_input('module_padding_bottom', 0, 0, 200); }
     public function module_margin_left_callback() { $this->render_number_input('module_margin_left', 0, 0, 200); }
     public function module_margin_right_callback() { $this->render_number_input('module_margin_right', 0, 0, 200); }
 

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -40,6 +40,8 @@ class My_Articles_Shortcode {
                     'pagination_color'            => '#2563eb',
                     'shadow_color'                => 'rgba(15,23,42,0.08)',
                     'shadow_color_hover'          => 'rgba(37,99,235,0.16)',
+                    'module_padding_top'          => 24,
+                    'module_padding_bottom'       => 24,
                     'module_padding_left'         => 24,
                     'module_padding_right'        => 24,
                     'gap_size'                    => 24,
@@ -69,6 +71,8 @@ class My_Articles_Shortcode {
                     'pagination_color'            => '#93c5fd',
                     'shadow_color'                => 'rgba(0,0,0,0.4)',
                     'shadow_color_hover'          => 'rgba(30,64,175,0.6)',
+                    'module_padding_top'          => 32,
+                    'module_padding_bottom'       => 32,
                     'module_padding_left'         => 32,
                     'module_padding_right'        => 32,
                     'gap_size'                    => 20,
@@ -99,6 +103,8 @@ class My_Articles_Shortcode {
                     'pagination_color'            => '#1d4ed8',
                     'shadow_color'                => 'rgba(0,0,0,0.04)',
                     'shadow_color_hover'          => 'rgba(0,0,0,0.08)',
+                    'module_padding_top'          => 16,
+                    'module_padding_bottom'       => 16,
                     'module_padding_left'         => 16,
                     'module_padding_right'        => 16,
                     'gap_size'                    => 20,
@@ -562,6 +568,7 @@ class My_Articles_Shortcode {
             'enable_debug_mode' => 0,
             'display_mode' => 'grid',
             'columns_mobile' => 1, 'columns_tablet' => 2, 'columns_desktop' => 3, 'columns_ultrawide' => 4,
+            'module_padding_top' => 0, 'module_padding_bottom' => 0,
             'module_padding_left' => 0, 'module_padding_right' => 0,
             'gap_size' => 25, 'list_item_gap' => 25,
             'list_content_padding_top' => 0, 'list_content_padding_right' => 0,
@@ -595,8 +602,10 @@ class My_Articles_Shortcode {
         $aliases = array(
             'desktop_columns'     => 'columns_desktop',
             'mobile_columns'      => 'columns_mobile',
-            'module_margin_left'  => 'module_padding_left',
-            'module_margin_right' => 'module_padding_right',
+            'module_margin_top'    => 'module_padding_top',
+            'module_margin_bottom' => 'module_padding_bottom',
+            'module_margin_left'   => 'module_padding_left',
+            'module_margin_right'  => 'module_padding_right',
         );
 
         foreach ( $aliases as $stored_key => $option_key ) {
@@ -1892,8 +1901,10 @@ class My_Articles_Shortcode {
         $title_font_size     = max( 1, absint( $options['title_font_size'] ?? $defaults['title_font_size'] ) );
         $meta_font_size      = max( 1, absint( $options['meta_font_size'] ?? $defaults['meta_font_size'] ) );
         $excerpt_font_size   = max( 1, absint( $options['excerpt_font_size'] ?? $defaults['excerpt_font_size'] ) );
-        $module_padding_left  = max( 0, absint( $options['module_padding_left'] ?? $defaults['module_padding_left'] ) );
-        $module_padding_right = max( 0, absint( $options['module_padding_right'] ?? $defaults['module_padding_right'] ) );
+        $module_padding_top    = max( 0, absint( $options['module_padding_top'] ?? $defaults['module_padding_top'] ) );
+        $module_padding_bottom = max( 0, absint( $options['module_padding_bottom'] ?? $defaults['module_padding_bottom'] ) );
+        $module_padding_left   = max( 0, absint( $options['module_padding_left'] ?? $defaults['module_padding_left'] ) );
+        $module_padding_right  = max( 0, absint( $options['module_padding_right'] ?? $defaults['module_padding_right'] ) );
 
         $title_color          = my_articles_sanitize_color( $options['title_color'] ?? '', $defaults['title_color'] );
         $meta_color           = my_articles_sanitize_color( $options['meta_color'] ?? '', $defaults['meta_color'] );
@@ -1923,6 +1934,10 @@ class My_Articles_Shortcode {
             --my-articles-list-padding-bottom: {$padding_bottom}px;
             --my-articles-list-padding-left: {$padding_left}px;
             --my-articles-border-radius: {$border_radius}px;
+            --my-articles-module-padding-top: {$module_padding_top}px;
+            --my-articles-module-padding-right: {$module_padding_right}px;
+            --my-articles-module-padding-bottom: {$module_padding_bottom}px;
+            --my-articles-module-padding-left: {$module_padding_left}px;
             --my-articles-title-color: {$title_color};
             --my-articles-title-font-size: {$title_font_size}px;
             --my-articles-meta-color: {$meta_color};
@@ -1937,8 +1952,10 @@ class My_Articles_Shortcode {
             --my-articles-badge-bg-color: {$pinned_badge_bg};
             --my-articles-badge-text-color: {$pinned_badge_text};
             background-color: {$module_bg_color};
-            padding-left: {$module_padding_left}px;
+            padding-top: {$module_padding_top}px;
             padding-right: {$module_padding_right}px;
+            padding-bottom: {$module_padding_bottom}px;
+            padding-left: {$module_padding_left}px;
         }
         #my-articles-wrapper-{$id} .my-article-item { background-color: {$vignette_bg_color}; }
         #my-articles-wrapper-{$id}.my-articles-grid .my-article-item .article-title-wrapper,

--- a/tests/MyArticlesMetaboxesTest.php
+++ b/tests/MyArticlesMetaboxesTest.php
@@ -257,6 +257,8 @@ final class MyArticlesMetaboxesTest extends TestCase
                 'columns_tablet'              => 0,
                 'columns_desktop'             => 99,
                 'columns_ultrawide'           => 999,
+                'module_padding_top'          => 250,
+                'module_padding_bottom'       => -20,
                 'module_padding_left'         => 250,
                 'module_padding_right'        => 1,
                 'gap_size'                    => 200,
@@ -282,6 +284,8 @@ final class MyArticlesMetaboxesTest extends TestCase
         self::assertSame(1, $saved['columns_tablet']);
         self::assertSame(6, $saved['columns_desktop']);
         self::assertSame(8, $saved['columns_ultrawide']);
+        self::assertSame(200, $saved['module_padding_top']);
+        self::assertSame(20, $saved['module_padding_bottom']);
         self::assertSame(200, $saved['module_padding_left']);
         self::assertSame(1, $saved['module_padding_right']);
         self::assertSame(50, $saved['gap_size']);

--- a/tests/MyArticlesSettingsSanitizeTest.php
+++ b/tests/MyArticlesSettingsSanitizeTest.php
@@ -120,6 +120,10 @@ final class MyArticlesSettingsSanitizeTest extends TestCase
         yield 'title font size maximum' => array('title_font_size', 99, 40);
         yield 'meta font size minimum' => array('meta_font_size', 1, 8);
         yield 'meta font size maximum' => array('meta_font_size', 999, 20);
+        yield 'module padding top minimum' => array('module_padding_top', -50, 0);
+        yield 'module padding top maximum' => array('module_padding_top', 999, 200);
+        yield 'module padding bottom minimum' => array('module_padding_bottom', -50, 0);
+        yield 'module padding bottom maximum' => array('module_padding_bottom', 999, 200);
         yield 'module margin left minimum' => array('module_margin_left', -50, 0);
         yield 'module margin left maximum' => array('module_margin_left', 999, 200);
         yield 'module margin right minimum' => array('module_margin_right', -50, 0);


### PR DESCRIPTION
## Summary
- add top/bottom module padding attributes to the block, metaboxes, shortcode defaults, and global settings
- surface the new controls in the editor UI, admin metabox, and plugin settings while updating design presets and inline styling
- align CSS variables, documentation, and automated tests with the expanded padding options

## Testing
- composer install
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e1a3ea0530832e91117ef0b6f482e7