### PR TITLE
docs: structurer la roadmap des améliorations

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,16 @@ Pour valider la gestion d'un identifiant d'instance invalide lors des appels AJA
 - **Tableau de bord des performances** : exposer des métriques (temps de réponse des endpoints, taux d'erreur, usages des modes d'affichage) directement dans la page « Instrumentation » pour faciliter le suivi.
 - **Accessibilité renforcée** : intégrer des scénarios de tests automatisés (axe-core, pa11y) dans la CI pour garantir la conformité des évolutions futures.
 
+### Roadmap synthétique
+
+| Horizon | Objectifs clés | Leviers associés |
+| --- | --- | --- |
+| **0-3 mois** | Séparer la préparation des requêtes, introduire un cache dédié et fiabiliser les rendus côté bloc. | Refonte de `My_Articles_Shortcode::render_shortcode()`, découplage de `build_display_state()` et normalisation de `render_block()`. |
+| **3-6 mois** | Industrialiser l'expérience éditeur (préréglages enrichis, filtres avancés) et préparer l'observabilité. | Galerie de presets avec métadonnées, extension des filtres front office, instrumentation exportable. |
+| **6-12 mois** | Offrir des intégrations enterprise (sources externes, analytics enrichi) et un monitoring temps réel. | Adaptateurs de contenus multiples, tableau de bord de performances et connecteurs Segment/Adobe. |
+
+Consultez `docs/roadmap-technique.md` pour une version détaillée des chantiers, des dépendances et des prérequis.
+
 ## Crédits
 
 Développé par LCV.

--- a/docs/fonctions-a-ameliorer.md
+++ b/docs/fonctions-a-ameliorer.md
@@ -64,6 +64,16 @@ Cette note recense les fonctions qui méritent une refonte pour se rapprocher de
   - Exposer un filtre `my_articles_calculate_total_pages` pour surcharger le calcul.
   - Fournir en sortie des métadonnées supplémentaires (total potentiels, taille restante) pour alimenter des dashboards ou un tracking front avancé.
 
+## 7. `My_Articles_Block::render_block()`
+- **Localisation** : `mon-affichage-article/includes/class-my-articles-block.php`
+- **Problèmes constatés** :
+  - Le bloc délègue directement au shortcode sans différencier les besoins éditeur (aperçu rapide, validation) du rendu frontal, ce qui empêche l'optimisation spécifique au mode preview.【F:mon-affichage-article/includes/class-my-articles-block.php†L32-L62】
+  - La conversion des attributs en overrides dépend d'une liste statique et mélange normalisation et typage, compliquant l'ajout d'options dynamiques et les tests unitaires.【F:mon-affichage-article/includes/class-my-articles-block.php†L64-L123】
+- **Pistes d'amélioration** :
+  - Introduire un adaptateur dédié au bloc afin de pouvoir court-circuiter la requête et injecter des données fictives lors de la prévisualisation dans Gutenberg.
+  - Extraire la normalisation des attributs vers des stratégies typées (booléens, listes, nombres) et exposer des filtres pour autoriser des extensions sans modifier le cœur du bloc.
+  - Ajouter des tests unitaires ciblant `prepare_overrides_from_attributes()` pour sécuriser les conversions et prévenir les régressions lors de l'ajout de nouveaux attributs.
+
 ## Tests de diagnostic ajoutés
 
 - **`tests/CalculateTotalPagesTest.php`** : nouvelle série de scénarios couvrant les combinaisons d'articles épinglés et réguliers, y compris le cas « illimité ». Ces tests servent de filet de sécurité avant refonte et facilitent le repérage d'effets de bord sur la pagination.【F:tests/CalculateTotalPagesTest.php†L1-L54】

