### PR TITLE
Add vertical module padding controls

### DIFF
--- a/mon-affichage-article/assets/css/styles.css
+++ b/mon-affichage-article/assets/css/styles.css
@@ -3,10 +3,15 @@
 .my-articles-wrapper {
     position: relative;
     box-sizing: border-box;
+    --my-articles-module-padding-top: 0px;
+    --my-articles-module-padding-right: 0px;
+    --my-articles-module-padding-bottom: 0px;
+    --my-articles-module-padding-left: 0px;
     --my-articles-skeleton-base: rgba(31, 41, 51, 0.08);
     --my-articles-skeleton-highlight: rgba(31, 41, 51, 0.16);
     --my-articles-skeleton-radius: var(--my-articles-border-radius, 12px);
     --my-articles-thumbnail-aspect-ratio: 16/9;
+    padding: var(--my-articles-module-padding-top) var(--my-articles-module-padding-right) var(--my-articles-module-padding-bottom) var(--my-articles-module-padding-left);
 }
 
 .my-articles-wrapper--loading,

--- a/mon-affichage-article/blocks/mon-affichage-articles/block.json
+++ b/mon-affichage-article/blocks/mon-affichage-articles/block.json
@@ -109,6 +109,16 @@
             "default": true,
             "description": "Affiche la pagination (puces) du diaporama."
         },
