### PR TITLE
Address review feedback: include schema-only overrides

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-block.php
+++ b/mon-affichage-article/includes/class-my-articles-block.php
@@ -61,8 +61,14 @@ class My_Articles_Block {
     public static function prepare_overrides_from_attributes( array $attributes ) {
         $defaults  = My_Articles_Shortcode::get_default_options();
         $overrides = array();
-        $filtered  = array_intersect_key( $attributes, $defaults );
         $schema    = self::get_override_schema();
+        $filtered  = array();
+
+        foreach ( $attributes as $key => $value ) {
+            if ( array_key_exists( $key, $defaults ) || array_key_exists( $key, $schema ) ) {
+                $filtered[ $key ] = $value;
+            }
+        }
 
         foreach ( $filtered as $key => $raw_value ) {
             if ( null === $raw_value ) {
@@ -70,7 +76,9 @@ class My_Articles_Block {
             }
 
             $definition    = isset( $schema[ $key ] ) && is_array( $schema[ $key ] ) ? $schema[ $key ] : array();
-            $default_value = $defaults[ $key ];
+            $default_value = array_key_exists( $key, $defaults )
+                ? $defaults[ $key ]
+                : ( isset( $definition['default'] ) ? $definition['default'] : null );
             $normalized    = self::normalize_override_value( $raw_value, $default_value, $definition );
 
             if ( null === $normalized ) {


### PR DESCRIPTION
## Summary
- introduce a normalization schema for block attribute overrides and allow extensions via filter
- add PHPUnit coverage to secure block override normalization and custom schema extensions
- ensure schema-defined override attributes survive normalization even without shortcode defaults

## Testing
- composer test *(fails: vendor/bin/phpunit not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e57a1f3d1c832ea390ee0b09c63845