### PR TITLE
Improve list layout visuals and add internal review notes

### DIFF
--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -1,0 +1,18 @@
+# Revue de code
+
+## Points forts
+- L'architecture du plugin est modulaire : chaque responsabilité (shortcode, assets, REST) est isolée dans une classe dédiée, ce qui facilite la maintenance.
+- Le socle CSS expose de nombreux jetons (`--my-articles-*`) et adopte `clamp()` pour gérer la fluidité typographique, ce qui offre une bonne base pour construire des thèmes personnalisés.
+
+## Correctifs appliqués
+- Protection supplémentaire dans la méthode `sanitize_scalar_argument()` pour éviter toute invocation d'un sanitizer non callable (ex. extensions tierces injectant un mauvais callback). Sans cette vérification, WordPress lèverait une erreur fatale avant même que la requête AJAX ne soit traitée.
+- Correction d'un bug CSS introduit lors de la refonte : en vue liste, l'image était contrainte par `aspect-ratio` et ne s'étirait plus sur toute la hauteur de la carte. Le wrapper et l'image sont désormais forcés à `height:100%` (et réinitialisés en mobile) ce qui restaure la parité visuelle avec la description.
+
+## Améliorations proposées
+1. **Fiabiliser le fallback des permaliens** : `get_permalink()` peut retourner `false` pour un contenu non publié. Dans `render_article_common_block()` on pourrait prévoir un `if ( ! $permalink )` pour désactiver l'ancre ou afficher un message, afin d'éviter des liens vides.
+2. **Traductions composées** : l'affichage de l'auteur repose sur `printf('%s %s', __('par'), get_the_author())`. Utiliser `sprintf( __( 'par %s', 'mon-articles' ), ... )` laisserait davantage de latitude aux traducteurs (certaines langues inversent l'ordre).
+3. **Test de non-régression pour le cache** : la logique d'invalidation dépend de `my_articles_get_cache_tracked_post_types()`. Ajouter un test unitaire/fonctionnel garantissant qu'un type personnalisé filtré invalide bien le cache évitera les régressions quand de nouveaux hooks seront ajoutés.
+4. **Squelettes personnalisables** : les placeholders HTML/CSS sont actuellement générés côté PHP sans thème alternatif. En externalisant la structure dans un template (ou en exposant plus de variables CSS), on faciliterait la création de skins skeleton via le Customizer ou le bloc.
+
+## Suivi visuel
+Un gabarit statique a été ajouté dans `docs/visual-debug.html` afin de tester rapidement les variations de styles sans avoir à lancer WordPress. Ce fichier référence directement les assets du plugin et peut être intégré à la CI visuelle (Percy, Loki, …).

--- a/docs/visual-debug.html
+++ b/docs/visual-debug.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Debug visuel - Mon Affichage Articles</title>
+    <link rel="stylesheet" href="../mon-affichage-article/assets/css/styles.css">
+    <style>
+        body {
+            font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            background: #f3f4f6;
+            padding: 2rem;
+        }
+        .demo-section {
+            margin-bottom: 3rem;
+        }
+        .demo-section h1 {
+            margin-bottom: 1rem;
+        }
+        .demo-wrapper {
+            max-width: 1100px;
+            margin: 0 auto;
+        }
+    </style>
+</head>
+<body>
+    <div class="demo-wrapper">
+        <section class="demo-section">
+            <h1>Grille</h1>
+            <div class="my-articles-wrapper my-articles-grid" data-cols-mobile="1" data-cols-tablet="2" data-cols-desktop="3" data-cols-ultrawide="4" data-min-card-width="280">
+                <div class="my-articles-grid-content">
+                    <article class="my-article-item">
+                        <a href="#" class="my-article-link">
+                            <div class="article-thumbnail-wrapper">
+                                <img src="https://picsum.photos/seed/1/640/360" alt="Article 1">
+                            </div>
+                            <div class="article-title-wrapper">
+                                <h2 class="article-title">Titre d'article en grille avec deux lignes maximum</h2>
+                                <div class="article-meta">
+                                    <span class="article-category">Actualités</span>
+                                    <span class="article-author">par Rédaction</span>
+                                    <span class="article-date">12 mars 2024</span>
+                                </div>
+                                <div class="my-article-excerpt">
+                                    Ceci est un extrait rapide pour vérifier l'alignement et la lisibilité du texte.
+                                </div>
+                            </div>
+                        </a>
+                    </article>
+                    <article class="my-article-item is-pinned">
+                        <a href="#" class="my-article-link">
+                            <div class="article-thumbnail-wrapper">
+                                <span class="my-article-badge">À la une</span>
+                                <img src="https://picsum.photos/seed/2/640/360" alt="Article 2">
+                            </div>
+                            <div class="article-title-wrapper">
+                                <h2 class="article-title">Article mis en avant pour tester le badge et les effets</h2>
+                                <div class="article-meta">
+                                    <span class="article-category">Inspiration</span>
+                                    <span class="article-author">par Camille</span>
+                                    <span class="article-date">9 mars 2024</span>
+                                </div>
+                                <div class="my-article-excerpt">
+                                    Encore un extrait un peu plus long pour vérifier ce qu'il se passe avec la nouvelle feuille de style.
+                                </div>
+                            </div>
+                        </a>
+                    </article>
+                </div>
+            </div>
+        </section>
+        <section class="demo-section">
+            <h1>Liste</h1>
+            <div class="my-articles-wrapper my-articles-list" data-cols-mobile="1" data-cols-tablet="1" data-cols-desktop="1" data-cols-ultrawide="1" data-min-card-width="280">
+                <div class="my-articles-list-content">
+                    <article class="my-article-item">
+                        <a href="#" class="my-article-link">
+                            <div class="article-thumbnail-wrapper">
+                                <img src="https://picsum.photos/seed/3/640/360" alt="Article 3">
+                            </div>
+                            <div class="article-content-wrapper">
+                                <h2 class="article-title">Affichage en liste avec image à gauche</h2>
+                                <div class="article-meta">
+                                    <span class="article-category">Tutoriel</span>
+                                    <span class="article-author">par Louis</span>
+                                    <span class="article-date">5 mars 2024</span>
+                                </div>
+                                <div class="my-article-excerpt">
+                                    L'extrait doit rester aligné verticalement et laisser suffisamment d'espace respirer, même sur les écrans plus larges.
+                                </div>
+                            </div>
+                        </a>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </div>
+    <script src="../mon-affichage-article/assets/js/responsive-layout.js"></script>
+    <script>
+        window.addEventListener('DOMContentLoaded', function () {
+            window.MyArticlesResponsiveLayout && window.MyArticlesResponsiveLayout.refreshAll && window.MyArticlesResponsiveLayout.refreshAll();
+        });
+    </script>
+</body>
+</html>

--- a/mon-affichage-article/assets/css/styles.css
+++ b/mon-affichage-article/assets/css/styles.css
@@ -727,9 +727,17 @@
     margin-bottom: var(--my-articles-list-gap);
 }
 
