### PR TITLE
Add instrumentation events and tracking options

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -1267,6 +1267,13 @@ class My_Articles_Shortcode {
         $load_more_rest_endpoint   = esc_url_raw( rest_url( 'my-articles/v1/load-more' ) );
         $nonce_refresh_endpoint    = esc_url_raw( rest_url( 'my-articles/v1/nonce' ) );
 
+        $global_instrumentation = my_articles_get_instrumentation_settings();
+        $instrumentation_payload = array(
+            'enabled' => ! empty( $global_instrumentation['enabled'] ),
+            'channel' => $global_instrumentation['channel'],
+            'fetchUrl' => esc_url_raw( rest_url( 'my-articles/v1/track' ) ),
+        );
+
         if ( ! empty( $options['show_category_filter'] ) || ! empty( $options['enable_keyword_search'] ) ) {
             wp_enqueue_script('my-articles-filter', MY_ARTICLES_PLUGIN_URL . 'assets/js/filter.js', ['jquery'], MY_ARTICLES_VERSION, true);
             wp_localize_script(
@@ -1281,6 +1288,7 @@ class My_Articles_Shortcode {
                     'countSingle' => __( '%s article affiché.', 'mon-articles' ),
                     'countPlural' => __( '%s articles affichés.', 'mon-articles' ),
                     'countNone'   => __( 'Aucun article à afficher.', 'mon-articles' ),
+                    'instrumentation' => $instrumentation_payload,
                 ]
             );
         }
@@ -1304,6 +1312,7 @@ class My_Articles_Shortcode {
                     'addedPlural'  => __( '%s articles ajoutés.', 'mon-articles' ),
                     'noAdditional' => __( 'Aucun article supplémentaire.', 'mon-articles' ),
                     'none'         => __( 'Aucun article à afficher.', 'mon-articles' ),
+                    'instrumentation' => $instrumentation_payload,
                 ]
             );
         }

--- a/mon-affichage-article/includes/helpers.php
+++ b/mon-affichage-article/includes/helpers.php
@@ -317,3 +317,41 @@ if ( ! function_exists( 'my_articles_calculate_total_pages' ) ) {
         ];
     }
 }
+
+if ( ! function_exists( 'my_articles_get_instrumentation_settings' ) ) {
+    /**
+     * Retrieve instrumentation settings saved in the plugin options.
+     *
+     * @return array{enabled:bool,channel:string} Normalized instrumentation configuration.
+     */
+    function my_articles_get_instrumentation_settings() {
+        $options = (array) get_option( 'my_articles_options', array() );
+
+        $enabled = ! empty( $options['instrumentation_enabled'] );
+        $allowed_channels = array( 'console', 'dataLayer', 'fetch' );
+
+        $channel = isset( $options['instrumentation_channel'] ) ? (string) $options['instrumentation_channel'] : 'console';
+
+        if ( ! in_array( $channel, $allowed_channels, true ) ) {
+            $channel = 'console';
+        }
+
+        return array(
+            'enabled' => $enabled,
+            'channel' => $channel,
+        );
+    }
+}
+
+if ( ! function_exists( 'my_articles_is_instrumentation_enabled' ) ) {
+    /**
+     * Determine whether instrumentation is enabled globally for the plugin.
+     *
+     * @return bool
+     */
+    function my_articles_is_instrumentation_enabled() {
+        $settings = my_articles_get_instrumentation_settings();
+
+        return ! empty( $settings['enabled'] );
+    }
+}

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -530,6 +530,21 @@ public function prepare_filter_articles_response( array $args ) {
             )
         );
 
+        if ( my_articles_is_instrumentation_enabled() ) {
+            do_action(
+                'my_articles_track_interaction',
+                'filter_response',
+                array(
+                    'instance_id'  => $instance_id,
+                    'category'     => $active_category,
+                    'search_query' => $options['search_query'],
+                    'sort'         => $options['sort'],
+                    'total_pages'  => $total_pages,
+                    'next_page'    => $next_page,
+                )
+            );
+        }
+
         return $response;
     }
 
@@ -756,6 +771,22 @@ public function prepare_load_more_articles_response( array $args ) {
                 )
             )
         );
+
+        if ( my_articles_is_instrumentation_enabled() ) {
+            do_action(
+                'my_articles_track_interaction',
+                'load_more_response',
+                array(
+                    'instance_id'  => $instance_id,
+                    'category'     => $active_category,
+                    'search_query' => $options['search_query'],
+                    'sort'         => $options['sort'],
+                    'requested_page' => $paged,
+                    'next_page'    => $response['next_page'],
+                    'total_pages'  => $response['total_pages'],
+                )
+            );
+        }
 
         return $response;
     }


### PR DESCRIPTION
## Summary
- emit lifecycle events in the filter and load more scripts with optional instrumentation channels
- add instrumentation settings in the admin UI and expose configuration to localized scripts plus REST tracking endpoint
- trigger a PHP action for server-side consumers, extend the README, and cover the new behavior with unit tests

## Testing
- npm run test:js

------
https://chatgpt.com/codex/tasks/task_e_68e2764b1fb8832e943b2001d1a7fc55