### PR TITLE
Add block toolbar controls for display and viewport previews

### DIFF
--- a/mon-affichage-article/blocks/mon-affichage-articles/editor.css
+++ b/mon-affichage-article/blocks/mon-affichage-articles/editor.css
@@ -22,3 +22,37 @@
 .wp-block-mon-affichage-articles .my-articles-block-placeholder__actions .components-button {
     text-decoration: none;
 }
+
+.wp-block-mon-affichage-articles .my-articles-block.is-preview-mobile,
+.wp-block-mon-affichage-articles .my-articles-block.is-preview-tablet,
+.wp-block-mon-affichage-articles .my-articles-block.is-preview-desktop {
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.wp-block-mon-affichage-articles .my-articles-block.is-preview-mobile {
+    max-width: 420px;
+}
+
+.wp-block-mon-affichage-articles .my-articles-block.is-preview-tablet {
+    max-width: 900px;
+}
+
+.wp-block-mon-affichage-articles .my-articles-block.is-preview-desktop {
+    max-width: 1180px;
+}
+
+.wp-block-mon-affichage-articles .my-articles-block.is-preview-mobile .my-articles-wrapper {
+    --my-articles-cols-tablet: var(--my-articles-cols-mobile);
+    --my-articles-cols-desktop: var(--my-articles-cols-mobile);
+    --my-articles-cols-ultrawide: var(--my-articles-cols-mobile);
+}
+
+.wp-block-mon-affichage-articles .my-articles-block.is-preview-tablet .my-articles-wrapper {
+    --my-articles-cols-desktop: var(--my-articles-cols-tablet);
+    --my-articles-cols-ultrawide: var(--my-articles-cols-tablet);
+}
+
+.wp-block-mon-affichage-articles .my-articles-block.is-preview-desktop .my-articles-wrapper {
+    --my-articles-cols-ultrawide: var(--my-articles-cols-desktop);
+}


### PR DESCRIPTION
## Summary
- add block toolbar controls to quickly toggle the display mode from the editor toolbar
- allow simulating mobile, tablet, and desktop layouts by applying preview classes via toolbar state
- style the new preview classes so the editor reflects responsive widths and column variables, and document the shortcuts in block help

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e26c3014d0832e83f0a9db5956cb4a