### PR TITLE
Refactor script data injection into reusable registry

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-enqueue.php
+++ b/mon-affichage-article/includes/class-my-articles-enqueue.php
@@ -30,6 +30,9 @@ class My_Articles_Enqueue {
         wp_register_script( 'swiper-js', $vendor_url . 'swiper/swiper-bundle.min.js', array(), '11.0.0', true );
         wp_register_script( 'lazysizes', $vendor_url . 'lazysizes/lazysizes.min.js', array(), '5.3.2', true );
         wp_register_script( 'my-articles-responsive-layout', MY_ARTICLES_PLUGIN_URL . 'assets/js/responsive-layout.js', array(), MY_ARTICLES_VERSION, true );
+        wp_register_script( 'my-articles-filter', MY_ARTICLES_PLUGIN_URL . 'assets/js/filter.js', array( 'jquery' ), MY_ARTICLES_VERSION, true );
+        wp_register_script( 'my-articles-load-more', MY_ARTICLES_PLUGIN_URL . 'assets/js/load-more.js', array( 'jquery' ), MY_ARTICLES_VERSION, true );
+        wp_register_script( 'my-articles-scroll-fix', MY_ARTICLES_PLUGIN_URL . 'assets/js/scroll-fix.js', array( 'jquery' ), MY_ARTICLES_VERSION, true );
         wp_register_script(
             'my-articles-swiper-init',
             MY_ARTICLES_PLUGIN_URL . 'assets/js/swiper-init.js',
@@ -182,5 +185,13 @@ class My_Articles_Enqueue {
                 ),
             ),
         );
+    }
+
+    public function register_script_data( $handle, $object_name, array $data ) {
+        if ( ! class_exists( 'My_Articles_Frontend_Data' ) ) {
+            return false;
+        }
+
+        return My_Articles_Frontend_Data::get_instance()->register( $handle, $object_name, $data );
     }
 }