+        "module_padding_top": {
+            "type": "integer",
+            "default": 0,
+            "description": "Marge interne haute du module (px)."
+        },
+        "module_padding_bottom": {
+            "type": "integer",
+            "default": 0,
+            "description": "Marge interne basse du module (px)."
+        },
         "module_padding_left": {
             "type": "integer",
             "default": 0,

--- a/mon-affichage-article/blocks/mon-affichage-articles/edit.js
+++ b/mon-affichage-article/blocks/mon-affichage-articles/edit.js
@@ -936,6 +936,34 @@
                     PanelBody,
                     { title: __('Espacements & typographie', 'mon-articles'), initialOpen: false },
                     el(RangeControl, {
+                        label: __('Marge intérieure haute (px)', 'mon-articles'),
+                        value: ensureNumber(attributes.module_padding_top, 0),
+                        min: 0,
+                        max: 200,
+                        allowReset: true,
+                        onChange: withLockedGuard('module_padding_top', function (value) {
+                            if (typeof value !== 'number') {
+                                value = 0;
+                            }
+                            setAttributes({ module_padding_top: value });
+                        }),
+                        disabled: isAttributeLocked('module_padding_top'),
+                    }),
+                    el(RangeControl, {
+                        label: __('Marge intérieure basse (px)', 'mon-articles'),
+                        value: ensureNumber(attributes.module_padding_bottom, 0),
+                        min: 0,
+                        max: 200,
+                        allowReset: true,
+                        onChange: withLockedGuard('module_padding_bottom', function (value) {
+                            if (typeof value !== 'number') {
+                                value = 0;
+                            }
+                            setAttributes({ module_padding_bottom: value });
+                        }),
+                        disabled: isAttributeLocked('module_padding_bottom'),
+                    }),
+                    el(RangeControl, {
                         label: __('Marge intérieure gauche (px)', 'mon-articles'),
                         value: ensureNumber(attributes.module_padding_left, 0),
                         min: 0,

--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -391,6 +391,8 @@ class My_Articles_Metaboxes {
             ]
         );
 
+        $this->render_field('module_padding_top', esc_html__('Marge intérieure haute (px)', 'mon-articles'), 'number', $opts, ['default' => 0, 'min' => 0, 'max' => 200]);
+        $this->render_field('module_padding_bottom', esc_html__('Marge intérieure basse (px)', 'mon-articles'), 'number', $opts, ['default' => 0, 'min' => 0, 'max' => 200]);
         $this->render_field('module_padding_left', esc_html__('Marge intérieure gauche (px)', 'mon-articles'), 'number', $opts, ['default' => 0, 'min' => 0, 'max' => 200]);
         $this->render_field('module_padding_right', esc_html__('Marge intérieure droite (px)', 'mon-articles'), 'number', $opts, ['default' => 0, 'min' => 0, 'max' => 200]);
         $this->render_field('gap_size', esc_html__('Espacement des vignettes (Grille)', 'mon-articles'), 'number', $opts, ['default' => 25, 'min' => 0, 'max' => 50]);
@@ -663,6 +665,12 @@ class My_Articles_Metaboxes {
         $sanitized['columns_ultrawide'] = isset( $input['columns_ultrawide'] )
             ? min( 8, max( 1, absint( $input['columns_ultrawide'] ) ) )
             : 4;
+        $sanitized['module_padding_top'] = isset( $input['module_padding_top'] )
+            ? min( 200, max( 0, absint( $input['module_padding_top'] ) ) )
+            : 0;
+        $sanitized['module_padding_bottom'] = isset( $input['module_padding_bottom'] )
+            ? min( 200, max( 0, absint( $input['module_padding_bottom'] ) ) )
+            : 0;
         $sanitized['module_padding_left'] = isset( $input['module_padding_left'] )
             ? min( 200, max( 0, absint( $input['module_padding_left'] ) ) )
             : 0;

--- a/mon-affichage-article/includes/class-my-articles-settings.php
+++ b/mon-affichage-article/includes/class-my-articles-settings.php
@@ -70,6 +70,8 @@ class My_Articles_Settings {
         add_settings_field( 'display_mode', __( 'Mode d\'affichage', 'mon-articles' ), array( $this, 'display_mode_callback' ), 'my-articles-admin', 'setting_section_layout' );
         add_settings_field( 'desktop_columns', __( 'Articles visibles (Desktop)', 'mon-articles' ), array( $this, 'desktop_columns_callback' ), 'my-articles-admin', 'setting_section_layout' );
         add_settings_field( 'mobile_columns', __( 'Articles visibles (Mobile)', 'mon-articles' ), array( $this, 'mobile_columns_callback' ), 'my-articles-admin', 'setting_section_layout' );
+        add_settings_field( 'module_margin_top', __( 'Marge en haut (px)', 'mon-articles' ), array( $this, 'module_margin_top_callback' ), 'my-articles-admin', 'setting_section_layout' );
+        add_settings_field( 'module_margin_bottom', __( 'Marge en bas (px)', 'mon-articles' ), array( $this, 'module_margin_bottom_callback' ), 'my-articles-admin', 'setting_section_layout' );
         add_settings_field( 'module_margin_left', __( 'Marge à gauche (px)', 'mon-articles' ), array( $this, 'module_margin_left_callback' ), 'my-articles-admin', 'setting_section_layout' );
         add_settings_field( 'module_margin_right', __( 'Marge à droite (px)', 'mon-articles' ), array( $this, 'module_margin_right_callback' ), 'my-articles-admin', 'setting_section_layout' );
         
@@ -134,6 +136,12 @@ class My_Articles_Settings {
         $sanitized_input['module_bg_color'] = my_articles_sanitize_color($input['module_bg_color'] ?? '', 'rgba(255,255,255,0)');
         $sanitized_input['vignette_bg_color'] = my_articles_sanitize_color($input['vignette_bg_color'] ?? '', '#ffffff');
         $sanitized_input['title_wrapper_bg_color'] = my_articles_sanitize_color($input['title_wrapper_bg_color'] ?? '', '#ffffff');
+        $sanitized_input['module_margin_top'] = isset( $input['module_margin_top'] )
+            ? min( 200, max( 0, intval( $input['module_margin_top'] ) ) )
+            : 0;
+        $sanitized_input['module_margin_bottom'] = isset( $input['module_margin_bottom'] )
+            ? min( 200, max( 0, intval( $input['module_margin_bottom'] ) ) )
+            : 0;
         $sanitized_input['module_margin_left'] = isset( $input['module_margin_left'] )
             ? min( 200, max( 0, intval( $input['module_margin_left'] ) ) )
             : 0;
@@ -200,6 +208,8 @@ class My_Articles_Settings {
     public function module_bg_color_callback() { $this->render_color_input('module_bg_color', 'rgba(255,255,255,0)', true); }
     public function vignette_bg_color_callback() { $this->render_color_input('vignette_bg_color', '#ffffff'); }
     public function title_wrapper_bg_color_callback() { $this->render_color_input('title_wrapper_bg_color', '#ffffff'); }
+    public function module_margin_top_callback() { $this->render_number_input('module_margin_top', 0, 0, 200); }
+    public function module_margin_bottom_callback() { $this->render_number_input('module_margin_bottom', 0, 0, 200); }
     public function module_margin_left_callback() { $this->render_number_input('module_margin_left', 0, 0, 200); }
     public function module_margin_right_callback() { $this->render_number_input('module_margin_right', 0, 0, 200); }
 

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -62,8 +62,10 @@ class My_Articles_Shortcode {
                     'pagination_color'            => '#2563eb',
                     'shadow_color'                => 'rgba(15,23,42,0.08)',
                     'shadow_color_hover'          => 'rgba(37,99,235,0.16)',
-                    'module_padding_left'         => 24,
+                    'module_padding_top'          => 24,
                     'module_padding_right'        => 24,
+                    'module_padding_bottom'       => 24,
+                    'module_padding_left'         => 24,
                     'gap_size'                    => 24,
                     'list_item_gap'               => 28,
                     'border_radius'               => 18,
@@ -91,8 +93,10 @@ class My_Articles_Shortcode {
                     'pagination_color'            => '#93c5fd',
                     'shadow_color'                => 'rgba(0,0,0,0.4)',
                     'shadow_color_hover'          => 'rgba(30,64,175,0.6)',
-                    'module_padding_left'         => 32,
+                    'module_padding_top'          => 32,
                     'module_padding_right'        => 32,
+                    'module_padding_bottom'       => 32,
+                    'module_padding_left'         => 32,
                     'gap_size'                    => 20,
                     'list_item_gap'               => 32,
                     'border_radius'               => 20,
@@ -121,8 +125,10 @@ class My_Articles_Shortcode {
                     'pagination_color'            => '#1d4ed8',
                     'shadow_color'                => 'rgba(0,0,0,0.04)',
                     'shadow_color_hover'          => 'rgba(0,0,0,0.08)',
-                    'module_padding_left'         => 16,
+                    'module_padding_top'          => 16,
                     'module_padding_right'        => 16,
+                    'module_padding_bottom'       => 16,
+                    'module_padding_left'         => 16,
                     'gap_size'                    => 20,
                     'list_item_gap'               => 24,
                     'border_radius'               => 8,
@@ -596,7 +602,8 @@ class My_Articles_Shortcode {
             'display_mode' => 'grid',
             'thumbnail_aspect_ratio' => self::get_default_thumbnail_aspect_ratio(),
             'columns_mobile' => 1, 'columns_tablet' => 2, 'columns_desktop' => 3, 'columns_ultrawide' => 4,
-            'module_padding_left' => 0, 'module_padding_right' => 0,
+            'module_padding_top' => 0, 'module_padding_right' => 0,
+            'module_padding_bottom' => 0, 'module_padding_left' => 0,
             'gap_size' => 25, 'list_item_gap' => 25,
             'list_content_padding_top' => 0, 'list_content_padding_right' => 0,
             'list_content_padding_bottom' => 0, 'list_content_padding_left' => 0,
@@ -629,8 +636,10 @@ class My_Articles_Shortcode {
         $aliases = array(
             'desktop_columns'     => 'columns_desktop',
             'mobile_columns'      => 'columns_mobile',
-            'module_margin_left'  => 'module_padding_left',
-            'module_margin_right' => 'module_padding_right',
+            'module_margin_top'    => 'module_padding_top',
+            'module_margin_left'   => 'module_padding_left',
+            'module_margin_bottom' => 'module_padding_bottom',
+            'module_margin_right'  => 'module_padding_right',
         );
 
         foreach ( $aliases as $stored_key => $option_key ) {
@@ -1009,6 +1018,11 @@ class My_Articles_Shortcode {
         $options['requested_category']         = $requested_category;
         $options['is_requested_category_valid'] = $is_requested_category_valid;
 
+        $options['module_padding_top']    = min( 200, max( 0, absint( $options['module_padding_top'] ?? $defaults['module_padding_top'] ) ) );
+        $options['module_padding_right']  = min( 200, max( 0, absint( $options['module_padding_right'] ?? $defaults['module_padding_right'] ) ) );
+        $options['module_padding_bottom'] = min( 200, max( 0, absint( $options['module_padding_bottom'] ?? $defaults['module_padding_bottom'] ) ) );
+        $options['module_padding_left']   = min( 200, max( 0, absint( $options['module_padding_left'] ?? $defaults['module_padding_left'] ) ) );
+
         self::$normalized_options_cache[ $cache_key ] = $options;
 
         return $options;
@@ -1279,7 +1293,7 @@ class My_Articles_Shortcode {
         }
 
         ob_start();
-        $this->enqueue_dynamic_styles( $options, $id );
+        $this->render_inline_styles( $options, $id );
 
         $wrapper_class = 'my-articles-wrapper my-articles-' . esc_attr($options['display_mode']);
 
@@ -2004,7 +2018,7 @@ class My_Articles_Shortcode {
         }
     }
 
-    private function enqueue_dynamic_styles( $options, $id ) {
+    private function render_inline_styles( $options, $id ) {
         $defaults = self::get_default_options();
 
         $min_card_width = 220;
@@ -2024,12 +2038,14 @@ class My_Articles_Shortcode {
         $padding_bottom = max( 0, absint( $options['list_content_padding_bottom'] ?? $defaults['list_content_padding_bottom'] ) );
         $padding_left   = max( 0, absint( $options['list_content_padding_left'] ?? $defaults['list_content_padding_left'] ) );
 
-        $border_radius       = max( 0, absint( $options['border_radius'] ?? $defaults['border_radius'] ) );
-        $title_font_size     = max( 1, absint( $options['title_font_size'] ?? $defaults['title_font_size'] ) );
-        $meta_font_size      = max( 1, absint( $options['meta_font_size'] ?? $defaults['meta_font_size'] ) );
-        $excerpt_font_size   = max( 1, absint( $options['excerpt_font_size'] ?? $defaults['excerpt_font_size'] ) );
-        $module_padding_left  = max( 0, absint( $options['module_padding_left'] ?? $defaults['module_padding_left'] ) );
-        $module_padding_right = max( 0, absint( $options['module_padding_right'] ?? $defaults['module_padding_right'] ) );
+        $border_radius        = max( 0, absint( $options['border_radius'] ?? $defaults['border_radius'] ) );
+        $title_font_size      = max( 1, absint( $options['title_font_size'] ?? $defaults['title_font_size'] ) );
+        $meta_font_size       = max( 1, absint( $options['meta_font_size'] ?? $defaults['meta_font_size'] ) );
+        $excerpt_font_size    = max( 1, absint( $options['excerpt_font_size'] ?? $defaults['excerpt_font_size'] ) );
+        $module_padding_top    = max( 0, absint( $options['module_padding_top'] ?? $defaults['module_padding_top'] ) );
+        $module_padding_right  = max( 0, absint( $options['module_padding_right'] ?? $defaults['module_padding_right'] ) );
+        $module_padding_bottom = max( 0, absint( $options['module_padding_bottom'] ?? $defaults['module_padding_bottom'] ) );
+        $module_padding_left   = max( 0, absint( $options['module_padding_left'] ?? $defaults['module_padding_left'] ) );
 
         $title_color          = my_articles_sanitize_color( $options['title_color'] ?? '', $defaults['title_color'] );
         $meta_color           = my_articles_sanitize_color( $options['meta_color'] ?? '', $defaults['meta_color'] );
@@ -2081,9 +2097,15 @@ class My_Articles_Shortcode {
             --my-articles-badge-bg-color: {$pinned_badge_bg};
             --my-articles-badge-text-color: {$pinned_badge_text};
             --my-articles-thumbnail-aspect-ratio: {$thumbnail_ratio};
+            --my-articles-module-padding-top: {$module_padding_top}px;
+            --my-articles-module-padding-right: {$module_padding_right}px;
+            --my-articles-module-padding-bottom: {$module_padding_bottom}px;
+            --my-articles-module-padding-left: {$module_padding_left}px;
             background-color: {$module_bg_color};
-            padding-left: {$module_padding_left}px;
+            padding-top: {$module_padding_top}px;
             padding-right: {$module_padding_right}px;
+            padding-bottom: {$module_padding_bottom}px;
+            padding-left: {$module_padding_left}px;
         }
         #my-articles-wrapper-{$id} .my-article-item { background-color: {$vignette_bg_color}; }
         #my-articles-wrapper-{$id}.my-articles-grid .my-article-item .article-title-wrapper,


### PR DESCRIPTION
## Summary
- add module padding top/bottom attributes and controls in the block editor and metabox settings
- normalize and expose the new padding values through shortcode defaults, presets, and inline styles
- surface CSS variables and defaults so module wrappers respect vertical padding on the front-end

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e24e0ee4d0832e95eca366fe8e43f2