### PR TITLE
Fix pinned article search fallback

### DIFF
--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -900,6 +900,14 @@ public function prepare_load_more_articles_response( array $args ) {
         $post_type   = isset( $args['post_type'] ) ? sanitize_key( $args['post_type'] ) : '';
 
         if ( '' === $post_type || ! post_type_exists( $post_type ) ) {
+            $normalized_post_type = my_articles_normalize_post_type( $post_type );
+
+            if ( '' !== $normalized_post_type ) {
+                $post_type = $normalized_post_type;
+            }
+        }
+
+        if ( '' === $post_type || ! post_type_exists( $post_type ) ) {
             return new WP_Error(
                 'my_articles_invalid_post_type',
                 __( 'Type de contenu invalide.', 'mon-articles' ),


### PR DESCRIPTION
## Summary
- ensure the pinned article search falls back to a valid selectable post type when the request omits or passes an invalid type
- reset admin ajax test fixtures for GET data and WP_Query stubs and add coverage for the new fallback behaviour

## Testing
- php vendor/phpunit/phpunit/phpunit -c phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68e439f0e968832ea602c57f11b8ccf1