### PR TITLE
Handle AJAX filters and sort forwarding

### DIFF
--- a/tests/FilterParameterSanitizerTest.php
+++ b/tests/FilterParameterSanitizerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MonAffichageArticles\Tests;
+
+use Mon_Affichage_Articles;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * @covers \Mon_Affichage_Articles::sanitize_filters_parameter
+ */
+final class FilterParameterSanitizerTest extends TestCase
+{
+    /** @var ReflectionMethod */
+    private $sanitizerMethod;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sanitizerMethod = new ReflectionMethod(Mon_Affichage_Articles::class, 'sanitize_filters_parameter');
+        $this->sanitizerMethod->setAccessible(true);
+    }
+
+    /**
+     * @param mixed $input
+     * @return array<int, array{taxonomy:string, slug:string}>
+     */
+    private function sanitize($input): array
+    {
+        $plugin = Mon_Affichage_Articles::get_instance();
+
+        /** @var array<int, array{taxonomy:string, slug:string}> $result */
+        $result = $this->sanitizerMethod->invoke($plugin, $input);
+
+        return $result;
+    }
+
+    public function test_sanitize_filters_parameter_handles_json_string(): void
+    {
+        $input = '[{"taxonomy":"category","slug":"World-News"}]';
+
+        $result = $this->sanitize($input);
+
+        $this->assertSame(
+            array(
+                array('taxonomy' => 'category', 'slug' => 'world-news'),
+            ),
+            $result
+        );
+    }
+
+    public function test_sanitize_filters_parameter_unslashes_nested_arrays(): void
+    {
+        $input = array(
+            array('taxonomy' => 'category', 'slug' => '  Featured  '),
+            array('taxonomy' => 'post_tag', 'slug' => 'Top-Story'),
+        );
+
+        $result = $this->sanitize($input);
+
+        $this->assertSame(
+            array(
+                array('taxonomy' => 'category', 'slug' => 'featured'),
+                array('taxonomy' => 'post_tag', 'slug' => 'top-story'),
+            ),
+            $result
+        );
+    }
+
+    public function test_sanitize_filters_parameter_rejects_non_iterable_values(): void
+    {
+        $this->assertSame(array(), $this->sanitize(123));
+        $this->assertSame(array(), $this->sanitize(null));
+    }
+}

--- a/tests/Rest/ControllerRoutesTest.php
+++ b/tests/Rest/ControllerRoutesTest.php
@@ -61,6 +61,7 @@ final class ControllerRoutesTest extends TestCase
         $request->set_param('current_url', 'http://example.com/page');
         $request->set_param('search', ' hello   world ');
         $request->set_param('sort', 'comment_count');
+        $request->set_param('filters', '[{"taxonomy":"category","slug":"news"}]');
 
         $response = $controller->filter_articles($request);
 
@@ -85,6 +86,9 @@ final class ControllerRoutesTest extends TestCase
                 'http_referer' => 'http://example.com/ref',
                 'search'       => ' hello   world ',
                 'sort'         => 'comment_count',
+                'filters'      => array(
+                    array('taxonomy' => 'category', 'slug' => 'news'),
+                ),
             ),
             $capturedArgs
         );
@@ -161,6 +165,9 @@ final class ControllerRoutesTest extends TestCase
         $request->set_param('category', 'featured');
         $request->set_param('search', 'top stories');
         $request->set_param('sort', 'title');
+        $request->set_param('filters', array(
+            array('taxonomy' => 'post_tag', 'slug' => 'highlights'),
+        ));
 
         $response = $controller->load_more_articles($request);
 
@@ -184,6 +191,9 @@ final class ControllerRoutesTest extends TestCase
                 'category'    => 'featured',
                 'search'      => 'top stories',
                 'sort'        => 'title',
+                'filters'     => array(
+                    array('taxonomy' => 'post_tag', 'slug' => 'highlights'),
+                ),
             ),
             $capturedArgs
         );


### PR DESCRIPTION
## Summary
- sanitize filter payloads from incoming requests so AJAX handlers can forward them safely
- forward both filters and sort values in the filter and load-more AJAX callbacks
- cover the new helper with unit tests and extend REST controller coverage for filter propagation

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e639edcfa4832eb0db17af0286d201