### PR TITLE
Add tutorial tab explaining instrumentation options

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-settings.php
+++ b/mon-affichage-article/includes/class-my-articles-settings.php
@@ -35,25 +35,69 @@ class My_Articles_Settings {
     }
 
     public function create_admin_page() {
+        $active_tab = isset( $_GET['tab'] ) ? sanitize_key( wp_unslash( $_GET['tab'] ) ) : 'settings';
+        $allowed_tabs = array( 'settings', 'tutorial' );
+
+        if ( ! in_array( $active_tab, $allowed_tabs, true ) ) {
+            $active_tab = 'settings';
+        }
+
         ?>
         <div class="wrap">
             <h1><?php esc_html_e( 'Réglages Tuiles - LCV', 'mon-articles' ); ?></h1>
             <div style="margin-bottom: 20px;">
-                <p style="margin: 0;"><strong>Auteur :</strong> LCV</p>
-                <p style="margin: 0;"><strong>Version :</strong> <?php echo esc_html( MY_ARTICLES_VERSION ); ?></p>
+                <p style="margin: 0;"><strong><?php esc_html_e( 'Auteur :', 'mon-articles' ); ?></strong> LCV</p>
+                <p style="margin: 0;"><strong><?php esc_html_e( 'Version :', 'mon-articles' ); ?></strong> <?php echo esc_html( MY_ARTICLES_VERSION ); ?></p>
             </div>
-            <p><?php esc_html_e( 'Utilisez le shortcode [mon_affichage_articles id="123"] pour afficher les articles. Vous pouvez récupérer l\'identifiant dans la metabox « Shortcode à utiliser ».', 'mon-articles' ); ?></p>
-            
-            <form method="post" action="options.php">
-                <?php settings_fields( $this->option_group ); do_settings_sections( 'my-articles-admin' ); submit_button(); ?>
-            </form>
-            <hr>
-            <h2><?php esc_html_e( 'Maintenance', 'mon-articles' ); ?></h2>
-            <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display: inline-block;">
-                <input type="hidden" name="action" value="my_articles_reset_settings">
-                <?php wp_nonce_field( 'my_articles_reset_settings_nonce' ); ?>
-                <?php submit_button( __( 'Réinitialiser les réglages', 'mon-articles' ), 'delete', 'submit', false, ['onclick' => 'return confirm("Êtes-vous sûr de vouloir réinitialiser tous les réglages ?");'] ); ?>
-            </form>
+
+            <h2 class="nav-tab-wrapper">
+                <a href="<?php echo esc_url( add_query_arg( array( 'page' => 'my-articles-settings', 'tab' => 'settings' ), admin_url( 'admin.php' ) ) ); ?>" class="nav-tab <?php echo 'settings' === $active_tab ? 'nav-tab-active' : ''; ?>">
+                    <?php esc_html_e( 'Réglages', 'mon-articles' ); ?>
+                </a>
+                <a href="<?php echo esc_url( add_query_arg( array( 'page' => 'my-articles-settings', 'tab' => 'tutorial' ), admin_url( 'admin.php' ) ) ); ?>" class="nav-tab <?php echo 'tutorial' === $active_tab ? 'nav-tab-active' : ''; ?>">
+                    <?php esc_html_e( 'Tutoriel', 'mon-articles' ); ?>
+                </a>
+            </h2>
+
+            <?php if ( 'tutorial' === $active_tab ) : ?>
+                <div class="my-articles-tutorial">
+                    <h2><?php esc_html_e( 'Instrumentation : comprendre ce que vous activez', 'mon-articles' ); ?></h2>
+                    <p><?php esc_html_e( 'La section « Instrumentation » vous permet de suivre ce que font les utilisateurs dans vos tuiles (filtrage, chargement progressif, etc.). En activant l’option, le plugin publie automatiquement des événements JavaScript qui décrivent chaque étape de ces interactions (requête, succès, erreur).', 'mon-articles' ); ?></p>
+
+                    <h3><?php esc_html_e( 'Choisir le canal de sortie', 'mon-articles' ); ?></h3>
+                    <ul>
+                        <li><strong><?php esc_html_e( 'Console du navigateur', 'mon-articles' ); ?></strong> — <?php esc_html_e( 'les événements sont simplement journalisés pour le débogage.', 'mon-articles' ); ?></li>
+                        <li><strong><?php esc_html_e( 'dataLayer', 'mon-articles' ); ?></strong> — <?php esc_html_e( 'les événements sont poussés dans window.dataLayer, idéal avec Google Tag Manager ou un outil d’analytics similaire.', 'mon-articles' ); ?></li>
+                        <li><strong><?php esc_html_e( 'fetch', 'mon-articles' ); ?></strong> — <?php esc_html_e( 'chaque événement est envoyé en POST JSON vers l’endpoint REST wp-json/my-articles/v1/track pour un traitement serveur ou une redirection vers un service tiers.', 'mon-articles' ); ?></li>
+                    </ul>
+
+                    <h3><?php esc_html_e( 'Utilisation côté front-end', 'mon-articles' ); ?></h3>
+                    <p><?php esc_html_e( 'Une fois l’instrumentation activée, la configuration est disponible dans window.myArticlesFilter.instrumentation et window.myArticlesLoadMore.instrumentation. Deux événements personnalisés sont émis :', 'mon-articles' ); ?></p>
+                    <ul>
+                        <li><code>my-articles:filter</code></li>
+                        <li><code>my-articles:load-more</code></li>
+                    </ul>
+                    <p><?php esc_html_e( 'Chaque événement possède un objet detail indiquant la phase (request, success, error), l’instance concernée, les paramètres de filtrage et des informations additionnelles (pages totales, nombre d’éléments ajoutés, etc.). Vous pouvez y réagir pour afficher des messages, alimenter votre outil d’analyse ou déclencher d’autres actions.', 'mon-articles' ); ?></p>
+
+                    <h3><?php esc_html_e( 'Traitement côté serveur (optionnel)', 'mon-articles' ); ?></h3>
+                    <p><?php esc_html_e( 'Avec le canal « fetch », les événements sont également disponibles via l’action WordPress my_articles_track_interaction. C’est l’occasion de connecter facilement votre solution de monitoring ou d’analytics existante.', 'mon-articles' ); ?></p>
+
+                    <p><?php esc_html_e( 'En résumé, cette section vous offre un moyen simple de suivre, analyser et rediriger les interactions des utilisateurs avec vos tuiles, sans code supplémentaire.', 'mon-articles' ); ?></p>
+                </div>
+            <?php else : ?>
+                <p><?php esc_html_e( 'Utilisez le shortcode [mon_affichage_articles id="123"] pour afficher les articles. Vous pouvez récupérer l\'identifiant dans la metabox « Shortcode à utiliser ».', 'mon-articles' ); ?></p>
+
+                <form method="post" action="options.php">
+                    <?php settings_fields( $this->option_group ); do_settings_sections( 'my-articles-admin' ); submit_button(); ?>
+                </form>
+                <hr>
+                <h2><?php esc_html_e( 'Maintenance', 'mon-articles' ); ?></h2>
+                <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display: inline-block;">
+                    <input type="hidden" name="action" value="my_articles_reset_settings">
+                    <?php wp_nonce_field( 'my_articles_reset_settings_nonce' ); ?>
+                    <?php submit_button( __( 'Réinitialiser les réglages', 'mon-articles' ), 'delete', 'submit', false, ['onclick' => 'return confirm("' . esc_js( __( 'Êtes-vous sûr de vouloir réinitialiser tous les réglages ?', 'mon-articles' ) ) . '");'] ); ?>
+                </form>
+            <?php endif; ?>
         </div>
         <?php
     }


### PR DESCRIPTION
## Summary
- add navigation tabs to the admin settings page to host documentation content
- document instrumentation options and workflows in a dedicated tutorial tab

## Testing
- php -l mon-affichage-article/includes/class-my-articles-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68e2d2759bc0832e928f0539456aa26e