### PR TITLE
Add automatic mode for load more pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Le panneau « Module » de l’éditeur propose un sélecteur de modèle ; le
 Options principales :
 
 - **Filtre de catégorie** : afficher une liste de catégories si l'option est activée.
-- **Pagination** : modes `load_more` (bouton « Charger plus ») ou `numbered` (pagination classique).
+- **Pagination** : modes `load_more` (bouton « Charger plus », avec option d’automatisation) ou `numbered` (pagination classique).
+- **Chargement automatique** : en activant `load_more_auto`, le bouton « Charger plus » déclenche la requête dès qu’il devient visible (IntersectionObserver ou repli via l’événement de scroll). Le module désactive automatiquement ce comportement si le navigateur est incompatible ou après un clic manuel du visiteur.
 - **Articles épinglés** : possibilité d'épingler certains articles, avec option d'ignorer les filtres.
 - **Lazy load** : chargement différé des images pour optimiser les performances.
 - **Étiquette ARIA** : personnalisez le libellé utilisé par les lecteurs d'écran depuis le panneau **Accessibilité** (par défaut, le titre du module sélectionné est proposé en suggestion).

--- a/mon-affichage-article/blocks/mon-affichage-articles/block.json
+++ b/mon-affichage-article/blocks/mon-affichage-articles/block.json
@@ -74,6 +74,10 @@
             "type": "string",
             "default": "none"
         },
+        "load_more_auto": {
+            "type": "boolean",
+            "default": false
+        },
         "slideshow_loop": {
             "type": "boolean",
             "default": true,

--- a/mon-affichage-article/blocks/mon-affichage-articles/edit.js
+++ b/mon-affichage-article/blocks/mon-affichage-articles/edit.js
@@ -761,6 +761,20 @@
                         }),
                         disabled: isAttributeLocked('pagination_mode'),
                     }),
