### PR TITLE
docs: détailler les axes UX/UI prioritaires

### DIFF
--- a/docs/comparaison-apps-pro.md
+++ b/docs/comparaison-apps-pro.md
@@ -45,4 +45,27 @@ Ce mémo met en parallèle **Tuiles – LCV** avec des extensions WordPress prof
 6. **Personnalisation des parcours**
    - Exploiter l'action `my_articles_track_interaction` pour introduire des règles de personnalisation (par exemple, remonter les contenus les plus cliqués, adapter l'ordre selon le profil utilisateur). Couplé à un cache segmenté, cela amènerait des capacités de « smart listing » recherchées dans les outils pro.【F:mon-affichage-article/includes/class-my-articles-settings.php†L62-L140】【F:mon-affichage-article/includes/class-my-articles-shortcode.php†L397-L440】
 
+### Focus UX/UI détaillé
+
+#### 1. Sélecteur visuel et onboarding
+Dans l'inspecteur Gutenberg, le choix du preset se limite à une simple liste déroulante `SelectControl` sans illustration ni catégories d'usage, et c'est également le cas pour la sélection du mode (grille/liste/slider) qui dépend d'autres menus textuels.【F:mon-affichage-article/blocks/mon-affichage-articles/edit.js†L806-L881】 Une expérience plus professionnelle passerait par :
+
+- **Panneau modal de découverte** : déclencher un panneau pleine largeur présentant chaque preset sous forme de vignette avec aperçu direct (mobile/tablette/desktop) et tags d'usage (« Editorial », « E-commerce », « Slider »). L'utilisateur y choisirait aussi le mode initial pour gagner un clic.
+- **Filtres et recherche** : ajouter des filtres contextuels (ex. « mode sombre », « compatible autoplay », « mise en avant d'auteurs ») appuyés sur des métadonnées stockées dans un registre JSON des presets pour se rapprocher du fonctionnement d'Essential Grid ou WP Grid Builder.
+- **Parcours d'onboarding** : proposer une visite guidée après insertion du bloc (tooltip séquentiel sur les contrôles clés, rappel des limitations quand un preset verrouille des options) afin d'accélérer la prise en main par les équipes non techniques.
+
+#### 2. Prévisualisation locale thémée
+La prévisualisation actuelle repose sur un appel REST qui renvoie le HTML public, injecté tel quel dans l'éditeur Gutenberg via `dangerouslySetInnerHTML`, sans appliquer les styles du thème actif ni simuler les variations responsive dans l'interface.【F:mon-affichage-article/blocks/mon-affichage-articles/preview.js†L64-L205】【F:mon-affichage-article/blocks/mon-affichage-articles/preview.js†L224-L294】 Pour se rapprocher des solutions premium :
+
+- **Mode « édition rapide »** : rendre les composants internes éditables directement dans l'éditeur (drag & drop des blocs enfant, ajustement instantané des espacements, sélection de palettes). Ce mode pourrait s'appuyer sur un rendu React local plutôt que sur la réponse HTML statique.
+- **Injection des styles du thème** : charger dynamiquement les feuilles de style globales du thème (ou une sélection de tokens) dans la preview et exposer un switch « Palette thème / Palette bloc » pour valider la cohérence graphique avant publication.
+- **Simulateur responsive** : intégrer un contrôleur de viewport (Mobile/Tablet/Desktop) et une bascule « Mode sombre » afin d'aligner la preview avec les parcours d'audit UX observés dans les outils pro.
+
+#### 3. Micro-interactions et états vides
+La feuille de style front assure les fondamentaux (squelettes animés, transitions d'opacité, variations grille/liste), mais aucune option ne permet de personnaliser ces micro-interactions ou de définir un état vide riche (CTA, recommandations, intégrations marketing).【F:mon-affichage-article/assets/css/styles.css†L1-L120】【F:mon-affichage-article/includes/class-my-articles-shortcode.php†L1955-L2046】 Les pistes à couvrir :
+
+- **Animations conditionnelles** : exposer des réglages pour choisir le type d'animation (fondu, slide, scale), définir la durée par breakpoint et respecter automatiquement `prefers-reduced-motion` en désactivant les transitions par défaut.
+- **État vide scénarisé** : permettre d'ajouter un bouton d'action, une liste d'articles suggérés ou un formulaire d'abonnement lorsque la requête ne retourne aucun contenu, plutôt que le simple message statique généré actuellement.
+- **Feedbacks interactifs** : intégrer des micro-effets (hover avec élévation, focus accentué, lottie ou icônes animées pour les badges) et des réglages d'accessibilité associés (contraste renforcé, annonce ARIA personnalisée) pour se rapprocher du niveau de finition des produits concurrents.
+
 En priorisant ces axes, Tuiles – LCV pourra rivaliser plus sereinement avec les extensions professionnelles, tant sur le confort d'utilisation que sur la richesse fonctionnelle attendue par les équipes marketing et éditoriales exigeantes.


### PR DESCRIPTION
## Summary
- add a dedicated "Focus UX/UI" section to détailed comparison notes
- describe improvements for preset selection, themed preview, and micro-interactions with actionable suggestions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e381f43a04832e9a21d5d9c0fe2bb2