--- a/docs/roadmap-technique.md
+++ b/docs/roadmap-technique.md
@@ -1,0 +1,78 @@
+# Roadmap technique Tuiles – LCV
+
+Cette feuille de route découpe les chantiers identifiés dans le README et les notes techniques en lots activables. Chaque objectif renvoie vers les zones de code concernées pour faciliter la planification.
+
+## 0-3 mois — Stabilisation et découplage
+
+### 1. Externaliser la préparation des données du shortcode
+- **Portée** : `My_Articles_Shortcode::render_shortcode()` et `My_Articles_Shortcode::build_display_state()`.
+- **Cibles** : créer un service de préparation (cache + normalisation) et un gestionnaire d'enqueue partagé.
+- **Livrables** :
+  - Interface PHP décrivant les états de rendu et le contrat de cache.
+  - Gestionnaire d'assets mutualisé (`My_Articles_Enqueue`) et remplacement de `wp_localize_script` par `wp_add_inline_script`.
+- **Référence** : voir `docs/fonctions-a-ameliorer.md` sections 1 et 2.
+
+### 2. Normaliser le rendu du bloc Gutenberg
+- **Portée** : `My_Articles_Block::render_block()` et conversion des attributs.
+- **Cibles** : isoler la préparation des overrides, prévoir un mode « prévisualisation » et réduire la duplication avec le shortcode.
+- **Livrables** :
+  - Tests unitaires PHP couvrant `prepare_overrides_from_attributes()`.
+  - Hook/filter pour étendre les attributs pris en charge par le bloc.
+- **Référence** : voir `docs/fonctions-a-ameliorer.md` section 7.
+
+### 3. Mise en place d'un socle de tests
+- **Portée** : scénarios PHPUnit existants (`tests/CalculateTotalPagesTest.php`).
+- **Cibles** : ajouter des tests autour de la pagination slideshow, des articles épinglés et du bloc.
+- **Livrables** :
+  - Suite PHPUnit élargie et intégration GitHub Actions.
+  - Documentation `composer test` + `npm run test:js` dans le README (déjà présente) et rappels dans les PR templates.
+
+## 3-6 mois — Expérience éditeur et design
+
+### 4. Catalogue de préréglages enrichi
+- **Portée** : presets du shortcode et panneau Module dans le bloc.
+- **Cibles** : charger des préréglages depuis des fichiers JSON, ajouter métadonnées (thumbnails, tags) et synchronisation REST.
+- **Livrables** :
+  - Galerie visuelle dans l'éditeur (panel React) + API REST pour exporter/importer.
+  - Commande WP-CLI pour synchroniser les presets.
+- **Référence** : `docs/pistes-amelioration-design.md` section 2.
+
+### 5. Filtres front avancés
+- **Portée** : scripts de filtrage (`assets/js`) et panneau de configuration du bloc.
+- **Cibles** : introduire recherche multi-critères, chips contextuelles et animation de feedback.
+- **Livrables** :
+  - Nouvelle couche de configuration front (data registry) + instrumentation des événements.
+  - Tests d'accessibilité et de clavier pour les nouveaux composants.
+- **Référence** : `docs/pistes-amelioration-design.md` section 4.
+
+## 6-12 mois — Observabilité et intégrations
+
+### 6. Tableau de bord instrumentation
+- **Portée** : page « Instrumentation » et endpoints REST (`/track`).
+- **Cibles** : centraliser les métriques temps réel (latence, erreurs) et proposer des exportations vers Segment/Adobe.
+- **Livrables** :
+  - Collecte côté serveur (`my_articles_track_interaction`) enrichie et enregistrement de logs structurés.
+  - Dashboard React dans l'admin + documentation d'intégration.
+- **Référence** : README section « Instrumentation et suivi » et `docs/fonctions-a-ameliorer.md` section 3.
+
+### 7. Connecteurs de contenu avancés
+- **Portée** : résolution des sources (`build_display_state`) et normalisation des IDs épinglés.
+- **Cibles** : permettre de plugger des services externes (Elastic, API tierces) via des adapters et un système de priorités.
+- **Livrables** :
+  - Hooks pour injecter des `WP_Query` alternatifs ou des collections d'articles.
+  - Tests d'intégration couvrant les fallback WordPress vs. source externe.
+- **Référence** : README section « Intégrations développeurs » et `docs/fonctions-a-ameliorer.md` section 2.
+
+## Dépendances transverses
+
+| Sujet | Dépendances | Notes |
+| --- | --- | --- |
+| Cache & performance | Finalisation du service de rendu avant instrumentation | Prioriser l'extraction de la couche données pour éviter la dette lors du monitoring. |
+| Accessibilité | Requiert les nouvelles interfaces de filtres | Prévoir un audit axe-core à chaque refonte UI. |
+| Internationalisation | À synchroniser avec la gestion des presets JSON | Maintenir la procédure de re-encodage `.mo` décrite dans le README. |
+
+## Suivi opérationnel
+
+- Ajouter ces jalons au board produit (colonne « Discovery » ↔ « Delivery »).
+- Créer un gabarit de ticket incluant : objectif, métriques attendues, dépendances, checklist QA.
+- Revoir la roadmap trimestriellement avec les équipes produit/design afin d'ajuster les priorités.


### PR DESCRIPTION
## Summary
- enrichir le README avec une roadmap synthétique alignée sur les pistes d'amélioration existantes
- ajouter une feuille de route technique détaillant les jalons à court, moyen et long terme
- documenter les limites actuelles du bloc Gutenberg et les pistes de refonte associées

## Testing
- n/a (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e55f243b4c832e9d713b1719f8931a