+
 .my-articles-list-content .my-article-item .article-thumbnail-wrapper {
     flex: 0 0 200px;
     margin-right: 20px;
+    height: 100%;
+    display: flex;
+}
+
+.my-articles-list-content .my-article-item .article-thumbnail-wrapper img {
+    height: 100%;
+    flex: 1 1 auto;
 }
 
 .my-articles-list-content .my-article-item .article-content-wrapper {
@@ -907,6 +915,7 @@
 
 .my-articles-list-content .my-article-item .my-article-link {
     flex-direction: row;
+    align-items: stretch;
 }
 
 @media (max-width: 767px) {
@@ -923,6 +932,11 @@
         margin-right: 0;
         margin-bottom: 15px;
         flex-basis: auto;
+        height: auto;
+    }
+
+    .my-articles-list-content .my-article-item .article-thumbnail-wrapper img {
+        height: auto;
     }
 
     .my-article-item .article-meta {

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -108,6 +108,10 @@ final class Mon_Affichage_Articles {
             return $default;
         }
 
+        if ( ! is_callable( $sanitizer ) ) {
+            return $default;
+        }
+
         $value = (string) $value;
         $sanitized = call_user_func( $sanitizer, $value );
 


### PR DESCRIPTION
## Summary
- harden the shortcode request sanitizer against invalid callbacks
- fix the list layout thumbnail so it stretches with the content and add a static visual regression page
- document the main review findings and suggested follow-ups

## Testing
- composer test
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e56366bfb8832e8ff1cbf3d36778b0