### PR TITLE
Expose pagination metadata for analytics

### DIFF
--- a/mon-affichage-article/assets/js/filter.js
+++ b/mon-affichage-article/assets/js/filter.js
@@ -1169,6 +1169,11 @@
                 renderedPinned = 0;
             }
 
+            var paginationMeta = null;
+            if (responseData && typeof responseData.pagination_meta === 'object' && responseData.pagination_meta !== null) {
+                paginationMeta = responseData.pagination_meta;
+            }
+
             emitFilterInteraction('success', $.extend({}, requestDetail, {
                 totalPages: totalPages,
                 nextPage: nextPage,
@@ -1181,7 +1186,8 @@
                 renderedRegularCount: renderedRegular,
                 renderedPinnedCount: renderedPinned,
                 totalRegular: parseInt(responseData.total_regular, 10) || 0,
-                totalPinned: parseInt(responseData.total_pinned, 10) || 0
+                totalPinned: parseInt(responseData.total_pinned, 10) || 0,
+                pagination: paginationMeta
             }));
         }
 

--- a/mon-affichage-article/assets/js/load-more.js
+++ b/mon-affichage-article/assets/js/load-more.js
@@ -1213,6 +1213,9 @@
             instrumentationDetail.totalRegular = parseInt(responseData.total_regular, 10) || 0;
             instrumentationDetail.totalPinned = parseInt(responseData.total_pinned, 10) || 0;
             instrumentationDetail.pinnedIds = typeof responseData.pinned_ids === 'string' ? responseData.pinned_ids : '';
+            if (responseData && typeof responseData.pagination_meta === 'object' && responseData.pagination_meta !== null) {
+                instrumentationDetail.pagination = responseData.pagination_meta;
+            }
             instrumentationDetail.hadNonceRefresh = hasRetried;
             instrumentationDetail.errorMessage = '';
             instrumentationDetail.status = 0;

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -913,6 +913,8 @@ JS;
             'effective_posts_per_page'    => $effective_posts_per_page,
             'is_unlimited'                => $is_unlimited,
             'updated_seen_pinned_ids'     => $updated_seen_pinned,
+            'unlimited_batch_size'        => $batch_cap,
+            'should_enforce_unlimited'    => (bool) $should_enforce_unlimited,
         );
     }
 
@@ -1978,10 +1980,20 @@ JS;
                 $total_regular_posts = (int) $count_query->found_posts;
             }
 
+            $pagination_context = array(
+                'current_page' => $paged,
+            );
+
+            if ( ! empty( $state['is_unlimited'] ) ) {
+                $pagination_context['unlimited_page_size'] = $state['unlimited_batch_size'];
+                $pagination_context['analytics_page_size'] = $state['unlimited_batch_size'];
+            }
+
             $pagination_totals = my_articles_calculate_total_pages(
                 $total_matching_pinned,
                 $total_regular_posts,
-                $effective_posts_per_page
+                $effective_posts_per_page,
+                $pagination_context
             );
             $total_pages = $pagination_totals['total_pages'];
 

--- a/tests/CalculateTotalPagesTest.php
+++ b/tests/CalculateTotalPagesTest.php
@@ -44,6 +44,28 @@ final class CalculateTotalPagesTest extends TestCase
             $result['next_page'] ?? null,
             'Unexpected next page index returned by my_articles_calculate_total_pages().'
         );
