### PR TITLE
Add selectable thumbnail aspect ratio option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Utiliser le shortcode :
 - **design_preset** (`custom`, `lcv-classique`, `dark-spotlight`, `editorial-focus`)
   - Contrôle l’application d’un préréglage complet (couleurs, ombres, espacements). Le modèle « Focus éditorial » est verrouillé et fige les réglages associés.
 - **display_mode** (`grid`, `list`, `slideshow`)
+- **thumbnail_aspect_ratio** (`1`, `4/3`, `3/2`, `16/9`) – contraint les images et squelettes à un ratio précis.
 - **posts_per_page** (nombre d'articles, `0` pour illimité)
 - **pagination_mode** (`none`, `load_more`, `numbered`)
 - **aria_label** (libellé ARIA du module, basé par défaut sur le titre de l’instance sélectionnée)

--- a/mon-affichage-article/assets/css/styles.css
+++ b/mon-affichage-article/assets/css/styles.css
@@ -6,6 +6,7 @@
     --my-articles-skeleton-base: rgba(31, 41, 51, 0.08);
     --my-articles-skeleton-highlight: rgba(31, 41, 51, 0.16);
     --my-articles-skeleton-radius: var(--my-articles-border-radius, 12px);
+    --my-articles-thumbnail-aspect-ratio: 16/9;
 }
 
 .my-articles-wrapper--loading,
@@ -104,7 +105,7 @@
 }
 
 .my-articles-skeleton__thumbnail {
-    aspect-ratio: 16 / 9;
+    aspect-ratio: var(--my-articles-thumbnail-aspect-ratio, 16/9);
     width: 100%;
 }
 
@@ -467,7 +468,7 @@
     width: 100%;
     height: auto;
     display: block;
-    aspect-ratio: 16 / 9;
+    aspect-ratio: var(--my-articles-thumbnail-aspect-ratio, 16/9);
     object-fit: cover;
 }
 

--- a/mon-affichage-article/blocks/mon-affichage-articles/block.json
+++ b/mon-affichage-article/blocks/mon-affichage-articles/block.json
@@ -23,6 +23,10 @@
             "type": "string",
             "default": "grid"
         },
+        "thumbnail_aspect_ratio": {
+            "type": "string",
+            "default": "16/9"
+        },
         "posts_per_page": {
             "type": "integer",
             "default": 10

--- a/mon-affichage-article/blocks/mon-affichage-articles/edit.js
+++ b/mon-affichage-article/blocks/mon-affichage-articles/edit.js
@@ -44,6 +44,28 @@
 
     var designPresets = window.myArticlesDesignPresets || {};
     var DESIGN_PRESET_FALLBACK = 'custom';
+    var DEFAULT_THUMBNAIL_ASPECT_RATIO = '16/9';
+    var THUMBNAIL_ASPECT_RATIO_OPTIONS = [
+        { value: '1', label: __('Carré (1:1)', 'mon-articles') },
+        { value: '4/3', label: __('Classique (4:3)', 'mon-articles') },
+        { value: '3/2', label: __('Photo (3:2)', 'mon-articles') },
+        { value: '16/9', label: __('Panoramique (16:9)', 'mon-articles') },
+    ];
+    var THUMBNAIL_ASPECT_RATIO_VALUES = THUMBNAIL_ASPECT_RATIO_OPTIONS.map(function (option) {
+        return option.value;
+    });
+
+    function sanitizeThumbnailAspectRatio(value) {
+        if (typeof value !== 'string') {
+            value = '';
+        }
+
+        if (THUMBNAIL_ASPECT_RATIO_VALUES.indexOf(value) === -1) {
+            return DEFAULT_THUMBNAIL_ASPECT_RATIO;
+        }
+
+        return value;
+    }
 
     var SSRContentWrapper = function (props) {
         var onChange = props.onChange;
@@ -138,6 +160,7 @@
             var previewRenderCount = _useState5[0];
             var setPreviewRenderCount = _useState5[1];
             var ssrAttributesKey = JSON.stringify(attributes || {});
+            var thumbnailAspectRatio = sanitizeThumbnailAspectRatio(attributes.thumbnail_aspect_ratio || DEFAULT_THUMBNAIL_ASPECT_RATIO);
 
             var isDesignPresetLocked = false;
 
@@ -170,6 +193,17 @@
                         : false,
                 };
             }, [attributes.instanceId]);
