### PR TITLE
Ensure filter pagination context is defined

### DIFF
--- a/mon-affichage-article/mon-affichage-articles.php
+++ b/mon-affichage-article/mon-affichage-articles.php
@@ -565,6 +565,15 @@ public function prepare_filter_articles_response( array $args ) {
         $rendered_regular_count = (int) $render_results['regular_rendered_count'];
         $rendered_pinned_count  = (int) $render_results['pinned_rendered_count'];
 
+        $pagination_context = array(
+            'current_page' => 1,
+        );
+
+        if ( ! empty( $is_unlimited ) ) {
+            $pagination_context['unlimited_page_size'] = $state['unlimited_batch_size'];
+            $pagination_context['analytics_page_size'] = $state['unlimited_batch_size'];
+        }
+
         $pagination_totals = my_articles_calculate_total_pages(
             $total_pinned_posts,
             $total_regular_posts,

--- a/tests/PrepareFilterArticlesResponseTest.php
+++ b/tests/PrepareFilterArticlesResponseTest.php
@@ -30,6 +30,7 @@ final class PrepareFilterArticlesResponseTest extends TestCase
             'wp_cache'         => $GLOBALS['mon_articles_test_wp_cache'] ?? null,
             'transients'       => $GLOBALS['mon_articles_test_transients'] ?? null,
             'transients_store' => $GLOBALS['mon_articles_test_transients_store'] ?? null,
+            'filters'          => $GLOBALS['mon_articles_test_filters'] ?? null,
         );
     }
 
@@ -62,6 +63,7 @@ final class PrepareFilterArticlesResponseTest extends TestCase
             $GLOBALS['mon_articles_test_wp_cache'] = $this->previousGlobals['wp_cache'];
             $GLOBALS['mon_articles_test_transients'] = $this->previousGlobals['transients'];
             $GLOBALS['mon_articles_test_transients_store'] = $this->previousGlobals['transients_store'];
+            $GLOBALS['mon_articles_test_filters'] = $this->previousGlobals['filters'];
         }
 
         parent::tearDown();
@@ -104,11 +106,22 @@ final class PrepareFilterArticlesResponseTest extends TestCase
         $GLOBALS['mon_articles_test_transients_store'] = array();
     }
 
-    private function createShortcodeDouble(): My_Articles_Shortcode
+    private function createShortcodeDouble(array $stateOverrides = array()): My_Articles_Shortcode
     {
-        return new class() extends My_Articles_Shortcode {
+        return new class($stateOverrides) extends My_Articles_Shortcode {
             /** @var array<int, array<string, mixed>> */
             public $capturedArgs = array();
+
+            /** @var array<string, mixed> */
+            private $stateOverrides;
+
+            /**
+             * @param array<string, mixed> $stateOverrides
+             */
+            public function __construct(array $stateOverrides)
+            {
+                $this->stateOverrides = $stateOverrides;
+            }
 
             public function build_display_state(array $options, array $args = array())
             {
@@ -117,7 +130,7 @@ final class PrepareFilterArticlesResponseTest extends TestCase
                     'args'    => $args,
                 );
 
-                return array(
+                $state = array(
                     'pinned_query'             => new WP_Query(array()),
                     'regular_query'            => new WP_Query(array(
                         array('ID' => 101, 'post_title' => 'Article A'),
@@ -130,7 +143,18 @@ final class PrepareFilterArticlesResponseTest extends TestCase
                     'render_limit'             => 2,
                     'regular_posts_needed'     => 2,
                     'is_unlimited'             => false,
+                    'unlimited_batch_size'     => 0,
                 );
+
+                foreach ($this->stateOverrides as $key => $value) {
+                    $state[$key] = $value;
+                }
+
+                if (!array_key_exists('unlimited_batch_size', $state)) {
+                    $state['unlimited_batch_size'] = 0;
+                }
+
+                return $state;
             }
 
             public function render_article_item($options, $is_pinned = false)
@@ -198,5 +222,100 @@ final class PrepareFilterArticlesResponseTest extends TestCase
         $this->assertSame('nouveautes', $shortcodeDouble->capturedArgs[0]['options']['search_query']);
         $this->assertSame('comment_count', $shortcodeDouble->capturedArgs[0]['options']['sort']);
         $this->assertSame('comment_count', $response['sort']);
+    }
+
+    public function test_prepare_filter_response_sets_pagination_context_current_page(): void
+    {
+        $instanceId = 654;
+
+        $settings = array(
+            'post_type'            => 'post',
+            'display_mode'         => 'list',
+            'pagination_mode'      => 'numbered',
+            'posts_per_page'       => 2,
+            'show_category_filter' => 1,
+        );
+
+        $this->primeInstanceMeta($instanceId, $settings);
+
+        $shortcodeDouble = $this->createShortcodeDouble();
+        $this->swapShortcodeInstance($shortcodeDouble);
+
+        $capturedContext = null;
+
+        add_filter(
+            'my_articles_calculate_total_pages',
+            function ($result, $totalPinned, $totalRegular, $perPage, $context) use (&$capturedContext) {
+                $capturedContext = $context;
+
+                return $result;
+            },
+            10,
+            5
+        );
+
+        $plugin = new Mon_Affichage_Articles();
+
+        $response = $plugin->prepare_filter_articles_response(array(
+            'instance_id' => $instanceId,
+            'category'    => 'actus',
+            'current_url' => 'http://example.com/',
+        ));
+
+        $this->assertIsArray($response);
+        $this->assertNotNull($capturedContext, 'Expected the pagination calculation hook to capture context.');
+        $this->assertSame(1, $capturedContext['current_page']);
+    }
+
+    public function test_prepare_filter_response_exposes_unlimited_batch_size_in_context(): void
+    {
+        $instanceId = 987;
+
+        $settings = array(
+            'post_type'            => 'post',
+            'display_mode'         => 'grid',
+            'pagination_mode'      => 'numbered',
+            'posts_per_page'       => 0,
+            'show_category_filter' => 1,
+        );
+
+        $this->primeInstanceMeta($instanceId, $settings);
+
+        $shortcodeDouble = $this->createShortcodeDouble(
+            array(
+                'is_unlimited'             => true,
+                'unlimited_batch_size'     => 7,
+                'effective_posts_per_page' => 0,
+            )
+        );
+        $this->swapShortcodeInstance($shortcodeDouble);
+
+        $capturedContext = null;
+
+        add_filter(
+            'my_articles_calculate_total_pages',
+            function ($result, $totalPinned, $totalRegular, $perPage, $context) use (&$capturedContext) {
+                $capturedContext = $context;
+
+                return $result;
+            },
+            10,
+            5
+        );
+
+        $plugin = new Mon_Affichage_Articles();
+
+        $response = $plugin->prepare_filter_articles_response(array(
+            'instance_id' => $instanceId,
+            'category'    => 'actus',
+            'current_url' => 'http://example.com/',
+        ));
+
+        $this->assertIsArray($response);
+        $this->assertNotNull($capturedContext, 'Expected unlimited pagination context to be captured.');
+        $this->assertArrayHasKey('unlimited_page_size', $capturedContext);
+        $this->assertArrayHasKey('analytics_page_size', $capturedContext);
+        $this->assertSame(7, $capturedContext['unlimited_page_size']);
+        $this->assertSame(7, $capturedContext['analytics_page_size']);
     }
 }


### PR DESCRIPTION
## Summary
- seed `prepare_filter_articles_response()` with a pagination context before calling the helper
- include unlimited batch metadata in the context to keep analytics consistent
- extend the filter response test suite to capture pagination context via the existing hook

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68e67030b9d0832ebc869653ccc8c982