### PR TITLE
Fix cache invalidation handler signature

### DIFF
--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -1078,7 +1078,7 @@ public function prepare_load_more_articles_response( array $args ) {
         }
     }
 
-    public function handle_clean_object_term_cache_invalidation( $object_ids, $taxonomies, $clean_terms ) {
+    public function handle_clean_object_term_cache_invalidation( $object_ids, $taxonomies, $clean_terms = true ) {
         if ( empty( $object_ids ) ) {
             return;
         }


### PR DESCRIPTION
## Summary
- make the clean object term cache invalidation handler compatible with hooks that provide only two parameters

## Testing
- php -l mon-affichage-article/mon-affichage-articles.php

------
https://chatgpt.com/codex/tasks/task_e_68e2e0f2cfbc832eb46421a86a89f3e5