+
+            useEffect(
+                function () {
+                    var sanitized = sanitizeThumbnailAspectRatio(attributes.thumbnail_aspect_ratio || DEFAULT_THUMBNAIL_ASPECT_RATIO);
+
+                    if (sanitized !== attributes.thumbnail_aspect_ratio) {
+                        setAttributes({ thumbnail_aspect_ratio: sanitized });
+                    }
+                },
+                [attributes.thumbnail_aspect_ratio]
+            );
 
             var canEditPosts = useSelect(function (select) {
                 var core = select('core');
@@ -695,6 +729,16 @@
                             setAttributes({ pagination_mode: value });
                         }),
                         disabled: isAttributeLocked('pagination_mode'),
+                    }),
+                    el(SelectControl, {
+                        label: __('Ratio des vignettes', 'mon-articles'),
+                        value: thumbnailAspectRatio,
+                        options: THUMBNAIL_ASPECT_RATIO_OPTIONS,
+                        onChange: withLockedGuard('thumbnail_aspect_ratio', function (value) {
+                            setAttributes({ thumbnail_aspect_ratio: sanitizeThumbnailAspectRatio(value) });
+                        }),
+                        help: __('Seuls les ratios 1, 4/3, 3/2 et 16/9 sont acceptés.', 'mon-articles'),
+                        disabled: isAttributeLocked('thumbnail_aspect_ratio'),
                     }),
                     isSlideshowMode
                         ? el(Fragment, {},

--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -386,6 +386,17 @@ class My_Articles_Metaboxes {
         $this->render_field('gap_size', esc_html__('Espacement des vignettes (Grille)', 'mon-articles'), 'number', $opts, ['default' => 25, 'min' => 0, 'max' => 50]);
         $this->render_field('list_item_gap', esc_html__('Espacement vertical (Liste)', 'mon-articles'), 'number', $opts, ['default' => 25, 'min' => 0, 'max' => 50]);
         $this->render_field('border_radius', esc_html__('Arrondi des bordures (px)', 'mon-articles'), 'number', $opts, ['default' => 12, 'min' => 0, 'max' => 50]);
+        $this->render_field(
+            'thumbnail_aspect_ratio',
+            esc_html__( 'Ratio des vignettes', 'mon-articles' ),
+            'select',
+            $opts,
+            [
+                'default'     => My_Articles_Shortcode::get_default_thumbnail_aspect_ratio(),
+                'options'     => My_Articles_Shortcode::get_thumbnail_aspect_ratio_choices(),
+                'description' => esc_html__( 'Les ratios autorisés sont 1, 4/3, 3/2 et 16/9.', 'mon-articles' ),
+            ]
+        );
         $this->render_field('enable_lazy_load', esc_html__('Activer le chargement paresseux des images (Lazy Load)', 'mon-articles'), 'checkbox', $opts, [
             'default'     => 1,
             'description' => __('Améliore considérablement la vitesse de chargement de la page.', 'mon-articles'),
@@ -620,6 +631,15 @@ class My_Articles_Metaboxes {
         $sanitized['design_preset'] = $design_preset;
 
         $sanitized['display_mode'] = in_array($input['display_mode'] ?? 'grid', ['grid', 'slideshow', 'list']) ? $input['display_mode'] : 'grid';
+        $allowed_thumbnail_ratios   = My_Articles_Shortcode::get_allowed_thumbnail_aspect_ratios();
+        $default_thumbnail_ratio    = My_Articles_Shortcode::get_default_thumbnail_aspect_ratio();
+        $requested_thumbnail_ratio  = isset( $input['thumbnail_aspect_ratio'] ) ? (string) $input['thumbnail_aspect_ratio'] : $default_thumbnail_ratio;
+
+        if ( ! in_array( $requested_thumbnail_ratio, $allowed_thumbnail_ratios, true ) ) {
+            $requested_thumbnail_ratio = $default_thumbnail_ratio;
+        }
+
+        $sanitized['thumbnail_aspect_ratio'] = $requested_thumbnail_ratio;
         $sanitized['columns_mobile'] = isset( $input['columns_mobile'] )
             ? min( 3, max( 1, absint( $input['columns_mobile'] ) ) )
             : 1;

--- a/mon-affichage-article/includes/class-my-articles-settings.php
+++ b/mon-affichage-article/includes/class-my-articles-settings.php
@@ -102,6 +102,15 @@ class My_Articles_Settings {
         $sanitized_input['mobile_columns'] = isset( $input['mobile_columns'] )
             ? min( 3, max( 1, intval( $input['mobile_columns'] ) ) )
             : 1;
+        $allowed_thumbnail_ratios = My_Articles_Shortcode::get_allowed_thumbnail_aspect_ratios();
+        $default_thumbnail_ratio  = My_Articles_Shortcode::get_default_thumbnail_aspect_ratio();
+        $requested_thumbnail_ratio = isset( $input['thumbnail_aspect_ratio'] ) ? (string) $input['thumbnail_aspect_ratio'] : $default_thumbnail_ratio;
+
+        if ( ! in_array( $requested_thumbnail_ratio, $allowed_thumbnail_ratios, true ) ) {
+            $requested_thumbnail_ratio = $default_thumbnail_ratio;
+        }
+
+        $sanitized_input['thumbnail_aspect_ratio'] = $requested_thumbnail_ratio;
         $sanitized_input['gap_size'] = isset( $input['gap_size'] )
             ? min( 50, max( 0, intval( $input['gap_size'] ) ) )
             : 25;

--- a/tests/MyArticlesSettingsSanitizeTest.php
+++ b/tests/MyArticlesSettingsSanitizeTest.php
@@ -140,4 +140,53 @@ final class MyArticlesSettingsSanitizeTest extends TestCase
             'Unlimited instances should forward -1 to WP_Query.'
         );
     }
+
+    public function test_sanitize_thumbnail_aspect_ratio_accepts_only_whitelist(): void
+    {
+        $settings = My_Articles_Settings::get_instance();
+        $defaults = My_Articles_Shortcode::get_default_options();
+
+        $invalid = $settings->sanitize(array('thumbnail_aspect_ratio' => '42/7'));
+
+        self::assertSame(
+            $defaults['thumbnail_aspect_ratio'],
+            $invalid['thumbnail_aspect_ratio'] ?? null,
+            'Unexpected ratios should fall back to the default value.'
+        );
+
+        $valid = $settings->sanitize(array('thumbnail_aspect_ratio' => '4/3'));
+
+        self::assertSame(
+            '4/3',
+            $valid['thumbnail_aspect_ratio'] ?? null,
+            'Allowed ratios should be preserved during sanitization.'
+        );
+    }
+
+    public function test_normalize_instance_options_enforces_thumbnail_aspect_ratio_whitelist(): void
+    {
+        $defaults = My_Articles_Shortcode::get_default_options();
+
+        $normalizedInvalid = My_Articles_Shortcode::normalize_instance_options(
+            array('thumbnail_aspect_ratio' => '7/5'),
+            array('source' => __METHOD__)
+        );
+
+        self::assertSame(
+            $defaults['thumbnail_aspect_ratio'],
+            $normalizedInvalid['thumbnail_aspect_ratio'],
+            'Invalid ratios should revert to the default thumbnail aspect ratio.'
+        );
+
+        $normalizedValid = My_Articles_Shortcode::normalize_instance_options(
+            array('thumbnail_aspect_ratio' => '3/2'),
+            array('source' => __METHOD__)
+        );
+
+        self::assertSame(
+            '3/2',
+            $normalizedValid['thumbnail_aspect_ratio'],
+            'Allowed ratios should survive normalization.'
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- add a configurable `thumbnail_aspect_ratio` option with block and metabox controls, plus whitelist validation in PHP/JS
- expose the aspect ratio through a CSS variable and switch thumbnails/skeletons to use the dynamic value with documentation updates
- extend automated coverage to assert sanitization and normalization of the new ratio option

## Testing
- composer test
- npm run test:js

------
https://chatgpt.com/codex/tasks/task_e_68e1a3f121f0832ead0eef71b942e215