### PR TITLE
feat: refresh admin settings with Radix-inspired styling

### DIFF
--- a/mon-affichage-article/assets/css/admin.css
+++ b/mon-affichage-article/assets/css/admin.css
@@ -1,43 +1,66 @@
 :root {
     --my-articles-admin-radius: 18px;
     --my-articles-admin-radius-sm: 12px;
-    --my-articles-admin-border: 1px solid color-mix(in srgb, var(--wp-admin-theme-color, #3c434a) 10%, transparent);
-    --my-articles-admin-bg: color-mix(in srgb, #ffffff 90%, var(--wp-admin-theme-color, #3c434a) 4%);
+    --my-articles-admin-radius-pill: 999px;
+    --my-articles-admin-border-color: color-mix(in srgb, var(--wp-admin-theme-color, #3c434a) 16%, transparent);
+    --my-articles-admin-border: 1px solid var(--my-articles-admin-border-color);
+    --my-articles-admin-border-strong: 1px solid color-mix(in srgb, var(--wp-admin-theme-color, #3c434a) 28%, transparent);
+    --my-articles-admin-bg: color-mix(in srgb, #ffffff 92%, var(--wp-admin-theme-color, #3c434a) 6%);
+    --my-articles-admin-surface: #ffffff;
+    --my-articles-admin-surface-muted: color-mix(in srgb, #f5f6fb 85%, var(--wp-admin-theme-color, #3c434a) 8%);
     --my-articles-admin-elevated: #ffffff;
     --my-articles-admin-text: #111827;
     --my-articles-admin-muted: #6b7280;
     --my-articles-admin-outline: color-mix(in srgb, var(--wp-admin-theme-color, #3c434a) 35%, transparent);
+    --my-articles-admin-accent: color-mix(in srgb, var(--wp-admin-theme-color, #3c434a) 65%, #2563eb 25%);
+    --my-articles-admin-accent-soft: color-mix(in srgb, var(--wp-admin-theme-color, #3c434a) 12%, #e8f1ff 88%);
+    --my-articles-admin-accent-contrast: #ffffff;
     --my-articles-admin-shadow: 0 18px 35px -18px rgba(15, 23, 42, 0.25);
-    --my-articles-admin-shadow-soft: 0 10px 25px -20px rgba(15, 23, 42, 0.25);
-    --my-articles-admin-radius-pill: 999px;
+    --my-articles-admin-shadow-soft: 0 20px 45px -30px rgba(15, 23, 42, 0.3);
+    --my-articles-admin-shadow-focus: 0 0 0 3px color-mix(in srgb, var(--wp-admin-theme-color, #3c434a) 22%, transparent);
     --my-articles-admin-gap: clamp(1.5rem, 1rem + 1vw, 2.5rem);
+    --my-articles-admin-gradient: linear-gradient(135deg, color-mix(in srgb, var(--wp-admin-theme-color, #3c434a) 30%, #f0f9ff 70%) 0%, #ffffff 60%, color-mix(in srgb, var(--wp-admin-theme-color, #3c434a) 18%, #eef2ff 82%) 100%);
 }
 
 .my-articles-admin {
     position: relative;
-    padding-block: clamp(1.5rem, 1.2rem + 0.6vw, 2.25rem);
+    isolation: isolate;
+    padding-block: clamp(1.5rem, 1.2rem + 0.6vw, 2.5rem);
     color: var(--my-articles-admin-text);
-    max-width: 1100px;
+    max-width: min(1040px, 100%);
+    margin-inline: auto;
 }
 
 .my-articles-admin__header {
+    position: relative;
+    overflow: hidden;
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
-    gap: clamp(1rem, 0.8rem + 0.5vw, 1.5rem);
-    padding: clamp(1.5rem, 1.2rem + 0.6vw, 2rem);
-    margin-bottom: clamp(1.5rem, 1rem + 1vw, 2.5rem);
-    background: var(--my-articles-admin-bg);
+    gap: clamp(1rem, 0.8rem + 0.6vw, 1.6rem);
+    padding: clamp(1.8rem, 1.4rem + 1vw, 2.5rem);
+    margin-bottom: clamp(1.5rem, 1rem + 1vw, 2.75rem);
+    background: var(--my-articles-admin-gradient);
     border-radius: var(--my-articles-admin-radius);
-    border: var(--my-articles-admin-border);
+    border: var(--my-articles-admin-border-strong);
     box-shadow: var(--my-articles-admin-shadow-soft);
+}
+
+.my-articles-admin__header::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top right, color-mix(in srgb, var(--my-articles-admin-accent) 18%, transparent) 0%, transparent 65%);
+    mix-blend-mode: screen;
+    opacity: 0.65;
+    pointer-events: none;
 }
 
 .my-articles-admin__title-group {
     display: flex;
-    align-items: center;
-    gap: clamp(0.75rem, 0.6rem + 0.4vw, 1rem);
+    align-items: flex-start;
+    gap: clamp(0.85rem, 0.65rem + 0.5vw, 1.2rem);
 }
 
 .my-articles-admin__badge {
@@ -45,31 +68,45 @@
     align-items: center;
     justify-content: center;
     font-weight: 600;
-    font-size: 0.85rem;
-    letter-spacing: 0.06em;
+    font-size: 0.82rem;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
-    padding: 0.35rem 0.75rem;
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--wp-admin-theme-color, #3c434a) 12%, transparent);
-    color: color-mix(in srgb, var(--wp-admin-theme-color, #3c434a) 75%, black 30%);
+    padding: 0.45rem 0.9rem;
+    border-radius: var(--my-articles-admin-radius-pill);
+    background: color-mix(in srgb, var(--my-articles-admin-accent) 18%, transparent);
+    color: color-mix(in srgb, var(--my-articles-admin-accent) 65%, #0f172a 30%);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
 .my-articles-admin__title {
     margin: 0;
-    font-size: clamp(1.5rem, 1.2rem + 1vw, 2.3rem);
+    font-size: clamp(1.65rem, 1.3rem + 1.1vw, 2.4rem);
     font-weight: 600;
+    color: color-mix(in srgb, var(--my-articles-admin-accent) 12%, var(--my-articles-admin-text) 88%);
+}
+
+.my-articles-admin__subtitle {
+    margin: 0.25rem 0 0;
+    font-size: 0.95rem;
+    color: color-mix(in srgb, var(--my-articles-admin-text) 65%, #ffffff 35%);
+    max-width: 36ch;
 }
 
 .my-articles-admin__meta {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    gap: 0.75rem;
+    gap: 0.85rem;
     margin: 0;
+    padding: 0.5rem 0.85rem;
+    background: color-mix(in srgb, var(--my-articles-admin-surface) 80%, transparent);
+    border-radius: var(--my-articles-admin-radius-pill);
+    border: 1px solid color-mix(in srgb, var(--my-articles-admin-border-color) 60%, transparent);
+    backdrop-filter: saturate(150%) blur(6px);
 }
 
 .my-articles-admin__meta-item {
     display: grid;
-    gap: 0.25rem;
+    gap: 0.2rem;
 }
 
 .my-articles-admin__meta-item dt {
@@ -89,13 +126,14 @@
 .my-articles-admin__tabs {
     display: inline-flex;
     align-items: center;
-    gap: 0.25rem;
-    background: #fff;
-    border-radius: var(--my-articles-admin-radius-pill, 999px);
-    padding: 0.25rem;
-    border: 1px solid color-mix(in srgb, var(--wp-admin-theme-color, #3c434a) 14%, transparent);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
-    margin-bottom: clamp(1.5rem, 1.2rem + 0.6vw, 2.25rem);
+    gap: 0.35rem;
+    background: color-mix(in srgb, var(--my-articles-admin-surface) 75%, transparent);
+    border-radius: var(--my-articles-admin-radius-pill);
+    padding: 0.35rem;
+    border: 1px solid color-mix(in srgb, var(--my-articles-admin-border-color) 55%, transparent);
+    margin-bottom: clamp(1.7rem, 1.3rem + 0.8vw, 2.5rem);
+    position: relative;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55), 0 1px 2px rgba(15, 23, 42, 0.06);
 }
 
 .my-articles-admin__tab {
@@ -103,46 +141,186 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 0.65rem 1.4rem;
+    padding: 0.65rem 1.45rem;
     font-weight: 500;
     font-size: 0.95rem;
-    border-radius: 999px;
-    color: var(--my-articles-admin-muted);
+    border-radius: var(--my-articles-admin-radius-pill);
+    color: color-mix(in srgb, var(--my-articles-admin-muted) 90%, var(--my-articles-admin-text) 10%);
     text-decoration: none;
-    transition: all 0.2s ease;
+    transition: color 0.2s ease, transform 0.2s ease;
+    min-width: 120px;
+}
+
+.my-articles-admin__tab::after {
+    content: "";
+    position: absolute;
+    inset: 2px;
+    border-radius: inherit;
+    background: transparent;
+    transition: background 0.2s ease, box-shadow 0.2s ease;
+    z-index: -1;
 }
 
 .my-articles-admin__tab:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--wp-admin-theme-color, #3c434a) 20%, transparent);
+    box-shadow: var(--my-articles-admin-shadow-focus);
 }
 
 .my-articles-admin__tab:hover {
-    color: var(--wp-admin-theme-color, #2271b1);
+    color: color-mix(in srgb, var(--my-articles-admin-accent) 70%, #111827 30%);
 }
 
-.my-articles-admin__tab.is-active {
-    background: var(--wp-admin-theme-color, #2271b1);
-    color: #fff;
-    box-shadow: 0 8px 16px -10px rgba(34, 113, 177, 0.6);
+.my-articles-admin__tab[data-state="active"] {
+    color: var(--my-articles-admin-accent-contrast);
+    transform: translateY(-1px);
+}
+
+.my-articles-admin__tab[data-state="active"]::after {
+    background: linear-gradient(135deg, var(--my-articles-admin-accent) 0%, color-mix(in srgb, var(--my-articles-admin-accent) 50%, #60a5fa 50%) 100%);
+    box-shadow: 0 10px 18px -12px color-mix(in srgb, var(--my-articles-admin-accent) 50%, transparent);
+}
+
+.my-articles-admin__tab-label {
+    position: relative;
+    z-index: 1;
+}
+
+@supports (backdrop-filter: blur(10px)) {
+    .my-articles-admin__tabs {
+        backdrop-filter: saturate(140%) blur(12px);
+    }
 }
 
 .my-articles-card {
-    background: var(--my-articles-admin-elevated);
+    position: relative;
+    z-index: 0;
+    background: var(--my-articles-admin-surface);
     border-radius: var(--my-articles-admin-radius);
     border: var(--my-articles-admin-border);
-    padding: clamp(1.5rem, 1.2rem + 0.7vw, 2.25rem);
+    padding: clamp(1.6rem, 1.2rem + 0.85vw, 2.4rem);
     box-shadow: var(--my-articles-admin-shadow);
     margin-bottom: var(--my-articles-admin-gap);
+    overflow: hidden;
+}
+
+.my-articles-card > * {
+    position: relative;
+    z-index: 1;
+}
+
+.my-articles-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+    background: radial-gradient(120% 100% at 0% 0%, color-mix(in srgb, var(--my-articles-admin-accent) 12%, transparent) 0%, transparent 55%);
+}
+
+.my-articles-card:hover::before {
+    opacity: 1;
 }
 
 .my-articles-card:last-of-type {
     margin-bottom: 0;
 }
 
+.my-articles-card--primary {
+    border: 1px solid color-mix(in srgb, var(--my-articles-admin-border-color) 90%, transparent);
+    background: linear-gradient(180deg, color-mix(in srgb, var(--my-articles-admin-surface) 95%, var(--my-articles-admin-accent-soft) 5%) 0%, var(--my-articles-admin-surface) 70%);
+}
+
+.my-articles-card--muted {
+    background: var(--my-articles-admin-surface-muted);
+    border: 1px solid color-mix(in srgb, var(--my-articles-admin-border-color) 70%, transparent);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.my-articles-card--muted::before {
+    display: none;
+}
+
+.my-articles-card__header {
+    display: grid;
+    gap: 0.4rem;
+    margin-bottom: 1.2rem;
+}
+
+.my-articles-card__title {
+    margin: 0;
+    font-size: 1.15rem;
+}
+
+.my-articles-card__description {
+    margin: 0;
+    font-size: 0.92rem;
+    color: var(--my-articles-admin-muted);
+}
+
+.my-articles-card__body {
+    display: grid;
+    gap: clamp(1rem, 0.8rem + 0.5vw, 1.6rem);
+}
+
+.my-articles-admin__notices {
+    display: grid;
+    gap: 0.9rem;
+    margin-bottom: clamp(1.2rem, 0.9rem + 0.6vw, 1.9rem);
+}
+
+.my-articles-admin__notices:empty {
+    display: none;
+}
+
+.my-articles-admin__notices .notice {
+    margin: 0;
+    border-radius: var(--my-articles-admin-radius-sm);
+    border: 1px solid color-mix(in srgb, var(--my-articles-admin-border-color) 55%, transparent);
+    box-shadow: 0 12px 24px -18px rgba(15, 23, 42, 0.35);
+    padding: 0.85rem 1.1rem;
+    background: color-mix(in srgb, #ffffff 92%, var(--wp-admin-theme-color, #3c434a) 8%);
+}
+
+.my-articles-admin__notices .notice-success {
+    border-color: color-mix(in srgb, #22c55e 35%, transparent);
+    background: color-mix(in srgb, #dcfce7 70%, #ffffff 30%);
+}
+
+.my-articles-admin__notices .notice-error {
+    border-color: color-mix(in srgb, #ef4444 45%, transparent);
+    background: color-mix(in srgb, #fee2e2 70%, #ffffff 30%);
+}
+
+.my-articles-admin__panel {
+    position: relative;
+    transition: opacity 0.3s ease;
+}
+
+.my-articles-admin__panel[hidden] {
+    display: none;
+}
+
+.my-articles-admin__panel[data-state="active"] {
+    animation: my-articles-admin-fade 0.35s ease;
+}
+
+.my-articles-admin__panel-grid {
+    display: grid;
+    gap: var(--my-articles-admin-gap);
+    align-items: start;
+}
+
+.my-articles-admin__intro {
+    margin: 0;
+    font-size: 1rem;
+    color: color-mix(in srgb, var(--my-articles-admin-muted) 80%, var(--my-articles-admin-text) 20%);
+}
+
 .my-articles-card--prose h2,
 .my-articles-card--prose h3 {
     font-weight: 600;
+    color: color-mix(in srgb, var(--my-articles-admin-text) 85%, var(--my-articles-admin-accent) 15%);
 }
 
 .my-articles-card--prose h2 {
@@ -169,9 +347,42 @@
     margin-top: 0.35rem;
 }
 
+.my-articles-card--prose code {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.1rem 0.4rem;
+    border-radius: 0.4rem;
+    background: color-mix(in srgb, var(--my-articles-admin-accent-soft) 45%, #ffffff 55%);
+    color: color-mix(in srgb, var(--my-articles-admin-accent) 70%, #111827 30%);
+    font-size: 0.9rem;
+}
+
+.my-articles-admin__form {
+    display: grid;
+    gap: clamp(1.2rem, 0.9rem + 0.8vw, 2rem);
+}
+
+.my-articles-admin__form h2,
+.my-articles-admin__form .title {
+    margin: clamp(1.6rem, 1.2rem + 0.8vw, 2.2rem) 0 0.65rem;
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: color-mix(in srgb, var(--my-articles-admin-text) 80%, var(--my-articles-admin-accent) 20%);
+    border-top: 1px solid color-mix(in srgb, var(--my-articles-admin-border-color) 70%, transparent);
+    padding-top: 1.35rem;
+}
+
+.my-articles-admin__form h2:first-child,
+.my-articles-admin__form .title:first-child {
+    margin-top: 0;
+    padding-top: 0;
+    border-top: none;
+}
+
 .my-articles-admin__form .form-table {
-    margin-top: 1.5rem;
+    margin-top: 0.5rem;
     width: 100%;
+    border-spacing: 0;
 }
 
 .my-articles-admin__form .form-table th {
@@ -187,7 +398,12 @@
 }
 
 .my-articles-admin__form .form-table tr {
-    border-bottom: 1px solid color-mix(in srgb, #0f172a 12%, transparent);
+    border-bottom: 1px solid color-mix(in srgb, var(--my-articles-admin-border-color) 65%, transparent);
+    transition: background 0.2s ease;
+}
+
+.my-articles-admin__form .form-table tr:hover {
+    background: color-mix(in srgb, var(--my-articles-admin-accent-soft) 25%, transparent);
 }
 
 .my-articles-admin__form .form-table tr:last-child {
@@ -201,10 +417,11 @@
     width: 100%;
     max-width: 420px;
     border-radius: var(--my-articles-admin-radius-sm);
-    border: 1px solid color-mix(in srgb, #0f172a 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--my-articles-admin-border-color) 65%, transparent);
     padding: 0.6rem 0.75rem;
     box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.08);
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    background: #ffffff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .my-articles-admin__form input[type="text"]:focus,
@@ -212,23 +429,51 @@
 .my-articles-admin__form select:focus,
 .my-articles-admin__form textarea:focus {
     outline: none;
-    border-color: var(--wp-admin-theme-color, #2271b1);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--wp-admin-theme-color, #2271b1) 24%, transparent);
+    border-color: color-mix(in srgb, var(--my-articles-admin-accent) 75%, transparent);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--my-articles-admin-accent) 24%, transparent);
+    transform: translateY(-1px);
 }
 
 .my-articles-admin__form .description {
     margin-top: 0.4rem;
     color: var(--my-articles-admin-muted);
     font-size: 0.85rem;
+    line-height: 1.5;
 }
 
 .my-articles-admin__form .wp-picker-container .wp-color-result {
     border-radius: var(--my-articles-admin-radius-sm);
     padding: 0.3rem 0.6rem;
+    border: 1px solid color-mix(in srgb, var(--my-articles-admin-border-color) 70%, transparent);
+    box-shadow: inset 0 1px 1px rgba(15, 23, 42, 0.08);
 }
 
 .my-articles-admin__form .submit {
     margin-top: 2rem;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.my-articles-admin__form .submit .button-primary {
+    border: none;
+    border-radius: var(--my-articles-admin-radius-pill);
+    padding: 0.65rem 1.6rem;
+    font-weight: 600;
+    background: linear-gradient(135deg, var(--my-articles-admin-accent) 0%, color-mix(in srgb, var(--my-articles-admin-accent) 65%, #60a5fa 35%) 100%);
+    color: var(--my-articles-admin-accent-contrast);
+    box-shadow: 0 16px 28px -18px color-mix(in srgb, var(--my-articles-admin-accent) 60%, transparent);
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.my-articles-admin__form .submit .button-primary:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 18px 34px -16px color-mix(in srgb, var(--my-articles-admin-accent) 65%, transparent);
+}
+
+.my-articles-admin__maintenance {
+    display: grid;
+    gap: 1rem;
 }
 
 .my-articles-admin__maintenance-header {
@@ -247,15 +492,42 @@
     justify-content: flex-start;
     align-items: center;
     gap: 0.75rem;
+    flex-wrap: wrap;
 }
 
 .my-articles-admin__actions .button {
-    border-radius: var(--my-articles-admin-radius-sm);
-    padding: 0.55rem 1.25rem;
+    border-radius: var(--my-articles-admin-radius-pill);
+    padding: 0.6rem 1.4rem;
     font-weight: 600;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.my-articles-admin__actions .button:hover {
+    transform: translateY(-1px);
+}
+
+.my-articles-admin__actions .button.delete {
+    background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+    border: none;
+    color: #ffffff;
+    box-shadow: 0 14px 26px -18px rgba(239, 68, 68, 0.85);
+}
+
+.my-articles-admin__actions .button.delete:hover {
+    background: linear-gradient(135deg, #f87171 0%, #dc2626 100%);
+}
+
+@media (min-width: 960px) {
+    .my-articles-admin__panel-grid {
+        grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
+    }
 }
 
 @media (max-width: 960px) {
+    .my-articles-admin__panel-grid {
+        grid-template-columns: 1fr;
+    }
+
     .my-articles-admin__form .form-table th {
         width: auto;
     }
@@ -274,5 +546,55 @@
 
     .my-articles-admin__form .form-table td {
         padding-bottom: 1.25rem;
+    }
+}
+
+@keyframes my-articles-admin-fade {
+    from {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --my-articles-admin-bg: color-mix(in srgb, #111827 80%, var(--wp-admin-theme-color, #3c434a) 20%);
+        --my-articles-admin-surface: color-mix(in srgb, #0f172a 85%, #1e293b 15%);
+        --my-articles-admin-surface-muted: color-mix(in srgb, #1e293b 88%, #0f172a 12%);
+        --my-articles-admin-text: #f8fafc;
+        --my-articles-admin-muted: #94a3b8;
+        --my-articles-admin-accent-contrast: #f8fafc;
+        --my-articles-admin-shadow: 0 25px 45px -35px rgba(15, 23, 42, 0.95);
+    }
+
+    .my-articles-admin__badge {
+        color: color-mix(in srgb, var(--my-articles-admin-accent-contrast) 85%, rgba(15, 23, 42, 0.4) 15%);
+    }
+
+    .my-articles-card--muted {
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+    }
+
+    .my-articles-admin__notices .notice {
+        background: color-mix(in srgb, #1e293b 80%, transparent);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .my-articles-admin__tab,
+    .my-articles-card,
+    .my-articles-admin__panel,
+    .my-articles-admin__actions .button,
+    .my-articles-admin__form .submit .button-primary {
+        transition-duration: 0.01ms !important;
+        animation-duration: 0.01ms !important;
+    }
+
+    .my-articles-card:hover::before {
+        opacity: 0;
     }
 }


### PR DESCRIPTION
## Summary
- restructure the admin settings page markup to expose tab roles, card panels, and maintenance actions with richer context
- refresh the admin stylesheet with Radix-inspired tokens, card treatments, and responsive grid layouts for settings and notices
- add dark-mode and reduced-motion refinements while keeping button, notice, and form controls visually consistent

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e58fa9ea1c832e86f702ceec4aa186