### PR TITLE
Add preset variations picker to articles block

### DIFF
--- a/mon-affichage-article/blocks/mon-affichage-articles/block.json
+++ b/mon-affichage-article/blocks/mon-affichage-articles/block.json
@@ -14,6 +14,89 @@
     "supports": {
         "html": false
     },
+    "example": {
+        "attributes": {
+            "design_preset": "lcv-classique",
+            "display_mode": "grid",
+            "show_excerpt": true,
+            "show_author": true,
+            "show_date": true
+        },
+        "innerBlocks": [
+            {
+                "name": "core/group",
+                "attributes": {
+                    "className": "my-articles-block-example"
+                },
+                "innerBlocks": [
+                    {
+                        "name": "core/heading",
+                        "attributes": {
+                            "level": 4,
+                            "content": "Titre d’article"
+                        }
+                    },
+                    {
+                        "name": "core/paragraph",
+                        "attributes": {
+                            "content": "Un exemple d’extrait pour illustrer le rendu du module."
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "variations": [
+        {
+            "name": "custom",
+            "title": "Personnalisé",
+            "description": "Conservez vos propres réglages de couleurs et d’espacements.",
+            "attributes": {
+                "design_preset": "custom"
+            },
+            "isDefault": true,
+            "scope": ["block"],
+            "icon": {
+                "src": "admin-customizer"
+            }
+        },
+        {
+            "name": "lcv-classique",
+            "title": "Classique LCV",
+            "description": "Fond clair légèrement bleuté, cartes arrondies et typographie lisible.",
+            "attributes": {
+                "design_preset": "lcv-classique"
+            },
+            "scope": ["block"],
+            "icon": {
+                "src": "screenoptions"
+            }
+        },
+        {
+            "name": "dark-spotlight",
+            "title": "Projecteur sombre",
+            "description": "Contraste élevé, idéal pour des pages sombres ou des encarts immersifs.",
+            "attributes": {
+                "design_preset": "dark-spotlight"
+            },
+            "scope": ["block"],
+            "icon": {
+                "src": "visibility"
+            }
+        },
+        {
+            "name": "editorial-focus",
+            "title": "Focus éditorial",
+            "description": "Présentation magazine sobre, optimisée pour les listes avec extraits courts.",
+            "attributes": {
+                "design_preset": "editorial-focus"
+            },
+            "scope": ["block"],
+            "icon": {
+                "src": "align-left"
+            }
+        }
+    ],
     "attributes": {
         "instanceId": {
             "type": "integer",

--- a/mon-affichage-article/blocks/mon-affichage-articles/editor.css
+++ b/mon-affichage-article/blocks/mon-affichage-articles/editor.css
@@ -22,3 +22,34 @@
 .wp-block-mon-affichage-articles .my-articles-block-placeholder__actions .components-button {
     text-decoration: none;
 }
+
+.wp-block-mon-affichage-articles .my-articles-block-variation-picker {
+    margin-bottom: 20px;
+}
+
+.wp-block-mon-affichage-articles .my-articles-variation-icon {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    font-size: 24px;
+}
+
+.wp-block-mon-affichage-articles .my-articles-variation-icon__base {
+    font-size: 24px;
+}
+
+.wp-block-mon-affichage-articles .my-articles-variation-icon__lock {
+    position: absolute;
+    bottom: -2px;
+    right: -2px;
+    font-size: 16px;
+    line-height: 1;
+    background: #ffffff;
+    border-radius: 50%;
+    padding: 2px;
+    box-shadow: 0 0 0 2px #ffffff;
+    color: #1f2937;
+}


### PR DESCRIPTION
## Summary
- add block example markup and declare design preset variations for the Mon Affichage block
- display a BlockVariationPicker when the block has no instance selected and sync the choice with `design_preset`
- style variation icons to highlight locked presets using the descriptions from the registered design presets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e26d6a9bfc832ea73f80aae70cf612