--- a/mon-affichage-article/includes/class-my-articles-frontend-data.php
+++ b/mon-affichage-article/includes/class-my-articles-frontend-data.php
@@ -1,0 +1,118 @@
+<?php
+// Fichier: includes/class-my-articles-frontend-data.php
+
+if ( ! defined( 'WPINC' ) ) {
+    die;
+}
+
+class My_Articles_Frontend_Data {
+
+    private static $instance;
+
+    private $data = array();
+
+    private $handles_to_output = array();
+
+    private $printed_handles = array();
+
+    public static function get_instance() {
+        if ( ! isset( self::$instance ) ) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    private function __construct() {
+        add_action( 'wp_print_scripts', array( $this, 'maybe_output_registered_data' ), 1 );
+        add_action( 'wp_print_footer_scripts', array( $this, 'maybe_output_registered_data' ), 1 );
+    }
+
+    public function register( $handle, $object_name, array $data ) {
+        if ( empty( $handle ) || empty( $object_name ) || empty( $data ) ) {
+            return false;
+        }
+
+        $sanitized_object_name = preg_replace( '/[^A-Za-z0-9_]/', '_', (string) $object_name );
+        if ( '' === $sanitized_object_name ) {
+            return false;
+        }
+
+        if ( ! isset( $this->data[ $handle ] ) ) {
+            $this->data[ $handle ] = array();
+        }
+
+        if ( isset( $this->data[ $handle ][ $sanitized_object_name ] ) ) {
+            $this->data[ $handle ][ $sanitized_object_name ] = $this->deep_merge(
+                $this->data[ $handle ][ $sanitized_object_name ],
+                $data
+            );
+        } else {
+            $this->data[ $handle ][ $sanitized_object_name ] = $data;
+        }
+
+        $this->handles_to_output[ $handle ] = true;
+
+        if ( did_action( 'wp_print_scripts' ) && ! isset( $this->printed_handles[ $handle ] ) ) {
+            $this->maybe_output_handle( $handle );
+        }
+
+        return true;
+    }
+
+    public function maybe_output_registered_data() {
+        if ( empty( $this->handles_to_output ) ) {
+            return;
+        }
+
+        foreach ( array_keys( $this->handles_to_output ) as $handle ) {
+            $this->maybe_output_handle( $handle );
+        }
+    }
+
+    private function maybe_output_handle( $handle ) {
+        if ( isset( $this->printed_handles[ $handle ] ) ) {
+            return;
+        }
+
+        if ( ! isset( $this->data[ $handle ] ) || empty( $this->data[ $handle ] ) ) {
+            $this->printed_handles[ $handle ] = true;
+            return;
+        }
+
+        if ( ! wp_script_is( $handle, 'enqueued' ) ) {
+            return;
+        }
+
+        foreach ( $this->data[ $handle ] as $object_name => $payload ) {
+            $encoded = wp_json_encode( $payload );
+
+            if ( false === $encoded ) {
+                continue;
+            }
+
+            $inline = sprintf(
+                'window.%1$s = window.%1$s || {}; window.%1$s = Object.assign({}, window.%1$s, %2$s);',
+                $object_name,
+                $encoded
+            );
+
+            wp_add_inline_script( $handle, $inline, 'before' );
+        }
+
+        $this->printed_handles[ $handle ] = true;
+    }
+
+    private function deep_merge( array $original, array $replacement ) {
+        foreach ( $replacement as $key => $value ) {
+            if ( is_array( $value ) && isset( $original[ $key ] ) && is_array( $original[ $key ] ) ) {
+                $original[ $key ] = $this->deep_merge( $original[ $key ], $value );
+                continue;
+            }
+
+            $original[ $key ] = $value;
+        }
+
+        return $original;
+    }
+}

--- a/mon-affichage-article/includes/class-my-articles-shortcode.php
+++ b/mon-affichage-article/includes/class-my-articles-shortcode.php
@@ -1686,56 +1686,58 @@ JS;
         );
 
         if ( ! empty( $options['show_category_filter'] ) || ! empty( $options['enable_keyword_search'] ) ) {
-            wp_enqueue_script('my-articles-filter', MY_ARTICLES_PLUGIN_URL . 'assets/js/filter.js', ['jquery'], MY_ARTICLES_VERSION, true);
-            wp_localize_script(
+            wp_enqueue_script( 'my-articles-filter' );
+
+            My_Articles_Enqueue::get_instance()->register_script_data(
                 'my-articles-filter',
                 'myArticlesFilter',
-                [
-                    'endpoint'      => $filter_rest_endpoint,
-                    'restRoot'      => $rest_root,
-                    'restNonce'     => $rest_nonce,
-                    'nonceEndpoint' => $nonce_refresh_endpoint,
-                    'errorText'     => __( 'Erreur AJAX.', 'mon-articles' ),
-                    'countSingle' => __( '%s article affiché.', 'mon-articles' ),
-                    'countPlural' => __( '%s articles affichés.', 'mon-articles' ),
-                    'countNone'   => __( 'Aucun article à afficher.', 'mon-articles' ),
+                array(
+                    'endpoint'          => $filter_rest_endpoint,
+                    'restRoot'          => $rest_root,
+                    'restNonce'         => $rest_nonce,
+                    'nonceEndpoint'     => $nonce_refresh_endpoint,
+                    'errorText'         => __( 'Erreur AJAX.', 'mon-articles' ),
+                    'countSingle'       => __( '%s article affiché.', 'mon-articles' ),
+                    'countPlural'       => __( '%s articles affichés.', 'mon-articles' ),
+                    'countNone'         => __( 'Aucun article à afficher.', 'mon-articles' ),
                     'countPartialSingle' => __( 'Affichage de %1$s article sur %2$s.', 'mon-articles' ),
                     'countPartialPlural' => __( 'Affichage de %1$s articles sur %2$s.', 'mon-articles' ),
                     'searchCountLabel'   => __( 'Résultats : %s', 'mon-articles' ),
                     'searchCountSingle'  => __( '%s résultat', 'mon-articles' ),
                     'searchCountPlural'  => __( '%s résultats', 'mon-articles' ),
                     'searchCountNone'    => __( 'Aucun résultat', 'mon-articles' ),
-                    'instrumentation' => $instrumentation_payload,
-                ]
+                    'instrumentation'    => $instrumentation_payload,
+                )
             );
         }
 
         if ( $options['pagination_mode'] === 'load_more' ) {
-            wp_enqueue_script('my-articles-load-more', MY_ARTICLES_PLUGIN_URL . 'assets/js/load-more.js', ['jquery'], MY_ARTICLES_VERSION, true);
-            wp_localize_script(
+            wp_enqueue_script( 'my-articles-load-more' );
+
+            My_Articles_Enqueue::get_instance()->register_script_data(
                 'my-articles-load-more',
                 'myArticlesLoadMore',
-                [
-                    'endpoint'       => $load_more_rest_endpoint,
-                    'restRoot'       => $rest_root,
-                    'restNonce'      => $rest_nonce,
-                    'nonceEndpoint'  => $nonce_refresh_endpoint,
-                    'loadingText'  => __( 'Chargement...', 'mon-articles' ),
-                    'loadMoreText' => esc_html__( 'Charger plus', 'mon-articles' ),
-                    'errorText'    => __( 'Erreur AJAX.', 'mon-articles' ),
-                    'totalSingle'  => __( '%s article affiché au total.', 'mon-articles' ),
-                    'totalPlural'  => __( '%s articles affichés au total.', 'mon-articles' ),
-                    'addedSingle'  => __( '%s article ajouté.', 'mon-articles' ),
-                    'addedPlural'  => __( '%s articles ajoutés.', 'mon-articles' ),
-                    'noAdditional' => __( 'Aucun article supplémentaire.', 'mon-articles' ),
-                    'none'         => __( 'Aucun article à afficher.', 'mon-articles' ),
+                array(
+                    'endpoint'        => $load_more_rest_endpoint,
+                    'restRoot'        => $rest_root,
+                    'restNonce'       => $rest_nonce,
+                    'nonceEndpoint'   => $nonce_refresh_endpoint,
+                    'loadingText'     => __( 'Chargement...', 'mon-articles' ),
+                    'loadMoreText'    => esc_html__( 'Charger plus', 'mon-articles' ),
+                    'errorText'       => __( 'Erreur AJAX.', 'mon-articles' ),
+                    'totalSingle'     => __( '%s article affiché au total.', 'mon-articles' ),
+                    'totalPlural'     => __( '%s articles affichés au total.', 'mon-articles' ),
+                    'addedSingle'     => __( '%s article ajouté.', 'mon-articles' ),
+                    'addedPlural'     => __( '%s articles ajoutés.', 'mon-articles' ),
+                    'noAdditional'    => __( 'Aucun article supplémentaire.', 'mon-articles' ),
+                    'none'            => __( 'Aucun article à afficher.', 'mon-articles' ),
                     'instrumentation' => $instrumentation_payload,
-                ]
+                )
             );
         }
 
         if ( $options['pagination_mode'] === 'numbered' ) {
-            wp_enqueue_script('my-articles-scroll-fix', MY_ARTICLES_PLUGIN_URL . 'assets/js/scroll-fix.js', ['jquery'], MY_ARTICLES_VERSION, true);
+            wp_enqueue_script( 'my-articles-scroll-fix' );
         }
 
         if ( ! empty( $options['enable_lazy_load'] ) ) {

--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -41,6 +41,7 @@ final class Mon_Affichage_Articles {
         require_once MY_ARTICLES_PLUGIN_DIR . 'includes/class-my-articles-settings.php';
         require_once MY_ARTICLES_PLUGIN_DIR . 'includes/class-my-articles-metaboxes.php';
         require_once MY_ARTICLES_PLUGIN_DIR . 'includes/class-my-articles-shortcode.php';
+        require_once MY_ARTICLES_PLUGIN_DIR . 'includes/class-my-articles-frontend-data.php';
         require_once MY_ARTICLES_PLUGIN_DIR . 'includes/class-my-articles-enqueue.php';
         require_once MY_ARTICLES_PLUGIN_DIR . 'includes/class-my-articles-block.php';
         require_once MY_ARTICLES_PLUGIN_DIR . 'includes/rest/class-my-articles-controller.php';
@@ -69,6 +70,7 @@ final class Mon_Affichage_Articles {
         My_Articles_Shortcode::get_instance();
         My_Articles_Block::get_instance();
         My_Articles_Enqueue::get_instance();
+        My_Articles_Frontend_Data::get_instance();
     }
 
     /**


### PR DESCRIPTION
## Summary
- add a dedicated frontend data registry that injects script payloads with `wp_add_inline_script`
- register public scripts via `My_Articles_Enqueue` and reuse them from the shortcode
- bootstrap the data registry service when the plugin loads

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e578e55854832ebd965e1a5dd5b798