### PR TITLE
Handle missing load-more endpoint gracefully

### DIFF
--- a/mon-affichage-article/assets/js/__tests__/load-more.test.js
+++ b/mon-affichage-article/assets/js/__tests__/load-more.test.js
@@ -396,4 +396,37 @@ describe('load-more endpoint interactions', () => {
         expect(feedback).not.toBeNull();
         expect(feedback.classList.contains('is-error')).toBe(false);
     });
+
+    it('surfaces a clear error when no endpoint is configured', () => {
+        window.myArticlesLoadMore.endpoint = '';
+        window.myArticlesLoadMore.restRoot = '';
+        window.myArticlesLoadMore.errorText = 'Configuration manquante.';
+
+        const events = [];
+        const handler = (event) => events.push(event.detail);
+        window.addEventListener('my-articles:load-more', handler);
+
+        $.ajax = jest.fn();
+
+        require('../load-more');
+
+        const button = $('.my-articles-load-more-btn');
+
+        expect(() => {
+            button.trigger('click');
+        }).not.toThrow();
+
+        expect($.ajax).not.toHaveBeenCalled();
+
+        const feedback = document.querySelector('.my-articles-feedback');
+        expect(feedback).not.toBeNull();
+        expect(feedback.textContent).toBe('Configuration manquante.');
+
+        expect(events).toHaveLength(1);
+        expect(events[0].phase).toBe('error');
+        expect(events[0].errorMessage).toBe('missing-endpoint');
+        expect(events[0].displayMessage).toBe('Configuration manquante.');
+
+        window.removeEventListener('my-articles:load-more', handler);
+    });
 });


### PR DESCRIPTION
## Summary
- prevent the load-more UI from throwing when no REST endpoint is configured
- surface a user-facing message and instrumentation metadata for the missing-endpoint case
- add a regression test covering the configuration error scenario

## Testing
- npm test
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e551def498832e9401ca5b0e935385