+
+        self::assertIsArray(
+            $result['meta'] ?? null,
+            'Expected pagination metadata to be exposed.'
+        );
+
+        $meta = $result['meta'];
+
+        self::assertSame(
+            $pinned + $regular,
+            $meta['total_items'] ?? null,
+            'Pagination metadata should report the total item count.'
+        );
+
+        self::assertArrayHasKey('first_page', $meta);
+        self::assertIsArray($meta['first_page']);
+        self::assertArrayHasKey('projected_total_pages', $meta);
+        self::assertSame(
+            $expectedPages,
+            $meta['projected_total_pages'] ?? null,
+            'Expected projected_total_pages to align with total_pages when no analytics override is provided.'
+        );
     }
 
     /**
@@ -55,7 +77,7 @@ final class CalculateTotalPagesTest extends TestCase
         yield 'pinned and regular fit first page' => array(1, 5, 4, 2, 2);
         yield 'pinned overflow onto extra page' => array(5, 0, 3, 2, 2);
         yield 'regular backlog after pinned content' => array(2, 10, 3, 4, 2);
-        yield 'unlimited layout still reports single page' => array(2, 3, 0, 1, 0);
+        yield 'unlimited layout reports unbounded' => array(2, 3, 0, 0, 0);
         yield 'pinned fill first page regular still pending' => array(4, 5, 4, 3, 2);
     }
 
@@ -67,7 +89,7 @@ final class CalculateTotalPagesTest extends TestCase
 
         \add_filter(
             'my_articles_calculate_total_pages',
-            static function (array $result, int $pinned, int $regular, int $perPage): array {
+            static function (array $result, int $pinned, int $regular, int $perPage, array $context = array()): array {
                 if (0 === $perPage) {
                     $result['total_pages'] = $pinned + $regular;
                 }
@@ -75,7 +97,7 @@ final class CalculateTotalPagesTest extends TestCase
                 return $result;
             },
             10,
-            4
+            5
         );
 
         $result = \my_articles_calculate_total_pages(2, 3, 0);
@@ -84,5 +106,44 @@ final class CalculateTotalPagesTest extends TestCase
         self::assertSame(0, $result['next_page']);
 
         $mon_articles_test_filters = array();
+    }
+
+    public function test_calculate_total_pages_reports_metadata_breakdown(): void
+    {
+        $result = \my_articles_calculate_total_pages(3, 7, 4, array('current_page' => 1));
+
+        $meta = $result['meta'] ?? array();
+
+        self::assertSame(10, $meta['total_items'] ?? null);
+        self::assertSame(3, $meta['first_page']['pinned'] ?? null);
+        self::assertSame(1, $meta['first_page']['regular'] ?? null);
+        self::assertSame(6, $meta['remaining_items'] ?? null);
+        self::assertSame(6, $meta['remaining_regular'] ?? null);
+        self::assertSame(0, $meta['remaining_pinned'] ?? null);
+        self::assertArrayHasKey('is_unbounded', $meta);
+        self::assertFalse($meta['is_unbounded']);
+    }
+
+    public function test_calculate_total_pages_supports_unlimited_projection(): void
+    {
+        $result = \my_articles_calculate_total_pages(
+            2,
+            6,
+            0,
+            array(
+                'current_page' => 1,
+                'unlimited_page_size' => 4,
+            )
+        );
+
+        $meta = $result['meta'] ?? array();
+
+        self::assertSame(0, $result['total_pages']);
+        self::assertTrue($meta['is_unbounded'] ?? false);
+        self::assertSame(8, $meta['total_items'] ?? null);
+        self::assertArrayHasKey('projected_page_size', $meta);
+        self::assertSame(4, $meta['projected_page_size']);
+        self::assertSame(2, $meta['projected_total_pages'] ?? null);
+        self::assertSame(4, $meta['projected_remaining_items'] ?? null);
     }
 }


### PR DESCRIPTION
## Summary
- enrich `my_articles_calculate_total_pages()` with contextual metadata, unbounded pagination handling, and projected counts
- propagate pagination metadata through shortcode responses and load-more/filter endpoints, surfacing it to JS instrumentation hooks
- extend PHPUnit coverage to exercise the new metadata contract and unlimited scenarios

## Testing
- vendor/bin/phpunit --configuration phpunit.xml.dist
- npm test -- --runTestsByPath mon-affichage-article/assets/js/__tests__/load-more.test.js mon-affichage-article/assets/js/__tests__/filter.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e4de071be0832ebccf73b124b182d8