### PR TITLE
Allow schema extensions to process new override attributes

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-block.php
+++ b/mon-affichage-article/includes/class-my-articles-block.php
@@ -59,18 +59,27 @@ class My_Articles_Block {
     }
 
     public static function prepare_overrides_from_attributes( array $attributes ) {
-        $defaults  = My_Articles_Shortcode::get_default_options();
+        $defaults = My_Articles_Shortcode::get_default_options();
+        $schema   = self::get_override_schema();
         $overrides = array();
-        $filtered  = array_intersect_key( $attributes, $defaults );
-        $schema    = self::get_override_schema();
+
+        $allowed_keys = array_fill_keys( array_keys( $defaults ), true );
+
+        foreach ( array_keys( $schema ) as $schema_key ) {
+            $allowed_keys[ $schema_key ] = true;
+        }
+
+        $filtered = array_intersect_key( $attributes, $allowed_keys );
 
         foreach ( $filtered as $key => $raw_value ) {
             if ( null === $raw_value ) {
                 continue;
             }
 
-            $definition    = isset( $schema[ $key ] ) && is_array( $schema[ $key ] ) ? $schema[ $key ] : array();
-            $default_value = $defaults[ $key ];
+            $definition = isset( $schema[ $key ] ) && is_array( $schema[ $key ] ) ? $schema[ $key ] : array();
+            $default_value = array_key_exists( $key, $defaults )
+                ? $defaults[ $key ]
+                : ( isset( $definition['default'] ) ? $definition['default'] : null );
             $normalized    = self::normalize_override_value( $raw_value, $default_value, $definition );
 
             if ( null === $normalized ) {


### PR DESCRIPTION
## Summary
- include schema-defined keys when normalizing block overrides so filtered attributes are preserved
- fall back to schema-provided defaults when shortcode defaults are missing

## Testing
- composer test *(fails: vendor/bin/phpunit not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e57af28288832ebb15dffaf2947c9d