+                    attributes.pagination_mode === 'load_more'
+                        ? el(ToggleControl, {
+                              label: __('Activer le déclenchement automatique', 'mon-articles'),
+                              help: __(
+                                  'Déclenche le bouton « Charger plus » dès qu’il devient visible à l’écran.',
+                                  'mon-articles'
+                              ),
+                              checked: !!attributes.load_more_auto,
+                              onChange: withLockedGuard('load_more_auto', function (value) {
+                                  setAttributes({ load_more_auto: !!value });
+                              }),
+                              disabled: isAttributeLocked('load_more_auto'),
+                          })
+                        : null,
                     el(SelectControl, {
                         label: __('Ratio des vignettes', 'mon-articles'),
                         value: thumbnailAspectRatio,

--- a/mon-affichage-article/includes/class-my-articles-block.php
+++ b/mon-affichage-article/includes/class-my-articles-block.php
@@ -70,6 +70,7 @@ class My_Articles_Block {
             'slideshow_pause_on_mouse_enter',
             'slideshow_show_navigation',
             'slideshow_show_pagination',
+            'load_more_auto',
         );
 
         foreach ( $filtered as $key => $raw_value ) {

--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -192,6 +192,10 @@ class My_Articles_Metaboxes {
             ],
             'description' => __('Ne s\'applique pas au mode Diaporama.', 'mon-articles'),
         ]);
+        $this->render_field('load_more_auto', esc_html__('Déclencher automatiquement le bouton « Charger plus »', 'mon-articles'), 'checkbox', $opts, [
+            'default'     => 0,
+            'description' => __('Lance la requête dès que le bouton devient visible. Se désactive automatiquement si le navigateur est incompatible ou après un clic manuel.', 'mon-articles'),
+        ]);
         $this->render_field(
             'enable_keyword_search',
             esc_html__( 'Activer la recherche par mots-clés', 'mon-articles' ),
@@ -576,6 +580,7 @@ class My_Articles_Metaboxes {
             ? min( 50, max( 0, absint( $input['posts_per_page'] ) ) )
             : 10;
         $sanitized['pagination_mode'] = isset($input['pagination_mode']) && in_array($input['pagination_mode'], ['none', 'load_more', 'numbered']) ? $input['pagination_mode'] : 'none';
+        $sanitized['load_more_auto'] = isset( $input['load_more_auto'] ) ? 1 : 0;
         $allowed_orderby = array( 'date', 'title', 'menu_order', 'meta_value' );
         $sanitized['orderby'] = isset( $input['orderby'] ) && in_array( $input['orderby'], $allowed_orderby, true ) ? $input['orderby'] : 'date';
         $order = isset( $input['order'] ) ? strtoupper( (string) $input['order'] ) : 'DESC';

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -573,6 +573,7 @@ class My_Articles_Shortcode {
             'order' => 'DESC',
             'meta_key' => '',
             'pagination_mode' => 'none',
+            'load_more_auto' => 0,
             'design_preset' => 'custom',
             'design_preset_locked' => 0,
             'enable_keyword_search' => 0,
@@ -705,6 +706,12 @@ class My_Articles_Shortcode {
         }
 
         $options = wp_parse_args( $raw_options, $defaults );
+
+        $options['load_more_auto'] = ! empty( $options['load_more_auto'] ) ? 1 : 0;
+
+        if ( $options['pagination_mode'] !== 'load_more' ) {
+            $options['load_more_auto'] = 0;
+        }
 
         $options['enable_keyword_search'] = ! empty( $options['enable_keyword_search'] ) ? 1 : 0;
 
@@ -1439,7 +1446,7 @@ class My_Articles_Shortcode {
                 if ( $total_pages > 1 && $paged < $total_pages) {
                     $next_page = min( $paged + 1, $total_pages );
                     $load_more_pinned_ids = ! empty( $displayed_pinned_ids ) ? array_map( 'absint', $displayed_pinned_ids ) : array();
-                    echo '<div class="my-articles-load-more-container"><button class="my-articles-load-more-btn" data-instance-id="' . esc_attr($id) . '" data-paged="' . esc_attr( $next_page ) . '" data-total-pages="' . esc_attr($total_pages) . '" data-pinned-ids="' . esc_attr(implode(',', $load_more_pinned_ids)) . '" data-category="' . esc_attr($options['term']) . '" data-search="' . esc_attr( $options['search_query'] ) . '">' . esc_html__( 'Charger plus', 'mon-articles' ) . '</button></div>';
+                    echo '<div class="my-articles-load-more-container"><button class="my-articles-load-more-btn" data-instance-id="' . esc_attr($id) . '" data-paged="' . esc_attr( $next_page ) . '" data-total-pages="' . esc_attr($total_pages) . '" data-pinned-ids="' . esc_attr(implode(',', $load_more_pinned_ids)) . '" data-category="' . esc_attr($options['term']) . '" data-search="' . esc_attr( $options['search_query'] ) . '" data-auto-load="' . esc_attr( $options['load_more_auto'] ? '1' : '0' ) . '">' . esc_html__( 'Charger plus', 'mon-articles' ) . '</button></div>';
                 }
             } elseif ($options['pagination_mode'] === 'numbered') {
                 $pagination_query_args = array();

--- a/mon-affichage-article/languages/mon-articles-fr_FR-d38246567e142318f24686bcaa0ee4b1.json
+++ b/mon-affichage-article/languages/mon-articles-fr_FR-d38246567e142318f24686bcaa0ee4b1.json
@@ -18,6 +18,9 @@
             "Actif uniquement si la lecture automatique est activée.": [
                 "Actif uniquement si la lecture automatique est activée."
             ],
+            "Activer le déclenchement automatique": [
+                "Activer le déclenchement automatique"
+            ],
             "Affichage": [
                 "Affichage"
             ],
@@ -114,6 +117,12 @@
             "Créer un nouveau module": [
                 "Créer un nouveau module"
             ],
+            "Déclenche le bouton « Charger plus » dès qu’il devient visible à l’écran.": [
+                "Déclenche le bouton « Charger plus » dès qu’il devient visible à l’écran."
+            ],
+            "Déclencher automatiquement le bouton « Charger plus »": [
+                "Déclencher automatiquement le bouton « Charger plus »"
+            ],
             "Date de publication": [
                 "Date de publication"
             ],
@@ -170,6 +179,9 @@
             ],
             "La sélection de couleur n’est pas disponible dans cet environnement.": [
                 "La sélection de couleur n’est pas disponible dans cet environnement."
+            ],
+            "Lance la requête dès que le bouton devient visible. Se désactive automatiquement si le navigateur est incompatible ou après un clic manuel.": [
+                "Lance la requête dès que le bouton devient visible. Se désactive automatiquement si le navigateur est incompatible ou après un clic manuel."
             ],
             "Laissez vide pour générer automatiquement une étiquette basée sur le titre du module.": [
                 "Laissez vide pour générer automatiquement une étiquette basée sur le titre du module."


### PR DESCRIPTION
## Summary
- add the `load_more_auto` toggle to the block attributes, metabox UI, defaults, and shortcode markup
- propagate the auto-load flag to the frontend, extend the load-more script with IntersectionObserver and scroll fallback logic, and disable automation when appropriate
- document the new behaviour, refresh translations, and cover it with updated Jest tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e24e10125c832eb15a3e7de3d2e96e