### PR TITLE
Improve load more diagnostics and loading experience

### DIFF
--- a/mon-affichage-article/assets/css/styles.css
+++ b/mon-affichage-article/assets/css/styles.css
@@ -105,6 +105,20 @@
     pointer-events: none;
 }
 
+.my-articles-wrapper.is-loading.is-loading-more .my-articles-skeleton {
+    display: none;
+}
+
+.my-articles-wrapper.is-loading.is-loading-more .my-articles-grid-content,
+.my-articles-wrapper.is-loading.is-loading-more .my-articles-list-content {
+    opacity: 1;
+}
+
+.my-articles-wrapper.is-loading.is-loading-more .my-articles-grid-content .my-article-item,
+.my-articles-wrapper.is-loading.is-loading-more .my-articles-list-content .my-article-item {
+    pointer-events: auto;
+}
+
 .my-articles-skeleton--grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(var(--my-articles-min-card-width), 1fr));


### PR DESCRIPTION
## Summary
- add a configurable debug logger for load-more interactions that can be toggled via `myArticlesDebug`
- log request lifecycle metadata to surface AJAX errors when the console would otherwise be silent
- prevent the load-more loading state from hiding existing articles by adjusting the `is-loading-more` styles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e54be690b8832ea0a5031edfd5824e