### PR TITLE
Prevent REST load-more failure caused by color sanitization

### DIFF
--- a/mon-affichage-article/includes/helpers.php
+++ b/mon-affichage-article/includes/helpers.php
@@ -15,6 +15,10 @@ if ( ! function_exists( 'my_articles_sanitize_color' ) ) {
     function my_articles_sanitize_color( $color, $default = '' ) {
         if ( is_string( $color ) ) {
             $color = trim( $color );
+        } elseif ( is_numeric( $color ) ) {
+            $color = (string) $color;
+        } else {
+            return $default;
         }
 
         if ( preg_match(


### PR DESCRIPTION
## Summary
- guard `my_articles_sanitize_color` against non-string values before attempting regex validation, ensuring REST callbacks no longer fatal when they receive unexpected data

## Testing
- composer test *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fc06d254832eb4c003a5b8f4f798