### PR TITLE
Add sort parameter support across articles display

### DIFF
--- a/mon-affichage-article/assets/js/__tests__/filter.test.js
+++ b/mon-affichage-article/assets/js/__tests__/filter.test.js
@@ -4,7 +4,7 @@ describe('filter endpoint interactions', () => {
 
     const setupDom = () => {
         document.body.innerHTML = `
-            <div class="my-articles-wrapper" data-instance-id="42">
+            <div class="my-articles-wrapper" data-instance-id="42" data-sort="date" data-sort-param="my_articles_sort_42">
                 <ul class="my-articles-filter-nav">
                     <li class="active"><button data-category="all" aria-pressed="true">Tous</button></li>
                     <li><button data-category="news">Actualités</button></li>
@@ -75,6 +75,7 @@ describe('filter endpoint interactions', () => {
                         total_pages: 2,
                         next_page: 3,
                         pinned_ids: '5,7',
+                        sort: 'comment_count',
                         pagination_html: '<nav class="my-articles-pagination">Page 1</nav>',
                     },
                 });
@@ -97,6 +98,8 @@ describe('filter endpoint interactions', () => {
             expect.objectContaining({ method: 'POST' })
         );
 
+        expect(ajaxOptions.data.sort).toBe('date');
+
         const contentHtml = document.querySelector('.my-articles-grid-content').innerHTML;
         expect(contentHtml).toContain('Filtré');
 
@@ -107,6 +110,10 @@ describe('filter endpoint interactions', () => {
         const loadMoreButton = document.querySelector('.my-articles-load-more-btn');
         expect(loadMoreButton).not.toBeNull();
         expect(loadMoreButton.getAttribute('data-pinned-ids')).toBe('5,7');
+        expect(loadMoreButton.getAttribute('data-sort')).toBe('comment_count');
+
+        const wrapper = document.querySelector('.my-articles-wrapper');
+        expect(wrapper.getAttribute('data-sort')).toBe('comment_count');
     });
 
     it('shows API error messages when the request fails', () => {

--- a/mon-affichage-article/assets/js/__tests__/load-more.test.js
+++ b/mon-affichage-article/assets/js/__tests__/load-more.test.js
@@ -5,7 +5,7 @@ describe('load-more endpoint interactions', () => {
 
     const setupDom = () => {
         document.body.innerHTML = `
-            <div class="my-articles-wrapper" data-instance-id="42">
+            <div class="my-articles-wrapper" data-instance-id="42" data-sort="date">
                 <div class="my-articles-grid-content">
                     <article class="my-article-item">Initial</article>
                 </div>
@@ -17,6 +17,7 @@ describe('load-more endpoint interactions', () => {
                         data-total-pages="4"
                         data-pinned-ids=""
                         data-category="news"
+                        data-sort="date"
                         data-auto-load="0"
                     >Charger plus</button>
                 </div>
@@ -92,6 +93,7 @@ describe('load-more endpoint interactions', () => {
                         total_pages: 4,
                         next_page: 3,
                         pinned_ids: '10,11',
+                        sort: 'comment_count',
                     },
                 });
             }
@@ -113,6 +115,8 @@ describe('load-more endpoint interactions', () => {
             expect.objectContaining({ method: 'POST' })
         );
 
+        expect(ajaxOptions.data.sort).toBe('date');
+
         const articles = document.querySelectorAll('.my-articles-grid-content .my-article-item');
         expect(articles).toHaveLength(2);
         expect(articles[1].textContent).toBe('Nouveau');
@@ -124,6 +128,10 @@ describe('load-more endpoint interactions', () => {
         const buttonNode = document.querySelector('.my-articles-load-more-btn');
         expect(buttonNode.getAttribute('data-pinned-ids')).toBe('10,11');
         expect(buttonNode.getAttribute('data-paged')).toBe('3');
+        expect(buttonNode.getAttribute('data-sort')).toBe('comment_count');
+
+        const wrapper = document.querySelector('.my-articles-wrapper');
+        expect(wrapper.getAttribute('data-sort')).toBe('comment_count');
     });
 
     it('displays server error messages when the request fails', () => {
@@ -158,7 +166,7 @@ describe('load-more endpoint interactions', () => {
 
     it('installs an observer and triggers automatic loading when enabled', () => {
         document.body.innerHTML = `
-            <div class="my-articles-wrapper" data-instance-id="21">
+            <div class="my-articles-wrapper" data-instance-id="21" data-sort="date">
                 <div class="my-articles-grid-content">
                     <article class="my-article-item">Initial</article>
                 </div>
@@ -170,6 +178,7 @@ describe('load-more endpoint interactions', () => {
                         data-total-pages="3"
                         data-pinned-ids=""
                         data-category="news"
+                        data-sort="date"
                         data-auto-load="1"
                     >Charger plus</button>
                 </div>
@@ -196,6 +205,7 @@ describe('load-more endpoint interactions', () => {
                         total_pages: 3,
                         next_page: 3,
                         pinned_ids: '',
+                        sort: 'date',
                     },
                 });
             }

--- a/mon-affichage-article/assets/js/admin-options.js
+++ b/mon-affichage-article/assets/js/admin-options.js
@@ -27,14 +27,14 @@
     }
 
     function toggleMetaKeyOption() {
-        var $orderbySelect = $('#orderby');
+        var $sortSelect = $('#sort');
         var $metaKeyOption = $('.meta-key-option');
 
         if (!$metaKeyOption.length) {
             return;
         }
 
-        if ($orderbySelect.length && $orderbySelect.val() === 'meta_value') {
+        if ($sortSelect.length && $sortSelect.val() === 'meta_value') {
             $metaKeyOption.show();
         } else {
             $metaKeyOption.hide();
@@ -150,7 +150,7 @@
     // Écouteurs d'événements
     $(document).on('change', '#pinned_show_badge', toggleBadgeOptions);
     $(document).on('change', '#show_excerpt', toggleExcerptOptions);
-    $(document).on('change', '#orderby', toggleMetaKeyOption);
+    $(document).on('change', '#sort', toggleMetaKeyOption);
     $(document).on('change', '#display_mode', toggleSlideshowOptions);
 
     // Exécution au chargement de la page pour définir l'état initial

--- a/mon-affichage-article/assets/js/load-more.js
+++ b/mon-affichage-article/assets/js/load-more.js
@@ -187,6 +187,26 @@
         return normalized.replace(/\s+/g, ' ').trim();
     }
 
+    function sanitizeSortValue(value) {
+        var normalized = '';
+
+        if (typeof value === 'string') {
+            normalized = value;
+        } else if (value === null || typeof value === 'undefined') {
+            normalized = '';
+        } else {
+            normalized = String(value);
+        }
+
+        normalized = normalized.trim();
+
+        if (!normalized) {
+            return '';
+        }
+
+        return normalized.replace(/[^a-z0-9_\-]+/gi, '').toLowerCase();
+    }
+
     function updateInstanceQueryParams(instanceId, params) {
         if (typeof window === 'undefined' || !window.history) {
             return;
@@ -716,6 +736,7 @@
         var pinnedIds = button.data('pinned-ids');
         var category = button.data('category');
         var searchValue = sanitizeSearchValue(button.data('search'));
+        var sortValue = sanitizeSortValue(button.data('sort'));
         var requestedPage = paged;
 
         if (!paged || paged <= 0) {
@@ -838,6 +859,16 @@
                 button.attr('data-search', updatedSearchValue);
             }
 
+            if (typeof responseData.sort !== 'undefined') {
+                var updatedSortValue = sanitizeSortValue(responseData.sort);
+                button.data('sort', updatedSortValue);
+                button.attr('data-sort', updatedSortValue);
+
+                if (wrapper && wrapper.length) {
+                    wrapper.attr('data-sort', updatedSortValue);
+                }
+            }
+
             if (typeof responseData.total_pages !== 'undefined') {
                 var serverTotalPages = parseInt(responseData.total_pages, 10);
                 if (!isNaN(serverTotalPages)) {
@@ -910,7 +941,8 @@
                     paged: paged,
                     pinned_ids: pinnedIds,
                     category: category,
-                    search: searchValue
+                    search: searchValue,
+                    sort: sortValue
                 },
                 beforeSend: function () {
                     var loadingText = loadMoreSettings.loadingText || originalButtonText;

--- a/mon-affichage-article/blocks/mon-affichage-articles/block.json
+++ b/mon-affichage-article/blocks/mon-affichage-articles/block.json
@@ -31,6 +31,10 @@
             "type": "integer",
             "default": 10
         },
+        "sort": {
+            "type": "string",
+            "default": "date"
+        },
         "orderby": {
             "type": "string",
             "default": "date"

--- a/mon-affichage-article/blocks/mon-affichage-articles/edit.js
+++ b/mon-affichage-article/blocks/mon-affichage-articles/edit.js
@@ -1124,15 +1124,17 @@
                     { title: __('Tri & ordre', 'mon-articles'), initialOpen: false },
                     el(SelectControl, {
                         label: __('Ordre de tri', 'mon-articles'),
-                        value: attributes.orderby || 'date',
+                        value: attributes.sort || attributes.orderby || 'date',
                         options: [
                             { label: __('Date de publication', 'mon-articles'), value: 'date' },
                             { label: __('Titre', 'mon-articles'), value: 'title' },
                             { label: __('Ordre du menu', 'mon-articles'), value: 'menu_order' },
                             { label: __('Méta personnalisée', 'mon-articles'), value: 'meta_value' },
+                            { label: __('Nombre de commentaires', 'mon-articles'), value: 'comment_count' },
+                            { label: __('Ordre personnalisé (post__in)', 'mon-articles'), value: 'post__in' },
                         ],
                         onChange: function (value) {
-                            setAttributes({ orderby: value });
+                            setAttributes({ sort: value, orderby: value });
                         },
                     }),
                     el(SelectControl, {
@@ -1146,7 +1148,7 @@
                             setAttributes({ order: value });
                         },
                     }),
-                    'meta_value' === (attributes.orderby || 'date')
+                    'meta_value' === (attributes.sort || attributes.orderby || 'date')
                         ? el(TextControl, {
                               label: __('Clé de méta personnalisée', 'mon-articles'),
                               value: attributes.meta_key || '',

--- a/mon-affichage-article/includes/class-my-articles-metaboxes.php
+++ b/mon-affichage-article/includes/class-my-articles-metaboxes.php
@@ -117,6 +117,10 @@ class My_Articles_Metaboxes {
         wp_nonce_field( 'my_articles_save_meta_box_data', 'my_articles_meta_box_nonce' );
         $opts = (array) get_post_meta( $post->ID, $this->option_key, true );
 
+        if ( ! isset( $opts['sort'] ) && isset( $opts['orderby'] ) ) {
+            $opts['sort'] = $opts['orderby'];
+        }
+
         $helper_message = wp_kses_post(
             __('<strong>Tutoriel :</strong> copier / coller le shortcode dans une balise HTML de WordPress.', 'mon-articles')
         );
@@ -144,17 +148,19 @@ class My_Articles_Metaboxes {
             ]
         );
         $this->render_field(
-            'orderby',
+            'sort',
             esc_html__( 'Ordre de tri', 'mon-articles' ),
             'select',
             $opts,
             [
                 'default'     => 'date',
                 'options'     => [
-                    'date'       => __( 'Date de publication', 'mon-articles' ),
-                    'title'      => __( 'Titre', 'mon-articles' ),
-                    'menu_order' => __( 'Ordre du menu', 'mon-articles' ),
-                    'meta_value' => __( 'Méta personnalisée', 'mon-articles' ),
+                    'date'          => __( 'Date de publication', 'mon-articles' ),
+                    'title'         => __( 'Titre', 'mon-articles' ),
+                    'menu_order'    => __( 'Ordre du menu', 'mon-articles' ),
+                    'meta_value'    => __( 'Méta personnalisée', 'mon-articles' ),
+                    'comment_count' => __( 'Nombre de commentaires', 'mon-articles' ),
+                    'post__in'      => __( 'Ordre personnalisé (post__in)', 'mon-articles' ),
                 ],
                 'description' => __( 'Choisissez le champ principal utilisé pour trier les contenus.', 'mon-articles' ),
             ]
@@ -583,8 +589,17 @@ class My_Articles_Metaboxes {
             : 10;
         $sanitized['pagination_mode'] = isset($input['pagination_mode']) && in_array($input['pagination_mode'], ['none', 'load_more', 'numbered']) ? $input['pagination_mode'] : 'none';
         $sanitized['load_more_auto'] = isset( $input['load_more_auto'] ) ? 1 : 0;
-        $allowed_orderby = array( 'date', 'title', 'menu_order', 'meta_value' );
-        $sanitized['orderby'] = isset( $input['orderby'] ) && in_array( $input['orderby'], $allowed_orderby, true ) ? $input['orderby'] : 'date';
+        $allowed_sort = array( 'date', 'title', 'menu_order', 'meta_value', 'comment_count', 'post__in' );
+        $resolved_sort = 'date';
+
+        if ( isset( $input['sort'] ) && in_array( $input['sort'], $allowed_sort, true ) ) {
+            $resolved_sort = $input['sort'];
+        } elseif ( isset( $input['orderby'] ) && in_array( $input['orderby'], $allowed_sort, true ) ) {
+            $resolved_sort = $input['orderby'];
+        }
+
+        $sanitized['sort']    = $resolved_sort;
+        $sanitized['orderby'] = $resolved_sort;
         $order = isset( $input['order'] ) ? strtoupper( (string) $input['order'] ) : 'DESC';
         $sanitized['order'] = in_array( $order, array( 'ASC', 'DESC' ), true ) ? $order : 'DESC';
         $meta_key = '';

--- a/mon-affichage-article/includes/rest/class-my-articles-controller.php
+++ b/mon-affichage-article/includes/rest/class-my-articles-controller.php
@@ -110,6 +110,11 @@ class My_Articles_Controller extends WP_REST_Controller {
                 'required'          => false,
                 'sanitize_callback' => 'sanitize_text_field',
             ),
+            'sort'        => array(
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => 'sanitize_key',
+            ),
         );
     }
 
@@ -145,6 +150,11 @@ class My_Articles_Controller extends WP_REST_Controller {
                 'type'              => 'string',
                 'required'          => false,
                 'sanitize_callback' => 'sanitize_text_field',
+            ),
+            'sort'        => array(
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => 'sanitize_key',
             ),
         );
     }
@@ -239,6 +249,7 @@ class My_Articles_Controller extends WP_REST_Controller {
                 'current_url'  => $request->get_param( 'current_url' ),
                 'http_referer' => $request->get_header( 'referer' ),
                 'search'       => $request->get_param( 'search' ),
+                'sort'         => $request->get_param( 'sort' ),
             )
         );
 
@@ -270,6 +281,7 @@ class My_Articles_Controller extends WP_REST_Controller {
                 'pinned_ids'  => $request->get_param( 'pinned_ids' ),
                 'category'    => $request->get_param( 'category' ),
                 'search'      => $request->get_param( 'search' ),
+                'sort'        => $request->get_param( 'sort' ),
             )
         );
 

--- a/tests/MyArticlesSettingsSanitizeTest.php
+++ b/tests/MyArticlesSettingsSanitizeTest.php
@@ -189,4 +189,36 @@ final class MyArticlesSettingsSanitizeTest extends TestCase
             'Allowed ratios should survive normalization.'
         );
     }
+
+    public function test_normalize_instance_options_applies_requested_sort_to_orderby(): void
+    {
+        $normalized = My_Articles_Shortcode::normalize_instance_options(
+            array(
+                'orderby' => 'date',
+                'sort' => 'date',
+                'meta_key' => '',
+            ),
+            array('requested_sort' => 'comment_count')
+        );
+
+        self::assertSame('comment_count', $normalized['orderby']);
+        self::assertSame('comment_count', $normalized['sort']);
+    }
+
+    public function test_normalize_instance_options_falls_back_when_sort_requires_meta_key(): void
+    {
+        $defaults = My_Articles_Shortcode::get_default_options();
+
+        $normalized = My_Articles_Shortcode::normalize_instance_options(
+            array(
+                'orderby' => 'date',
+                'sort' => 'date',
+                'meta_key' => '',
+            ),
+            array('requested_sort' => 'meta_value')
+        );
+
+        self::assertSame($defaults['orderby'], $normalized['orderby']);
+        self::assertSame($defaults['sort'], $normalized['sort']);
+    }
 }

--- a/tests/Rest/ControllerRoutesTest.php
+++ b/tests/Rest/ControllerRoutesTest.php
@@ -47,6 +47,7 @@ final class ControllerRoutesTest extends TestCase
                         'next_page'   => 2,
                         'pinned_ids'  => '1,2',
                         'search_query' => 'hello world',
+                        'sort'        => 'comment_count',
                     );
                 },
             )
@@ -59,6 +60,7 @@ final class ControllerRoutesTest extends TestCase
         $request->set_param('category', 'news');
         $request->set_param('current_url', 'http://example.com/page');
         $request->set_param('search', ' hello   world ');
+        $request->set_param('sort', 'comment_count');
 
         $response = $controller->filter_articles($request);
 
@@ -70,6 +72,7 @@ final class ControllerRoutesTest extends TestCase
                 'next_page'   => 2,
                 'pinned_ids'  => '1,2',
                 'search_query' => 'hello world',
+                'sort'        => 'comment_count',
             ),
             $response->get_data()
         );
@@ -81,6 +84,7 @@ final class ControllerRoutesTest extends TestCase
                 'current_url'  => 'http://example.com/page',
                 'http_referer' => 'http://example.com/ref',
                 'search'       => ' hello   world ',
+                'sort'         => 'comment_count',
             ),
             $capturedArgs
         );
@@ -143,6 +147,7 @@ final class ControllerRoutesTest extends TestCase
                         'total_pages' => 5,
                         'next_page'   => 4,
                         'search_query' => 'top stories',
+                        'sort'        => 'title',
                     );
                 },
             )
@@ -155,6 +160,7 @@ final class ControllerRoutesTest extends TestCase
         $request->set_param('pinned_ids', '1,2,3');
         $request->set_param('category', 'featured');
         $request->set_param('search', 'top stories');
+        $request->set_param('sort', 'title');
 
         $response = $controller->load_more_articles($request);
 
@@ -166,6 +172,7 @@ final class ControllerRoutesTest extends TestCase
                 'total_pages' => 5,
                 'next_page'   => 4,
                 'search_query' => 'top stories',
+                'sort'        => 'title',
             ),
             $response->get_data()
         );
@@ -176,6 +183,7 @@ final class ControllerRoutesTest extends TestCase
                 'pinned_ids'  => '1,2,3',
                 'category'    => 'featured',
                 'search'      => 'top stories',
+                'sort'        => 'title',
             ),
             $capturedArgs
         );


### PR DESCRIPTION
## Summary
- extend shortcode, REST controller, and plugin entry to support new sort parameter values including comment_count and post__in
- expose sort selection in block attributes, editor UI, and admin metabox while syncing defaults with existing orderby handling
- propagate the selected sort through front-end filtering and load-more flows and add PHP/Jest coverage for the new behavior

## Testing
- npm test
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e267e0d1e8832ea3154df7c566a861