### PR TITLE
Fix fatal error from duplicate join_paths method

### DIFF
--- a/mon-affichage-article/includes/class-my-articles-cli.php
+++ b/mon-affichage-article/includes/class-my-articles-cli.php
@@ -266,21 +266,6 @@ if ( defined( 'WP_CLI' ) && WP_CLI && ! class_exists( 'My_Articles_CLI_Presets_C
             WP_CLI::success( sprintf( 'Catalogue de préréglages synchronisé (%d manifestes).', $count ) );
         }
 
-        private static function join_paths( $base, $segment ) {
-            $base    = rtrim( (string) $base, '/\\' );
-            $segment = ltrim( (string) $segment, '/\\' );
-
-            if ( '' === $base ) {
-                return $segment;
-            }
-
-            if ( '' === $segment ) {
-                return $base;
-            }
-
-            return $base . DIRECTORY_SEPARATOR . $segment;
-        }
-
         private static function normalize_path( $path ) {
             $normalized = str_replace( '\\', '/', (string) $path );
             $normalized = preg_replace( '#/+#', '/', $normalized );


### PR DESCRIPTION
## Summary
- remove the redundant join_paths() implementation from the CLI command class to avoid fatal errors when loading via WP-CLI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f5543da540832e86878c9a7307cd7f