### PR TITLE
Add module insights panel to block inspector

### DIFF
--- a/mon-affichage-article/blocks/mon-affichage-articles/editor.css
+++ b/mon-affichage-article/blocks/mon-affichage-articles/editor.css
@@ -61,3 +61,37 @@
 .wp-block-mon-affichage-articles .my-articles-block.is-preview-desktop .my-articles-wrapper {
     --my-articles-cols-ultrawide: var(--my-articles-cols-desktop);
 }
+
+.my-articles-block__module-insights {
+    margin-top: 12px;
+    padding: 14px 16px;
+    border-radius: 10px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: linear-gradient(135deg, rgba(248, 250, 255, 0.65) 0%, rgba(226, 232, 240, 0.35) 100%);
+}
+
+.my-articles-block__module-insights-row + .my-articles-block__module-insights-row {
+    margin-top: 10px;
+}
+
+.my-articles-block__module-insights-label {
+    display: block;
+    font-size: 12px;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    color: #475569;
+    margin-bottom: 2px;
+}
+
+.my-articles-block__module-insights-value {
+    display: block;
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.my-articles-block__module-insights-actions {
+    margin-top: 12px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}


### PR DESCRIPTION
## Summary
- add utilities to compute module status, freshness, and formatting in the block editor
- expose a new "État du module" panel with health notices, metadata, and quick actions
- polish the inspector styling for the insights panel

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e59b64ea28832e91dc9075c71513f2